### PR TITLE
Remove physical cores requirements

### DIFF
--- a/client/public/runtime/app-content.js
+++ b/client/public/runtime/app-content.js
@@ -23,7 +23,6 @@ window.gContent.ADDRESS_BTC = '1MjMuVLEaAd8HJd3mh94L8qQe4cE6tH87V';
  * */
 
 window.gContent.REQUIREMENTS = {
-  'cores':          { C:   2,  N:   4,  S:    8, F:     2 },
   'threads':        { C:   4,  N:   8,  S:   16, F:     4 },
   'ram':            { C:   8,  N:  32,  S:   64, F:     8 },
   'size':           { C: 220,  N: 440,  S:  880, F:  9000 },

--- a/client/src/components/NodeGridTable/CustomTooltip.jsx
+++ b/client/src/components/NodeGridTable/CustomTooltip.jsx
@@ -35,9 +35,6 @@ export const CustomTooltip = ({ componentName, displayName, gstore }) => {
     case 'ram':
       Component = RamTooltip;
       break;
-    case 'cores':
-      Component = CoresTooltip;
-      break;
     case 'threads':
       Component = ThreadsTooltip;
       break;
@@ -184,10 +181,6 @@ export const EPSTooltip = () => {
 
 export const RamTooltip = () => {
   return <TooltipTableHeader name='RAM' tooltipContent={ColumnHelp('ram', ' GB')} />;
-};
-
-export const CoresTooltip = () => {
-  return <TooltipTableHeader name='Cores' tooltipContent={ColumnHelp('cores')} />;
 };
 
 export const ThreadsTooltip = () => {

--- a/client/src/components/NodeGridTable/CustomisedCells/NumberCell.jsx
+++ b/client/src/components/NodeGridTable/CustomisedCells/NumberCell.jsx
@@ -31,7 +31,6 @@ export const NumberCell = (props) => {
         // prettier-ignore
         // eslint-disable-next-line no-lone-blocks
         {
-            failed.cores = _fs_compare(node, reqObj, 'cores');
             failed.threads = _fs_compare(node, reqObj, 'threads');
             // Allow a difference of 3 GB since RAM sizes are mosty a few gigs short when reported
             failed.ram = !node.ram || !reqObj.ram || reqObj.ram - node.ram > 3.0;

--- a/client/src/components/NodeGridTable/index.jsx
+++ b/client/src/components/NodeGridTable/index.jsx
@@ -143,7 +143,6 @@ export const NodeGridTable = ({
       filter: 'agNumberColumnFilter',
       minWidth: 100
     },
-    { field: 'cores', headerName: 'Cores', cellRenderer: 'numberCell', filter: 'agNumberColumnFilter', minWidth: 100 },
     { field: 'threads', headerName: 'Threads', cellRenderer: 'numberCell', filter: 'agNumberColumnFilter' },
     {
       field: 'dws',

--- a/client/src/content/index.js
+++ b/client/src/content/index.js
@@ -13,7 +13,6 @@ export const ADDRESS_BTC = window.gContent.ADDRESS_BTC;
 
 {
 const _reqsObj = window.gContent.REQUIREMENTS;
-r.defreq_wrap('cores',          _reqsObj['cores']);
 r.defreq_wrap('threads',        _reqsObj['threads']);
 r.defreq_wrap('ram',            _reqsObj['ram']);
 r.defreq_wrap('size',           _reqsObj['size']);

--- a/client/src/content/internal/req_helpers.jsx
+++ b/client/src/content/internal/req_helpers.jsx
@@ -48,13 +48,6 @@ export const getreq__fractus = (name) => getreq('fractus', name);
 /* Help Information to show on toolips  */
 
 defhelp(
-  'cores',
-  <div>
-    Number of <strong>physical cores</strong> attached to the node
-  </div>
-);
-
-defhelp(
   'threads',
   <div>
     Number of <strong>logical cores (threads)</strong> attached to the node

--- a/client/src/guides/NodeRequirements/index.jsx
+++ b/client/src/guides/NodeRequirements/index.jsx
@@ -38,8 +38,6 @@ export const RequirementsCumulus = (
     fluxAmount={CC_COLLATERAL_CUMULUS}
     requirementsContent={
       <>
-        {getreq__cumulus('cores')} Cores
-        <br />
         {getreq__cumulus('threads')} Threads
         <br />
         {getreq__cumulus('ram')} GB RAM
@@ -64,8 +62,6 @@ export const RequirementsNimbus = (
     fluxAmount={CC_COLLATERAL_NIMBUS}
     requirementsContent={
       <>
-        {getreq__nimbus('cores')} Cores
-        <br />
         {getreq__nimbus('threads')} Threads
         <br />
         {getreq__nimbus('ram')} GB RAM
@@ -90,8 +86,6 @@ export const RequirementsStratus = (
     fluxAmount={CC_COLLATERAL_STRATUS}
     requirementsContent={
       <>
-        {getreq__stratus('cores')} Cores
-        <br />
         {getreq__stratus('threads')} Threads
         <br />
         {getreq__stratus('ram')} GB RAM
@@ -116,8 +110,6 @@ export const RequirementsFractus = (
     fluxAmount={CC_COLLATERAL_FRACTUS}
     requirementsContent={
       <>
-        {getreq__fractus('cores')} Cores
-        <br />
         {getreq__fractus('threads')} Threads
         <br />
         {getreq__fractus('ram')} GB RAM

--- a/client/src/home/apidata.js
+++ b/client/src/home/apidata.js
@@ -551,7 +551,6 @@ function _fillPartial_benchmarks(fluxNode, benchmarks) {
       fluxNode.benchmark_status = 'passed';
   }
 
-  fluxNode.cores = parseInt(benchmarks['real_cores'] || 0);
   fluxNode.threads = parseInt(benchmarks['cores'] || 0);
   fluxNode.eps = benchmarks['eps'] || 0;
   fluxNode.ram = benchmarks['ram'] || 0;

--- a/client/src/main/apidata.js
+++ b/client/src/main/apidata.js
@@ -481,7 +481,6 @@ function _fillPartial_benchmarks(fluxNode, benchmarks) {
       fluxNode.benchmark_status = 'passed';
   }
 
-  fluxNode.cores = parseInt(benchmarks['real_cores'] || 0);
   fluxNode.threads = parseInt(benchmarks['cores'] || 0);
   fluxNode.eps = benchmarks['eps'] || 0;
   fluxNode.ram = benchmarks['ram'] || 0;


### PR DESCRIPTION
This PR removes the `Cores` column, leaving only the `Threads`.

## Details

Flux Benchmark v5.0.0 removed `real_cores`, leaving only `cores` which are in fact threads (vCores).

Example benchmark 5.0.0 result:
https://api.runonflux.io/benchmark/getbenchmarks
<details>
<summary>View example</summary>

  ```json
  {
    "status": "success",
    "data": {
      "ipaddress": "172.94.101.64",
      "architecture": "amd64",
      "armboard": "",
      "status": "STRATUS",
      "time": 1741802887,
      "cores": 16,
      "ram": 62,
      "ssd": 931.51,
      "hdd": 0,
      "ddwrite": 770.206875,
      "totalstorage": 931.51,
      "disksinfo": [
        {
          "disk": "nvme0n1",
          "size": 931.51,
          "writespeed": 770.206875
        }
      ],
      "eps": 6255.84,
      "ping": 8.431,
      "download_speed": 268.394984,
      "upload_speed": 162.04172,
      "bench_version": "1.0.20",
      "speed_version": "1.2.0",
      "thunder": false,
      "systemsecure": false,
      "error": ""
    }
  }
  ```

</details>

This was confirmed by `@Method` on the Flux Discord.
Message link: https://discord.com/channels/404415190835134464/1107766373448437842/1349417401753669667

As a result, `Cores` are now showing `0` for all nodes on fluxnode.app
![image](https://github.com/user-attachments/assets/38e55c8d-b0e5-4665-a1cb-e243ee563692)
