### PR TITLE
Fix #142: Privacy Mode still showed wallet data in Parallel Assets and the wallet tooltip

### DIFF
--- a/client/src/main/Header/index.jsx
+++ b/client/src/main/Header/index.jsx
@@ -1,4 +1,4 @@
-import { format_minutes } from 'utils';
+import { format_minutes, hide_sensitive_number } from 'utils';
 
 import { Classes, Popover2 } from '@blueprintjs/popover2';
 
@@ -85,7 +85,12 @@ function DisplayTotalScore({ value }) {
   );
 }
 
-function WalletFluxBreakdown({ walletHealth, walletAmountFlux, totalScore }) {
+/*
+ * The wallet cell itself respects Privacy Mode, but this hover tooltip did not
+ * — locked, available and total score stayed readable with Privacy Mode on
+ * (issue #142).
+ */
+function WalletFluxBreakdown({ walletHealth, walletAmountFlux, totalScore, isPrivacy }) {
   const locked = walletHealth
     ? (walletHealth.cumulus.node_count * CC_COLLATERAL_CUMULUS) +
       (walletHealth.nimbus.node_count * CC_COLLATERAL_NIMBUS) +
@@ -93,19 +98,24 @@ function WalletFluxBreakdown({ walletHealth, walletAmountFlux, totalScore }) {
     : 0;
   const available = walletAmountFlux - locked;
 
+  const show = (value) => {
+    const formatted = value.toLocaleString();
+    return isPrivacy ? hide_sensitive_number(formatted) : formatted;
+  };
+
   return (
     <div className='d-block mb-0 cell-tooltip-box'>
       <p>
         <span className='ct-name'>Locked: </span>
-        <span className='ct-val'>{locked.toLocaleString()} FLUX</span>
+        <span className='ct-val'>{show(locked)} FLUX</span>
       </p>
       <p>
         <span className='ct-name'>Available: </span>
-        <span className='ct-val'>{available.toLocaleString()} FLUX</span>
+        <span className='ct-val'>{show(available)} FLUX</span>
       </p>
       <p>
         <span className='ct-name'>Total Score: </span>
-        <span className='ct-val'>{totalScore}</span>
+        <span className='ct-val'>{show(totalScore ?? 0)}</span>
       </p>
     </div>
   );
@@ -232,7 +242,7 @@ export function DashboardCells({ gstore: gs, total_donations, totalScoreAgainstS
               )}
             </CellTooltip>
 
-            <CellTooltip tooltipContent={<WalletFluxBreakdown walletHealth={walletHealth} walletAmountFlux={gs.wallet_amount_flux} totalScore={totalScoreAgainstSearchedWallet} />}>
+            <CellTooltip tooltipContent={<WalletFluxBreakdown walletHealth={walletHealth} walletAmountFlux={gs.wallet_amount_flux} totalScore={totalScoreAgainstSearchedWallet} isPrivacy={enablePrivacyMode} />}>
               {(ref, tooltipProps) => (
                 <Cell
                   elementRef={ref}

--- a/client/src/main/MainApp.jsx
+++ b/client/src/main/MainApp.jsx
@@ -676,7 +676,7 @@ class MainApp extends React.Component {
                   {this.state.isPALoading ? (
                     <Spinner intent='primary' size={150} />
                   ) : (
-                    <ParallelAssets summary={this.state.walletPASummary} theme={this.props.theme} />
+                    <ParallelAssets summary={this.state.walletPASummary} theme={this.props.theme} enablePrivacyMode={enablePrivacyMode} />
                   )}
                 </div>
               ) : (

--- a/client/src/main/ParallelAssets/index.jsx
+++ b/client/src/main/ParallelAssets/index.jsx
@@ -9,6 +9,7 @@ import { InfoCell } from 'components/InfoCell';
 import { FiDollarSign, FiAward, FiShoppingBag, FiLayers } from 'react-icons/fi';
 
 import { pa_summary_full } from 'main/apidata';
+import { hide_sensitive_number } from 'utils';
 import ErgoLogo from 'assets/Ergo_Orange.png'
 import KDALogo from 'assets/kadena-kda-logo.png'
 import ETHLogo from 'assets/ethereum-eth-logo.png'
@@ -22,7 +23,17 @@ import MATICLogo from 'assets/polygon-matic-logo.png'
 import BaseLogo_white from 'assets/Base_Symbol_White.png'
 import BaseLogo_black from 'assets/Base_Symbol_Black.png'
 
-function PASummary(summary) {
+/*
+ * Privacy Mode promises no wallet data is on screen. Parallel Assets had no
+ * privacy handling at all, so every claimable / claimed / mined figure stayed
+ * visible with it on (issue #142).
+ */
+function maskAmount(value, enablePrivacyMode, decimals = 2) {
+  const fixed = Number(value ?? 0).toFixed(decimals);
+  return enablePrivacyMode ? hide_sensitive_number(fixed) : fixed;
+}
+
+function PASummary(summary, enablePrivacyMode) {
   return (
     <div className='pa-summary adp-border-color'>
       <div id='title'>Parallel Assets Summary</div>
@@ -30,6 +41,7 @@ function PASummary(summary) {
         <InfoCell
           name='Total Claimable'
           value={summary.total_claimable}
+          isPrivacy={enablePrivacyMode}
           icon={<FiShoppingBag />}
           iconColor='#000'
           iconColorAlt='#eeeeee'
@@ -39,6 +51,7 @@ function PASummary(summary) {
         <InfoCell
           name={<>Total Claimed to date</>}
           value={summary.total_claimed_to_date}
+          isPrivacy={enablePrivacyMode}
           icon={<FiAward />}
           iconColor='#000'
           iconColorAlt='#eeeeee'
@@ -50,6 +63,7 @@ function PASummary(summary) {
         <InfoCell
           name='Total mined'
           value={summary.total_mined}
+          isPrivacy={enablePrivacyMode}
           icon={<FiLayers />}
           iconColor='#000'
           iconColorAlt='#eeeeee'
@@ -62,7 +76,7 @@ function PASummary(summary) {
   );
 }
 
-function PAssetCard({ assetName, blockStyle, logoUrl, paInfo, placeholder }) {
+function PAssetCard({ assetName, blockStyle, logoUrl, paInfo, placeholder, enablePrivacyMode }) {
   return (
     <div className={'adp-text-normal pa-card' + ` pa-grad-${blockStyle}`}>
       <div className='logo-wrapper'>
@@ -74,31 +88,31 @@ function PAssetCard({ assetName, blockStyle, logoUrl, paInfo, placeholder }) {
       <div className='info-area'>
         <div className='border-bottom adp-border-color pt-2 pb-2'>
           <div className='text-center fs-6 text-wrap'>
-            <span className='fw-bold'>{placeholder ? 'TBC' : `${paInfo.possible_claimable.toFixed(2)} Possible
+            <span className='fw-bold'>{placeholder ? 'TBC' : `${maskAmount(paInfo.possible_claimable, enablePrivacyMode)} Possible
             Claimable`}</span>
           </div>
         </div>
         <div className='border-bottom adp-border-color pt-2 pb-2'>
           <div className='text-center fs-6 text-wrap'>
-            <span className='fw-bold'>{placeholder ? 'TBC' : `${paInfo.amount_claimed.toFixed(2)} Claimed Amount`}</span>
+            <span className='fw-bold'>{placeholder ? 'TBC' : `${maskAmount(paInfo.amount_claimed, enablePrivacyMode)} Claimed Amount`}</span>
           </div>
         </div>
 
         <div className='border-bottom adp-border-color pt-2 pb-2'>
           <div className='text-center fs-6 text-wrap'>
-            <span className='fw-bold'>{placeholder ? 'TBC' : `${paInfo.fusion_fee.toFixed(2)} Fusion Fee`}</span>
+            <span className='fw-bold'>{placeholder ? 'TBC' : `${maskAmount(paInfo.fusion_fee, enablePrivacyMode)} Fusion Fee`}</span>
           </div>
         </div>
 
         <div className='border-bottom adp-border-color pt-2 pb-2'>
           <div className='text-center fs-6 text-wrap'>
-            <span className='fw-bold'>{placeholder ? 'TBC' : `${paInfo.paid.toFixed(2)} Fees Paid`}</span>
+            <span className='fw-bold'>{placeholder ? 'TBC' : `${maskAmount(paInfo.paid, enablePrivacyMode)} Fees Paid`}</span>
           </div>
         </div>
 
         <div className='pt-2 pb-2'>
           <div className='text-center fs-6 text-wrap'>
-            <span className='fw-bold'>{placeholder ? 'TBC' : `${paInfo.amount_received.toFixed(2)} Received Amount`}</span>
+            <span className='fw-bold'>{placeholder ? 'TBC' : `${maskAmount(paInfo.amount_received, enablePrivacyMode)} Received Amount`}</span>
           </div>
         </div>
       </div>
@@ -106,17 +120,18 @@ function PAssetCard({ assetName, blockStyle, logoUrl, paInfo, placeholder }) {
   );
 }
 
-export function ParallelAssets({ summary, theme }) {
+export function ParallelAssets({ summary, theme, enablePrivacyMode = false }) {
 
   return (
     <Container fluid>
       <Row>
         <Col className='margin-b-xl' offset={{}} lg={7}>
-          {PASummary(summary)}
+          {PASummary(summary, enablePrivacyMode)}
         </Col>
         <Col className='margin-b-xl' lg={17}>
           <div className='parallel-assets-list'>
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.kda}
               blockStyle='kda'
               logoUrl={KDALogo}
@@ -124,6 +139,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'KDA'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.eth}
               blockStyle='eth'
               logoUrl={ETHLogo}
@@ -131,6 +147,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'Ethereum'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.bsc}
               blockStyle='bsc'
               logoUrl={BNBLogo}
@@ -138,6 +155,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'BSC'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.trn}
               blockStyle='trn'
               logoUrl={TRNLogo}
@@ -145,6 +163,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'Tron'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.sol}
               blockStyle='sol'
               logoUrl={SOLLogo}
@@ -152,6 +171,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'Solana'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.avx}
               blockStyle='avx'
               logoUrl={AVXLogo}
@@ -159,6 +179,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'AVAX'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.erg}
               blockStyle='erg'
               logoUrl={ErgoLogo}
@@ -166,12 +187,14 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'Ergo'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.algo}
               blockStyle='alg'
               logoUrl={theme === 'light' ? ArgoblackLogo : ArgoLogo}
               assetName={'Algorand'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.matic}
               blockStyle='matic'
               logoUrl={MATICLogo}
@@ -179,6 +202,7 @@ export function ParallelAssets({ summary, theme }) {
               assetName={'Polygon'}
             />
             <PAssetCard
+              enablePrivacyMode={enablePrivacyMode}
               paInfo={summary.assets.base}
               blockStyle='base'
               logoUrl={theme === 'light' ? BaseLogo_black : BaseLogo_white}


### PR DESCRIPTION
Closes #142.

Both leaks reported in the issue, confirmed and fixed.

## 1. Parallel Assets had no privacy handling at all

`grep enablePrivacyMode main/ParallelAssets/index.jsx` returned nothing. The section renders:

- **Summary:** total claimable, total claimed to date, total mined
- **Ten asset cards**, each showing possible claimable, claimed amount, fusion fee, fees paid, received amount

That is **53 wallet figures** visible with Privacy Mode on.

`InfoCell` already accepts an `isPrivacy` prop, so the three summary cells use the existing path. The card figures go through a small `maskAmount` helper.

## 2. The wallet Flux tooltip

The wallet cell itself respects Privacy Mode — but the hover tooltip on it did not:

```
Locked:      1,000 FLUX
Available:   234 FLUX
Total Score: 4,521
```

All three now mask. Total Score is included: it is wallet-specific and reveals fleet size, so leaving it readable would defeat the point.

## Plumbing

None needed. `MainApp.jsx:606` already destructures `enablePrivacyMode` in the same render scope where `ParallelAssets` is mounted at line 679.

## Detail

Masking is applied to the **formatted** string rather than the raw number, so a hidden value keeps the shape of a visible one:

```
1,234  ->  X,XXX      (not XXXX)
```

This matches how `format_amount` in `utils.js` already behaves.

## Verification

Build exit 0, no warnings in any changed file. All 10 `<PAssetCard>` instances confirmed to receive the prop (`grep -A1 '<PAssetCard' | grep -c enablePrivacyMode` → 10 of 10).

Worth a visual confirm with a real wallet before merge — the change is mechanical and follows an existing proven pattern, but Privacy Mode is the kind of feature where a second pair of eyes on the rendered page is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W