### PR TITLE
Follow-up to #148: bump the app-specs cache key and prune the orphan

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1254,10 +1254,29 @@ export async function fetch_global_performance_rankings() {
 // and would crash on a v1-keyed cache written by this version — bumping the key
 // keeps a rollback safe.
 const HOME_APP_SPECS_CACHE_KEY = 'homeAppSpecs_v2';
+
+/*
+ * Keys this module used to write. sessionStorage runs ~85% full on a normal
+ * load (globalPerfRankings_v3 alone is ~2.9 MB of a ~5 MB quota), so leaving a
+ * ~1.3 MB orphan behind after a key bump is enough to push the new write over
+ * the limit. setItem is wrapped in a silent catch, so that failure is invisible
+ * and caching just quietly stops working.
+ */
+const HOME_APP_SPECS_STALE_KEYS = ['homeAppSpecs_v1'];
+
+function _prune_stale_app_spec_caches() {
+  for (const key of HOME_APP_SPECS_STALE_KEYS) {
+    try {
+      sessionStorage.removeItem(key);
+    } catch {}
+  }
+}
 const HOME_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const BLOCKS_PER_DAY = 2880; // 30 sec/block
 
 export async function fetch_global_app_specs(gstore) {
+  _prune_stale_app_spec_caches();
+
   try {
     const raw = sessionStorage.getItem(HOME_APP_SPECS_CACHE_KEY);
     if (raw) {

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1249,7 +1249,11 @@ export async function fetch_global_performance_rankings() {
 /* =================== GLOBAL APP SPECIFICATIONS ================= */
 /* ================================================================ */
 
-const HOME_APP_SPECS_CACHE_KEY = 'homeAppSpecs_v1';
+// v2: enterprise apps now report null (unknown) resources instead of 0, so the
+// cached shape changed. Older code does spec.cpuPerInst.toFixed(2) unguarded
+// and would crash on a v1-keyed cache written by this version — bumping the key
+// keeps a rollback safe.
+const HOME_APP_SPECS_CACHE_KEY = 'homeAppSpecs_v2';
 const HOME_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const BLOCKS_PER_DAY = 2880; // 30 sec/block
 


### PR DESCRIPTION
Follow-up to #148, which merged before these two commits landed on its branch.

## Why this is needed

#148 changed enterprise apps to report `null` resources instead of `0`, and that value is persisted to sessionStorage. The cache key was **not** bumped in what got merged, so `homeAppSpecs_v1` on the integration branch now contains:

```json
{ "name": "hunderdxsale", "cpuPerInst": null, "enterprise": true }
```

Older code renders `spec.cpuPerInst.toFixed(2)` unguarded. On a **rollback**, or in a tab still running older JS, that throws and the error boundary replaces the entire home overview:

```
TypeError: Cannot read properties of null (reading 'toFixed')
    at Array.map  (ExpiringTodayPanel)
    at Array.map  (DeployedTodayPanel)
```

I hit this for real while verifying — checking out the pre-#148 build with a warm cache from #148 crashed both panels. Clearing sessionStorage made it render normally, confirming the cache and not the code was the cause.

## Two commits

**1. `homeAppSpecs_v1` → `_v2`.** Standard shape-change bump, makes a rollback safe.

**2. Prune the orphaned v1 entry.** This one is less obvious. Bumping the key leaves the old ~1.3 MB entry behind, and sessionStorage is already at **~85% of quota on a normal load**:

| Key | Size |
|---|---|
| `globalPerfRankings_v3` | 2,912 KB |
| `homeAppSpecs_v2` | 1,408 KB |
| others | 5 KB |
| **Total** | **4,325 KB** of a ~5,120 KB quota |

The orphan was enough to push the new write past the limit. `setItem` is wrapped in a silent `catch`, so the failure was invisible — the page rendered fine and simply refetched 1.3 MB on every load. `homeAppSpecs_v2` was never written until I cleared storage by hand.

## Verification

Cold-start on the built app, all five merged/open changes integrated:

```json
{
  "v1Orphan": false,
  "v2Present": true,
  "totalCacheKB": 4325,
  "crashed": false,
  "panels": 9,
  "enterpriseDash": 15,
  "enterpriseZero": 0
}
```

120 tests pass, build exit 0, no new warnings.

## Related

The underlying quota pressure is filed separately as #153 — this PR only removes the orphan it created. Two keys account for 4.3 MB and both grow with the network, so there is no headroom for the next key bump either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W