### PR TITLE
Fix #143: add GBP — and fix the USD rate being quoted against EUR (~17% error)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "formatter": "prettier --config-precedence cli-override --ignore-unknown --config \".prettierrc.toml\"",
-    "format": "yarn run formatter --write ."
+    "format": "yarn run formatter --write .",
+    "test": "react-scripts test"
   },
   "dependencies": {
     "@blueprintjs/core": "^4.5.1",

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -852,48 +852,10 @@ export async function getDemoWallet() {
 }
 
 // Fetch USD Latest currency rate
-const usdCurrencyRate = async ()=> {
-  let response = await fetch('https://api.frankfurter.app/latest?to=USD');
-  const resData = await response.json();
-  return resData.rates;
-}
+// Currency rates now live in client/src/currency.js so they can be unit
+// tested. Re-exported here to keep existing import paths working.
+export { lazy_load_currency_rate, SUPPORTED_CURRENCIES } from 'currency';
 
-
-const CURRENCY_RATE_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-// Fetch other currencies and store
-export async function lazy_load_currency_rate() {
-
-  const supportedCurrencies = ['USD', 'EUR', 'AUD'];
-  const cached = await appStore.getItem(StoreKeys.CURRENCY_RATES);
-  const isFresh = cached && cached.timestamp && (Date.now() - cached.timestamp < CURRENCY_RATE_TTL_MS);
-  if (isFresh) {
-    return cached.rates;
-  }
-
-  try {
-    const res = await fetch('https://api.frankfurter.app/latest?to=' + supportedCurrencies.join(',') + '&base=USD');
-    const json = await res.json();
-    const currencyRates = json.rates;
-
-    const usd = await usdCurrencyRate();
-    const currencies = {...usd, ...currencyRates}
-    console.log('rates:', currencies);
-
-    if(res.ok){
-      await appStore.setItem(StoreKeys.CURRENCY_RATES, { rates: currencies, timestamp: Date.now() });
-      return currencies;
-    }else{
-      return null
-    }
-
-  } catch (error) {
-    console.log(error);
-    // Return stale data if available rather than nothing
-    if (cached && cached.rates) return cached.rates;
-  }
-  return null;
-}
 /* ======================================================================= */
 /* ======================================================================= */
 /* =========================== Fractus Count =========================== */

--- a/client/src/components/Navbar/CurrencyMenuItem.jsx
+++ b/client/src/components/Navbar/CurrencyMenuItem.jsx
@@ -2,8 +2,19 @@ import { Select2 } from '@blueprintjs/select';
 import { Button, Label } from '@blueprintjs/core';
 import { MenuItem2 } from '@blueprintjs/popover2';
 
+import { SUPPORTED_CURRENCIES } from 'currency';
+
 export function CurrencyMenuItem({ currencyRates, selectedCurrency, onChange }) {
-  const currencyOptions = currencyRates === null ? ['USD'] : Object.entries(currencyRates).map(([currency, rate]) => currency);
+  // Order by SUPPORTED_CURRENCIES rather than whatever order the rates object
+  // happens to have, so USD stays first and the menu does not reshuffle when
+  // the API changes its response order.
+  const currencyOptions =
+    currencyRates === null
+      ? ['USD']
+      : [
+          ...SUPPORTED_CURRENCIES.filter((c) => c in currencyRates),
+          ...Object.keys(currencyRates).filter((c) => !SUPPORTED_CURRENCIES.includes(c))
+        ];
 
   return (
     <Select2

--- a/client/src/currency.js
+++ b/client/src/currency.js
@@ -1,0 +1,63 @@
+// Currency rates for the value display, kept in its own module so it can be
+// unit tested without importing the rest of apidata.js.
+
+import { appStore, StoreKeys } from 'persistance/store';
+
+const CURRENCY_RATE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const FRANKFURTER_URL = 'https://api.frankfurter.app/latest';
+
+/*
+ * Every rate is quoted against USD, because all prices in the app originate as
+ * flux_price_usd and are rendered as `flux_price_usd * selectedCurrency.rate`.
+ */
+export const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'AUD', 'GBP'];
+
+/**
+ * A cache is only usable if it is recent AND covers every supported currency.
+ * Without the second check, adding a currency leaves it invisible for up to an
+ * hour after deploy for anyone with a warm cache.
+ */
+export function isCacheUsable(cached, now = Date.now()) {
+  if (!cached?.rates || !cached?.timestamp) return false;
+  if (now - cached.timestamp >= CURRENCY_RATE_TTL_MS) return false;
+  return SUPPORTED_CURRENCIES.every((c) => c in cached.rates);
+}
+
+/**
+ * Frankfurter omits the base currency from its response, so USD is added here
+ * at exactly 1.
+ *
+ * This used to come from a second request — `latest?to=USD` with no base.
+ * Frankfurter defaults the base to EUR, so that returned USD *per EUR* (1.1662
+ * at time of writing) rather than 1. Selecting USD in the currency menu
+ * therefore multiplied every USD figure by 1.17: wallet value, earnings
+ * projections and Flux price were all ~17% too high for anyone who had
+ * explicitly chosen USD. The default { currency: 'USD', rate: 1 } in
+ * LayoutContext was correct, which is why it went unnoticed.
+ */
+export function buildRates(apiRates) {
+  // USD last so it always wins, even if a future API response includes it.
+  return { ...(apiRates || {}), USD: 1 };
+}
+
+export async function lazy_load_currency_rate() {
+  const cached = await appStore.getItem(StoreKeys.CURRENCY_RATES);
+  if (isCacheUsable(cached)) return cached.rates;
+
+  try {
+    const res = await fetch(`${FRANKFURTER_URL}?to=${SUPPORTED_CURRENCIES.join(',')}&base=USD`);
+    if (!res.ok) return cached?.rates ?? null;
+
+    const json = await res.json();
+    const currencies = buildRates(json?.rates);
+
+    await appStore.setItem(StoreKeys.CURRENCY_RATES, { rates: currencies, timestamp: Date.now() });
+    return currencies;
+  } catch (error) {
+    console.log(error);
+    // Return stale data if available rather than nothing
+    if (cached?.rates) return cached.rates;
+  }
+  return null;
+}

--- a/client/src/currency.test.js
+++ b/client/src/currency.test.js
@@ -1,0 +1,87 @@
+/*
+ * persistance/store does `import * as localforage` — a namespace import of a CJS
+ * module that webpack tolerates but Jest does not, so importing it here throws
+ * before any test runs. The functions under test are pure and never touch the
+ * store, so it is stubbed. Fixing the interop properly is part of #147.
+ */
+jest.mock('persistance/store', () => ({
+  appStore: { getItem: jest.fn(), setItem: jest.fn() },
+  StoreKeys: { CURRENCY_RATES: 'currencyRates' },
+}));
+
+import { buildRates, isCacheUsable, SUPPORTED_CURRENCIES } from './currency';
+
+/*
+ * These pin a live money bug: the USD rate used to be fetched from
+ * `frankfurter.app/latest?to=USD` with no base. Frankfurter defaults the base
+ * to EUR, so that call returns USD *per EUR* — 1.1662 when this was found —
+ * and selecting USD in the currency menu inflated every USD figure by ~17%.
+ */
+
+describe('buildRates', () => {
+  it('pins USD at exactly 1', () => {
+    // Frankfurter omits the base currency, so a base=USD response has no USD key
+    const apiRates = { EUR: 0.85749, AUD: 1.398, GBP: 0.73358 };
+    expect(buildRates(apiRates).USD).toBe(1);
+  });
+
+  it('never lets the API supply a USD rate other than 1', () => {
+    // The shape of the old bug: a USD-per-EUR value leaking into the rate table.
+    // Even if a future response carries a USD key, it must not survive.
+    expect(buildRates({ USD: 1.1662, EUR: 0.85749 }).USD).toBe(1);
+    expect(buildRates({ EUR: 0.85749 }).USD).toBe(1);
+  });
+
+  it('passes the other currencies through untouched', () => {
+    const rates = buildRates({ EUR: 0.85749, AUD: 1.398, GBP: 0.73358 });
+    expect(rates).toEqual({ USD: 1, EUR: 0.85749, AUD: 1.398, GBP: 0.73358 });
+  });
+
+  it('survives a missing or malformed response', () => {
+    expect(buildRates(undefined)).toEqual({ USD: 1 });
+    expect(buildRates(null)).toEqual({ USD: 1 });
+  });
+
+  it('converts a USD price correctly for every supported currency', () => {
+    const rates = buildRates({ EUR: 0.85749, AUD: 1.398, GBP: 0.73358 });
+    const fluxPriceUsd = 0.0434;
+    expect(fluxPriceUsd * rates.USD).toBeCloseTo(0.0434, 6);
+    expect(fluxPriceUsd * rates.GBP).toBeCloseTo(0.031837, 6);
+  });
+});
+
+describe('SUPPORTED_CURRENCIES', () => {
+  it('includes GBP', () => {
+    expect(SUPPORTED_CURRENCIES).toContain('GBP');
+  });
+
+  it('leads with USD, the base every rate is quoted against', () => {
+    expect(SUPPORTED_CURRENCIES[0]).toBe('USD');
+  });
+});
+
+describe('isCacheUsable', () => {
+  const fresh = { rates: { USD: 1, EUR: 0.86, AUD: 1.4, GBP: 0.73 }, timestamp: 1000 };
+  const now = 1000 + 60 * 1000; // one minute later
+
+  it('accepts a recent cache covering every supported currency', () => {
+    expect(isCacheUsable(fresh, now)).toBe(true);
+  });
+
+  it('rejects a cache missing a newly added currency, however recent', () => {
+    // Exactly the GBP rollout case: a warm cache written before GBP existed
+    const preGbp = { rates: { USD: 1, EUR: 0.86, AUD: 1.4 }, timestamp: 1000 };
+    expect(isCacheUsable(preGbp, now)).toBe(false);
+  });
+
+  it('rejects a cache older than the TTL', () => {
+    expect(isCacheUsable(fresh, 1000 + 61 * 60 * 1000)).toBe(false);
+  });
+
+  it('rejects empty, partial and malformed caches', () => {
+    expect(isCacheUsable(null, now)).toBe(false);
+    expect(isCacheUsable({}, now)).toBe(false);
+    expect(isCacheUsable({ rates: { USD: 1 } }, now)).toBe(false);
+    expect(isCacheUsable({ timestamp: 1000 }, now)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #143.

## The requested change

GBP added to the supported currency list. The menu is fully dynamic, so that part really is one line.

## The bug I found doing it

The USD rate came from a **second** request:

```js
fetch('https://api.frankfurter.app/latest?to=USD')   // no base!
```

Frankfurter defaults the base to **EUR** when none is given. Verified live:

```json
{"amount":1,"base":"EUR","date":"2026-08-25","rates":{"USD":1.1662}}
```

So the "USD rate" was **USD per EUR — 1.1662, not 1** — and it was merged straight into the rate table.

Every price renders as `flux_price_usd * selectedCurrency.rate`, so picking **USD** in the currency menu inflated **wallet value, earnings projections and the Flux price by ~17%**.

It went unnoticed because `LayoutContext` defaults to a hardcoded `{ currency: 'USD', rate: 1 }` — the figures are only wrong once a user *explicitly selects* USD from the menu. Anyone who has ever opened that dropdown and chosen USD has been seeing inflated numbers.

The `base=USD` response never contains a USD key, so USD is now pinned to `1` locally and the second request is gone.

```
before:  { USD: 1.1662, AUD: 1.398, EUR: 0.85749 }
after:   { AUD: 1.398, EUR: 0.85749, GBP: 0.73358, USD: 1 }
```

## Cache invalidation

Cache validity now also requires the cached rates to **cover every supported currency**, not just be recent. Without that, a warm cache written before GBP existed would hide it for up to an hour after deploy — so the feature would look broken for exactly the users who visit most often.

## Menu ordering

Options now follow `SUPPORTED_CURRENCIES` rather than object key order. Pinning USD to 1 moved it to the end of the object, which would have sorted it last behind AUD/EUR/GBP.

## Structure

Currency logic moves to `client/src/currency.js`. `apidata.js` cannot be imported under Jest — it pulls in `utils.js`, which does `import * as duration from 'dayjs/plugin/duration'`, a CJS namespace import Jest rejects. `apidata.js` re-exports the module so **no call site changes**. Same pattern as `fluxinfo.js` in #148, and the direction #147 proposes for the rest of the file.

`persistance/store` has the same interop problem (`import * as localforage`), so the test stubs it — the functions under test are pure and never touch the store. Fixing the interop properly is scoped in #147.

## Tests

11 added, covering the exact shape of the bug:

- USD pinned to 1 even if a future response supplies a USD key
- other currencies passed through untouched
- a pre-GBP warm cache is rejected however recent
- TTL expiry, malformed and partial caches
- a real conversion: `0.0434 USD × 0.73358 = 0.031837 GBP`

Build: exit 0, no warnings in any changed file.

## Note for merging

This PR also adds the `test` script to `package.json`, as does #148. If #148 merges first this will show a one-line conflict on that script — trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W