### PR TITLE
wordpress API changed

### DIFF
--- a/client/src/home/apidata.js
+++ b/client/src/home/apidata.js
@@ -335,7 +335,7 @@ export async function fetch_global_stats(walletAddress = null) {
     try {
       const res = await fetch('https://jetpackbridge.runonflux.io/api/v1/wordpress.php?action=COUNT');
       const json = await res.json();
-      store.wordpressCount = json?.count;
+      store.wordpressCount = json;
     } catch (error) {
       console.log('error', error);
     }


### PR DESCRIPTION
Changes was made to API:  https://jetpackbridge.runonflux.io/api/v1/wordpress.php?action=COUNT
Thus changes to code done to make it work was getting:

<img width="1072" alt="image" src="https://github.com/2ndtlmining/Fluxnode/assets/108513481/5a578da6-0aac-47e1-922f-193923e34fd4">


Local testing looks like:

<img width="1186" alt="image" src="https://github.com/2ndtlmining/Fluxnode/assets/108513481/352b2fa4-44f7-44ae-88e7-6edaac2d074f">


