### PR TITLE
Fix #91: Flux daemon version on the Overview (+ stop fetching getinfo twice)

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -60,6 +60,7 @@ export function create_global_store() {
     uniqueWalletAddressesCount: 0,
     wordpressCount: 0,
     fluxBlockHeight: 0,
+    daemon_version: 0,
     node_count: {
       cumulus: 0,
       nimbus: 0,
@@ -421,10 +422,29 @@ export async function fetch_global_stats(walletAddress = null) {
   }
 };
 
-  const fetchBlockHeight = async () => {
-    const res = await fetch('https://api.runonflux.io/daemon/getinfo');
-    const json = await res.json();
-    store.current_block_height = json['data']['blocks'];
+  /*
+   * daemon/getinfo used to be fetched twice per refresh — once here for
+   * current_block_height and again in getFluxBlockInfo for fluxBlockHeight,
+   * which is the same field under a second name. Both keys are kept because
+   * different views read different ones, but there is now one request.
+   *
+   * This also gains a try/catch it never had: fetchBlockHeight threw straight
+   * into the Promise.all below, so a single blip on this endpoint failed the
+   * entire global stats load.
+   */
+  const fetchDaemonInfo = async () => {
+    try {
+      const res = await fetch('https://api.runonflux.io/daemon/getinfo');
+      const json = await res.json();
+      const info = json?.data;
+
+      const blocks = info?.blocks ?? 0;
+      store.current_block_height = blocks;
+      store.fluxBlockHeight = blocks;
+      store.daemon_version = info?.version ?? 0;
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   const fetchRichList = async () => {
@@ -513,27 +533,16 @@ export async function fetch_global_stats(walletAddress = null) {
   // fetchTotalDeployedApps. store.wordpressCount is now derived from the shared
   // aggregate, with the same matching rule (exact runonflux/wp-nginx, any tag).
 
-  const getFluxBlockInfo = async () => {
-    try {
-      const res = await fetch('https://api.runonflux.io/daemon/getinfo');
-      const json = await res.json();
-      store.fluxBlockHeight = json?.data?.blocks ?? 0;
-    } catch (error) {
-      console.log('error', error);
-    }
-  };
-
   await Promise.all([
     fetchCurrency(),
     fetchWallet(),
     fetchNode(),
     fetchBenchVer(),
     fetchFluxVer(),
-    fetchBlockHeight(),
+    fetchDaemonInfo(),
     fetchRichList(),
     fetchTotalDeployedApps(),
-    fetchUniqueWalletAddresses(),
-    getFluxBlockInfo()
+    fetchUniqueWalletAddresses()
   ]);
 
   fill_rewards(store);

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -16,7 +16,7 @@ import CountUp from 'components/CountUp';
 import { CC_COLLATERAL_CUMULUS, CC_COLLATERAL_NIMBUS, CC_COLLATERAL_STRATUS } from 'content';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
 import { CategoryTooltip } from 'components/CategoryTooltip';
-import { fluxos_version_string } from 'main/flux_version';
+import { fluxos_version_string, daemon_version_string } from 'main/flux_version';
 import { shortImageName } from 'utils';
 
 // ── Format helpers ─────────────────────────────────────────────────────────────
@@ -186,6 +186,18 @@ function NetworkStatsPanel({ gstore, gpuPrices }) {
               ? fluxos_version_string(gstore.bench_latest_version)
               : '—'}
           </span>
+        </div>
+        <div className="hov-kv-row">
+          <Tooltip2
+            content="Version reported by the Flux daemon. Compare against your own node to spot an out-of-date fluxd."
+            placement="top"
+            hoverOpenDelay={250}
+            transitionDuration={80}
+            popoverClassName="hov-cat-tooltip"
+          >
+            <span className="hov-kv-label">Daemon Version</span>
+          </Tooltip2>
+          <span className="hov-kv-value">{daemon_version_string(gstore.daemon_version) ?? '—'}</span>
         </div>
         {gpuPrices && (
           <>

--- a/client/src/main/flux_version.js
+++ b/client/src/main/flux_version.js
@@ -28,3 +28,27 @@ export function fv_compare(descA, descB) {
 
   return 0;
 }
+
+/**
+ * The Flux daemon reports its version as a packed integer, inherited from the
+ * Zcash/Bitcoin client convention:
+ *
+ *     CLIENT_VERSION = 1000000*major + 10000*minor + 100*revision + build
+ *
+ * so 9010050 is 9.1.0 build 50. In that convention a build of 50 marks a final
+ * release, so it is omitted; anything else (alpha/beta/rc) is shown.
+ *
+ * Returns null for a missing or unparseable value so callers can render a dash.
+ */
+export function daemon_version_string(packed) {
+  const n = Number(packed);
+  if (!Number.isFinite(n) || n <= 0) return null;
+
+  const major = Math.floor(n / 1000000);
+  const minor = Math.floor(n / 10000) % 100;
+  const revision = Math.floor(n / 100) % 100;
+  const build = n % 100;
+
+  const base = `${major}.${minor}.${revision}`;
+  return build === 50 ? base : `${base}.${build}`;
+}


### PR DESCRIPTION
Closes #91.

## The ask

Users were hitting problems with an out-of-date `fluxd` and had nothing on the Overview to compare against. The network panel now shows **Daemon Version** alongside FluxOS Version and Bench Version.

```
FluxOS Version    8.17.1
Bench Version     6.3.1
Daemon Version    9.1.0      ← new
```

## Decoding the version

The daemon reports a packed integer, inherited from the Zcash/Bitcoin client convention:

```
CLIENT_VERSION = 1000000*major + 10000*minor + 100*revision + build
```

So the live value `9010050` is **9.1.0 build 50**. A build of 50 marks a *final release* in that convention, so it is omitted; anything else (alpha/beta/rc) is shown in full.

`daemon_version_string()` returns `null` for a missing or unparseable value, so the row renders an em dash rather than `NaN`. Verified across `9010050 → 9.1.0`, `9010049 → 9.1.0.49`, `8000150 → 8.0.1`, and `0` / `null` / `undefined` → `null`.

## The duplicate fetch I found doing it

`daemon/getinfo` was being fetched **twice per refresh**:

```js
const fetchBlockHeight = async () => { ...json['data']['blocks'] → current_block_height }
const getFluxBlockInfo = async () => { ...json?.data?.blocks    → fluxBlockHeight      }
```

The same field, under two different store keys, from two separate requests. Both keys are kept — `MaintenanceCell` and `HomeOverview` read `current_block_height`, `home/Header` reads `fluxBlockHeight`, `AppsSection` falls back between them — but there is now one fetch.

## And a robustness bug

`fetchBlockHeight` had **no try/catch**, so it threw straight into the `Promise.all` that drives `fetch_global_stats`. A single blip on that endpoint failed the entire global stats load and blanked the home page. It is now wrapped like every one of its neighbours.

## Verification

Against the running production build:

```json
{
  "Daemon Version": "9.1.0",
  "rawDaemonVersion": 9010050,
  "getinfoRequestCount": 1,          // was 2
  "blockHeightKeysAgree": true
}
```

Build exit 0, no warnings in any changed file.

## Not included

Per-node daemon versions are available (`stats.runonflux.io/fluxinfo?projection=daemon` covers all 6,515 nodes), so flagging *which of your nodes* is behind is possible — but that is a node-grid column, not the Overview row this issue asked for. Happy to file it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W