### PR TITLE
Fix #55: footer rework — compact, theme-aware, mobile-friendly, v1.1.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/client/src/components/Footer/index.jsx
+++ b/client/src/components/Footer/index.jsx
@@ -1,11 +1,12 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useCallback } from 'react';
 import './index.scss';
 
 import { IconContext } from 'react-icons';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { LayoutContext } from 'contexts/LayoutContext';
 
-import { IoLogoTwitter, IoMailUnread, IoLogoYoutube, IoLogoGithub } from 'react-icons/io5';
-import { BsGithub, BsBugFill } from 'react-icons/bs';
+import { IoLogoTwitter, IoMailUnread, IoLogoYoutube } from 'react-icons/io5';
+import { BsGithub, BsBugFill, BsCheckLg, BsClipboard } from 'react-icons/bs';
 
 import { URL_YOUTUBE, URL_TWITTER, URL_GITHUB, EMAIL, ADDRESS_FLUX, ADDRESS_BTC } from 'content/index';
 
@@ -19,87 +20,122 @@ function _RenderAppVersion() {
   return `v${APP_VERSION}${suffix}`;
 }
 
+const SOCIAL_LINKS = [
+  { key: 'twitter', href: URL_TWITTER, label: 'Twitter', Icon: IoLogoTwitter },
+  { key: 'youtube', href: URL_YOUTUBE, label: 'YouTube', Icon: IoLogoYoutube },
+  { key: 'email', href: `mailto:${EMAIL}`, label: 'Email us', Icon: IoMailUnread },
+  { key: 'github', href: URL_GITHUB, label: 'Source on GitHub', Icon: BsGithub },
+  {
+    key: 'bug',
+    href: 'https://github.com/2ndtlmining/Fluxnode/issues',
+    label: 'Report an issue',
+    Icon: BsBugFill
+  }
+];
+
+/** "t1abcdef...uvwxyz" — keeps a donation address recognisable without eating a whole row. */
+function truncateAddress(address) {
+  if (!address || address.length <= 20) return address;
+  return `${address.slice(0, 8)}…${address.slice(-6)}`;
+}
+
+function DonateChip({ label, address }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    if (!address) return;
+    try {
+      // navigator.clipboard is unavailable over plain http, which some node
+      // operators use to reach the site — fall back rather than doing nothing.
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(address);
+      } else {
+        const el = document.createElement('textarea');
+        el.value = address;
+        el.setAttribute('readonly', '');
+        el.style.position = 'absolute';
+        el.style.left = '-9999px';
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard blocked — the full address is in the tooltip */
+    }
+  }, [address]);
+
+  if (!address) return null;
+
+  return (
+    <Tooltip2
+      content={copied ? 'Copied to clipboard' : address}
+      placement="top"
+      hoverOpenDelay={150}
+      popoverClassName="footer-addr-tooltip"
+    >
+      <button
+        type="button"
+        className={`footer-chip${copied ? ' footer-chip--copied' : ''}`}
+        onClick={copy}
+        aria-label={`Copy ${label} donation address`}
+      >
+        <span className="footer-chip__label">{label}</span>
+        <span className="footer-chip__addr">{truncateAddress(address)}</span>
+        <span className="footer-chip__icon">{copied ? <BsCheckLg /> : <BsClipboard />}</span>
+      </button>
+    </Tooltip2>
+  );
+}
+
 export function Footer() {
   const { lastUpdated, arcaneHumanVersion } = useContext(LayoutContext);
 
   return (
-    <footer className='v-footer'>
-      <div className='container-fluid px-5'>
-        <div className='row pt-5 pb-2'>
-          <div className='col-md-4 mb-md-0 mb-4'>
-            <h2 className='footer-heading'>Follow Us</h2>
-            <IconContext.Provider value={{ size: '20px', color: '#12cc94' }}>
-              <ul className='links-list p-0'>
-                <li>
-                  <a href={URL_TWITTER} target='_blank'>
-                    <IoLogoTwitter className='footer-logo' />
-                  </a>
-                </li>
-                <li>
-                  <a href={URL_YOUTUBE} target='_blank'>
-                    <IoLogoYoutube className='footer-logo' />
-                  </a>
-                </li>
-                <li>
-                  <a href={'mailto:' + EMAIL} target='_blank'>
-                    <IoMailUnread className='footer-logo' />
-                  </a>
-                </li>
-                <li>
-                  <a href={URL_GITHUB} target='_blank'>
-                    <BsGithub className='footer-logo' />
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href='https://github.com/2ndtlmining/Fluxnode/issues'
-                    target='_blank'
-                    rel='noreferrer'
-                    title='Report an Issue'
-                  >
-                    <BsBugFill className='footer-logo' />
-                  </a>
-                </li>
+    <footer className="v-footer">
+      <div className="footer-inner">
+        <div className="footer-bar">
+          <div className="footer-bar__left">
+            <IconContext.Provider value={{ size: '18px', color: '#12cc94' }}>
+              <ul className="links-list">
+                {SOCIAL_LINKS.map(({ key, href, label, Icon }) => (
+                  <li key={key}>
+                    <Tooltip2 content={label} placement="top" hoverOpenDelay={200}>
+                      <a href={href} target="_blank" rel="noreferrer noopener" aria-label={label}>
+                        <Icon className="footer-logo" />
+                      </a>
+                    </Tooltip2>
+                  </li>
+                ))}
               </ul>
             </IconContext.Provider>
-            <p>
-              <span className='hl-app-version'>
-                FluxNode {_RenderAppVersion()}
-                {arcaneHumanVersion && <> · {arcaneHumanVersion}</>}
-              </span>
-            </p>
+
+            <span className="footer-meta">
+              <span className="hl-app-version">FluxNode {_RenderAppVersion()}</span>
+              {arcaneHumanVersion && <span className="footer-meta__sep">·</span>}
+              {arcaneHumanVersion && <span>{arcaneHumanVersion}</span>}
+              {lastUpdated && <span className="footer-meta__sep">·</span>}
+              {lastUpdated && (
+                <span className="footer-meta__updated">
+                  Updated{' '}
+                  {lastUpdated.toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                  })}
+                </span>
+              )}
+            </span>
           </div>
 
-          <div className='col-md-8 mb-md-0 mb-4'>
-            <h2 className='footer-heading donation-heading'>Donations</h2>
-            <p className='donation-info'>
-              Donations are very much appreciated. Please consider donating to keep the website development going.
-            </p>
-            <ul className='donate-list p-0 ms-4'>
-              <li>
-                <span className='hl-addr-name'>Flux Address:&nbsp;</span>
-                <span className='hl-addr-val'>{ADDRESS_FLUX}</span>
-              </li>
-              <li>
-                <span className='hl-addr-name'>BTC Address:&nbsp;</span>
-                <span className='hl-addr-val'>{ADDRESS_BTC}</span>
-              </li>
-            </ul>
-          </div>
-
-          <div className='col-12'>
-            <div className='line mt-4'></div>
-          </div>
-        </div>
-
-        <div className='row pt-3 pb-5'>
-          <div className='col-12'>
-            <p>Copyright ©&nbsp;2023 All rights reserved</p>
-            {lastUpdated && (
-              <p style={{ color: '#5c7080', fontSize: '0.75rem', margin: '0' }}>
-                Last updated: {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
-              </p>
-            )}
+          <div className="footer-bar__right">
+            <span className="footer-donate-label">Support development</span>
+            <div className="footer-chips">
+              <DonateChip label="FLUX" address={ADDRESS_FLUX} />
+              <DonateChip label="BTC" address={ADDRESS_BTC} />
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/components/Footer/index.scss
+++ b/client/src/components/Footer/index.scss
@@ -1,94 +1,256 @@
+@import 'styles/functional';
+
 .v-footer {
+  // Light is the base, dark is the override — matching the rest of the app.
+  // The footer used to be hardcoded #101823, so it stayed dark in light mode
+  // (issue #55).
+  background-color: #eceef1;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+
+  @include rule-mode-dark() {
     background-color: #101823;
-
-    padding: 0;
-    margin: 0;
-    overflow: hidden;
+    border-top-color: rgba(255, 255, 255, 0.06);
+  }
 }
 
-.container-fluid {
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 15px;
-    margin-right: auto;
-    margin-left: auto;
+.footer-inner {
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 14px 24px;
 }
 
-.footer-heading {
-    font-size: 18px;
-    margin-bottom: 20px;
-    font-weight: 400;
-    letter-spacing: normal;
-    line-height: 1.5;
-
-    color: #fff;
+/* One band: identity + links on the left, donations on the right.
+   Wraps to a stacked layout on narrow screens rather than overflowing. */
+.footer-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px 20px;
 }
+
+.footer-bar__left,
+.footer-bar__right {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.footer-bar__right {
+  justify-content: flex-end;
+}
+
+/* ── Social icons ─────────────────────────────────────────────────────────── */
 
 .v-footer .links-list {
-    li {
-        list-style: none;
-        margin: 0 10px 0 0;
-        display: inline-block;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 
-        a {
-            height: 40px;
-            width: 40px;
-            display: block;
-            border-radius: 50%;
-            position: relative;
+  li {
+    margin: 0;
+    display: block;
+  }
 
-            // background: rgba(0, 0, 0, 0.05);
-            background-color: rgba(210, 230, 210, 0.075);
-        }
+  a {
+    height: 34px;
+    width: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: rgba(0, 0, 0, 0.05);
+    transition: background-color 120ms ease, transform 120ms ease;
 
-        .footer-logo {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            -webkit-transform: translate(-50%, -50%);
-            -ms-transform: translate(-50%, -50%);
-            transform: translate(-50%, -50%);
-        }
+    @include rule-mode-dark() {
+      background-color: rgba(210, 230, 210, 0.075);
     }
+
+    &:hover,
+    &:focus-visible {
+      background-color: rgba(18, 204, 148, 0.18);
+      transform: translateY(-1px);
+    }
+  }
 }
 
-.v-footer {
-    .hl-addr-name,
-    p {
-        color: rgba(232, 230, 227, 0.5);
-        font-size: 1rem;
-    }
+/* ── Version / build meta ─────────────────────────────────────────────────── */
 
-    .donate-list {
-        list-style: none;
-    }
+.footer-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: rgba(28, 32, 38, 0.6);
+  min-width: 0;
 
-    .hl-addr-name {
-        font-weight: 500;
-    }
-    .hl-addr-val {
-        color: rgb(181, 175, 166);
-    }
-
-    .hl-app-version {
-        font-weight: 500;
-    }
+  @include rule-mode-dark() {
+    color: rgba(232, 230, 227, 0.55);
+  }
 }
 
-.v-footer .donation-heading {
-    font-size: 24px;
-    margin-bottom: 10px;
-    position: relative;
-    top: -5px;
+.footer-meta .hl-app-version {
+  font-weight: 600;
+  color: rgba(20, 24, 30, 0.85);
+
+  @include rule-mode-dark() {
+    color: rgba(232, 230, 227, 0.8);
+  }
 }
 
-.v-footer p.donation-info {
-    font-weight: 500;
-    color: #fff;
-    font-size: 18px;
-    margin-bottom: 14px;
+.footer-meta__sep {
+  opacity: 0.4;
 }
 
-.line {
-    border-top: 1px solid rgba(255, 255, 255, 0.2);
+.footer-meta__updated {
+  white-space: nowrap;
+}
+
+/* ── Donation chips ───────────────────────────────────────────────────────── */
+
+.footer-donate-label {
+  font-size: 0.8rem;
+  color: rgba(28, 32, 38, 0.6);
+  white-space: nowrap;
+
+  @include rule-mode-dark() {
+    color: rgba(232, 230, 227, 0.55);
+  }
+}
+
+.footer-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.footer-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  background: rgba(255, 255, 255, 0.7);
+  color: rgb(72, 78, 88);
+  font-size: 0.76rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba(18, 204, 148, 0.5);
+    background: rgba(18, 204, 148, 0.08);
+  }
+
+  @include rule-mode-dark() {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgb(181, 175, 166);
+  }
+}
+
+.footer-chip--copied {
+  border-color: rgba(18, 204, 148, 0.7);
+  color: #12cc94;
+}
+
+.footer-chip__label {
+  font-weight: 700;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: rgba(20, 24, 30, 0.8);
+
+  @include rule-mode-dark() {
+    color: rgba(232, 230, 227, 0.75);
+  }
+}
+
+.footer-chip--copied .footer-chip__label {
+  color: #12cc94;
+}
+
+.footer-chip__addr {
+  opacity: 0.85;
+}
+
+.footer-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.footer-addr-tooltip {
+  .bp4-popover2-content {
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    word-break: break-all;
+    max-width: 280px;
+  }
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .footer-bar {
+    justify-content: center;
+  }
+
+  .footer-bar__left,
+  .footer-bar__right {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .footer-meta {
+    justify-content: center;
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .footer-inner {
+    padding: 12px 14px;
+  }
+
+  .v-footer .links-list {
+    gap: 6px;
+
+    a {
+      height: 32px;
+      width: 32px;
+    }
+  }
+
+  .footer-meta {
+    font-size: 0.72rem;
+  }
+
+  .footer-donate-label {
+    width: 100%;
+    text-align: center;
+  }
+
+  .footer-chips {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .footer-chip {
+    font-size: 0.7rem;
+    padding: 5px 8px;
+  }
 }


### PR DESCRIPTION
Closes #55.

## Before

A three-row Bootstrap grid: a "Follow Us" heading, a "Donations" heading plus explanatory paragraph, two full-length addresses on their own rows, a divider, a 2023 copyright line, and 3rem of padding top and bottom. On a phone that ran to roughly three screens' worth of height for five links and two addresses.

## After

One band — icons, version and build meta on the left; donations on the right — wrapping to a stacked layout on narrow screens.

```
🐦 ▶ ✉ ⌂ 🐛   FluxNode v1.1.1 · jolly wombat · Updated 08:36:50
                    Support development  [FLUX t1ebxupk…qwLmUG 📋] [BTC 1MjMuVLE…6tH87V 📋]
```

- **Icons kept** — all five, now with hover states, tooltips and `aria-label`s
- **v1.1.1**
- **Copyright removed**
- **Donations compacted** — heading + paragraph + two full-width address rows become two click-to-copy chips. Address truncated, full value in the tooltip, ✓ confirmation on copy. `navigator.clipboard` is unavailable over plain http (some operators reach the site that way), so there is an `execCommand` fallback.

## The light-mode bug (#55, open since Feb 2023)

The footer hardcoded `background-color: #101823`, so it stayed dark when the rest of the app went light. Light is now the base and dark is the override, matching the convention in `MainApp.scss`.

Worth noting for review: this uses `rule-mode-dark()` and **not** `qualify()`. `qualify()` concatenates (`.app-mode-dark.v-footer`) but the footer is a *descendant* of the themed `div.App`, so `qualify()` would silently never match. I hit that and corrected it before building — verified in the emitted CSS:

```css
.v-footer{background-color:#eceef1;border-top:1px solid rgba(0,0,0,.08)}
.app-mode-dark .v-footer{background-color:#101823;border-top-color:hsla(0,0%,100%,.06)}
```

## Mobile verification

The browser would not resize below the desktop viewport in my environment, so instead I applied the ≤480px rules to the live DOM and measured overflow against the production build:

| Width | Overflow | Footer height |
|---|---|---|
| 320px (iPhone SE) | none | 197px |
| 360px | none | 197px |
| 390px (iPhone 15) | none | 161px |
| 430px | none | 161px |

No horizontal scroll at any width. Chips stack below 390px, side by side above it.

Light mode confirmed rendering with a light surface and dark text (`rgb(236,238,241)` background, `rgba(28,32,38,0.6)` meta text).

## Also

`target="_blank"` links were missing `rel="noreferrer"`.

## Not in scope

The right-hand host stats block (Fluxtracker-style *Hosted in / Running on / cpus / mem*) is **not** here — the client is a static bundle with no way to learn about the machine serving it. Specced separately as #145.

Build: exit 0, no warnings in either changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W