### PR TITLE
Feature #146: category tooltips show the top 3 apps and their counts

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -3,7 +3,7 @@ import * as dayjs from 'dayjs';
 import { format_minutes } from 'utils';
 import { fluxos_version_desc, fluxos_version_string, fluxos_version_desc_parse } from 'main/flux_version';
 import { categorizeApp, categorizeAppSpec, isOpaqueRuntimeImage } from 'main/Gamification/appCategories';
-import { fetch_fluxinfo_aggregate } from 'fluxinfo';
+import { fetch_fluxinfo_aggregate, buildCategoryTop } from 'fluxinfo';
 
 import { FLUXNODE_INFO_API_MODE, FLUXNODE_INFO_API_URL } from 'app-buildinfo';
 
@@ -102,6 +102,7 @@ export function create_global_store() {
     },
     topRunningImages: [],
     runningCategoryMap: {},
+    runningCategoryTop: {},
     // Provenance for the running-app figures above. `runningAppsStatus` is one
     // of 'live' | 'stale' | 'unavailable' so the UI can say what it is showing
     // instead of silently swapping in a different dataset (see issue #144).
@@ -461,14 +462,36 @@ export async function fetch_global_stats(walletAddress = null) {
 
     // Category breakdown from actual running containers (more accurate than spec data)
     const categoryMap = {};
+    // Per-category image tallies, keyed on the image name with the tag stripped
+    // so feather:1.0.13 and feather:1.0.14 count as one app rather than two.
+    // Genuinely different images stay separate — minecraft-server and
+    // minecraft-bedrock-server are two apps, not two versions of one.
+    const categoryImages = {};
+
     for (const [image, count] of imageEntries) {
       // Git-deployed apps all run the same wrapper image, which says nothing
       // about the workload inside — keep them uncategorized rather than
       // reporting 175 containers of "DevOps".
       const cat = isOpaqueRuntimeImage(image) ? 'other' : categorizeApp(image.toLowerCase());
       categoryMap[cat] = (categoryMap[cat] || 0) + count;
+
+      const base = image.split(':')[0];
+      categoryImages[cat] = categoryImages[cat] || {};
+      categoryImages[cat][base] = (categoryImages[cat][base] || 0) + count;
     }
+
     store.runningCategoryMap = categoryMap;
+
+    /*
+     * Top 3 apps per category, for the category tooltips. Several categories
+     * are effectively a single app — Computing is 99% Folding@Home, Monitoring
+     * 94% Globalping — which the bar chart alone does not convey.
+     *
+     * Ties are broken alphabetically: Media currently has three apps on 3
+     * containers each, so sorting by count alone reshuffles them on every
+     * refresh.
+     */
+    store.runningCategoryTop = buildCategoryTop(categoryImages);
   };
 
   const fetchUniqueWalletAddresses = async () => {

--- a/client/src/components/CategoryTooltip/index.jsx
+++ b/client/src/components/CategoryTooltip/index.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import './index.scss';
+
+import { CATEGORY_TOOLTIPS } from 'content/appCategoryMeta';
+import { shortImageName } from 'utils';
+
+/*
+ * Category tooltip: the static description, plus the three biggest apps in that
+ * category with their container counts.
+ *
+ * The bar chart alone implies a dozen comparably-composed ecosystems. In
+ * practice several categories are one app wearing a category's clothes —
+ * Computing is 99% Folding@Home, Monitoring is 94% Globalping — and that only
+ * becomes visible when you name the members.
+ *
+ * `breakdown` comes from gstore.runningCategoryTop and may be absent: the Apps
+ * tab renders per-wallet data, and the spec panels render per-app rows, where
+ * network-wide totals would be misleading. Those pass nothing and get the
+ * description alone.
+ */
+export function CategoryTooltip({ category, breakdown }) {
+  const description = CATEGORY_TOOLTIPS[category] || category;
+  const top = breakdown?.top || [];
+
+  return (
+    <div className="cat-tooltip">
+      <div className="cat-tooltip__desc">{description}</div>
+
+      {top.length > 0 && (
+        <ul className="cat-tooltip__list">
+          {top.map(({ image, count }) => (
+            <li key={image} className="cat-tooltip__row">
+              <span className="cat-tooltip__name">{shortImageName(image)}</span>
+              <span className="cat-tooltip__count">{count.toLocaleString()}</span>
+            </li>
+          ))}
+
+          {breakdown.otherCount > 0 && (
+            <li className="cat-tooltip__row cat-tooltip__row--rest">
+              <span className="cat-tooltip__name">
+                +{breakdown.otherCount} other{breakdown.otherCount === 1 ? '' : 's'}
+              </span>
+              <span className="cat-tooltip__count">{breakdown.otherTotal.toLocaleString()}</span>
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/CategoryTooltip/index.scss
+++ b/client/src/components/CategoryTooltip/index.scss
@@ -1,0 +1,42 @@
+.cat-tooltip {
+  max-width: 300px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.cat-tooltip__desc {
+  opacity: 0.9;
+}
+
+.cat-tooltip__list {
+  list-style: none;
+  margin: 7px 0 0;
+  padding: 7px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.cat-tooltip__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  line-height: 1.6;
+}
+
+.cat-tooltip__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cat-tooltip__count {
+  flex: none;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.cat-tooltip__row--rest {
+  opacity: 0.6;
+}

--- a/client/src/fluxinfo.js
+++ b/client/src/fluxinfo.js
@@ -154,3 +154,32 @@ export async function fetch_fluxinfo_aggregate() {
     _fluxinfoInFlight = null;
   }
 }
+
+/**
+ * Shape per-category image tallies into the top 3 plus a remainder, for the
+ * category tooltips.
+ *
+ * Input is { category: { imageName: count } } with tags already stripped, so
+ * feather:1.0.13 and feather:1.0.14 arrive as one entry. Genuinely different
+ * images stay separate — minecraft-server and minecraft-bedrock-server are two
+ * apps, not two versions of one.
+ *
+ * Ties break alphabetically. Media currently has three apps on 3 containers
+ * each, so sorting by count alone reshuffles them between refreshes.
+ */
+export function buildCategoryTop(categoryImages) {
+  return Object.fromEntries(
+    Object.entries(categoryImages || {}).map(([cat, images]) => {
+      const ranked = Object.entries(images || {}).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+      const top = ranked.slice(0, 3);
+      return [
+        cat,
+        {
+          top: top.map(([image, count]) => ({ image, count })),
+          otherCount: ranked.length - top.length,
+          otherTotal: ranked.slice(3).reduce((sum, [, c]) => sum + c, 0)
+        }
+      ];
+    })
+  );
+}

--- a/client/src/fluxinfoResilience.test.js
+++ b/client/src/fluxinfoResilience.test.js
@@ -1,4 +1,4 @@
-import { fetch_fluxinfo_aggregate } from './fluxinfo';
+import { fetch_fluxinfo_aggregate, buildCategoryTop } from './fluxinfo';
 
 /*
  * Regression tests for issue #144.
@@ -126,5 +126,52 @@ describe('fetch_fluxinfo_aggregate', () => {
 
     expect(status).toBe('unavailable');
     expect(aggregate).toBeNull();
+  });
+});
+
+describe('buildCategoryTop', () => {
+  it('returns the three biggest apps, most to least', () => {
+    const { computing } = buildCategoryTop({
+      computing: { 'a/folding-at-home': 2264, 'b/foldingathome-arm64': 13, 'c/rosetta': 3, 'd/other': 1 },
+    });
+    expect(computing.top).toEqual([
+      { image: 'a/folding-at-home', count: 2264 },
+      { image: 'b/foldingathome-arm64', count: 13 },
+      { image: 'c/rosetta', count: 3 },
+    ]);
+  });
+
+  it('never returns more than three', () => {
+    const images = Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`img${i}`, i + 1]));
+    expect(buildCategoryTop({ web: images }).web.top).toHaveLength(3);
+  });
+
+  it('reports the remainder so the top 3 are not mistaken for the whole category', () => {
+    const { gaming } = buildCategoryTop({ gaming: { a: 10, b: 5, c: 3, d: 2, e: 1 } });
+    expect(gaming.otherCount).toBe(2);
+    expect(gaming.otherTotal).toBe(3);
+    // top + remainder must reconcile to the category total
+    expect(gaming.top.reduce((s, x) => s + x.count, 0) + gaming.otherTotal).toBe(21);
+  });
+
+  it('breaks ties alphabetically so the order is stable between refreshes', () => {
+    // Media really does have three apps on 3 containers each
+    const a = buildCategoryTop({ media: { owncast: 3, 'yt-dl': 3, qbittorrent: 3 } });
+    const b = buildCategoryTop({ media: { qbittorrent: 3, owncast: 3, 'yt-dl': 3 } });
+    expect(a.media.top.map((x) => x.image)).toEqual(['owncast', 'qbittorrent', 'yt-dl']);
+    expect(a.media.top).toEqual(b.media.top);
+  });
+
+  it('handles categories with fewer than three apps', () => {
+    const { ai } = buildCategoryTop({ ai: { doccano: 3, duckling: 3 } });
+    expect(ai.top).toHaveLength(2);
+    expect(ai.otherCount).toBe(0);
+    expect(ai.otherTotal).toBe(0);
+  });
+
+  it('handles missing and empty input without throwing', () => {
+    expect(buildCategoryTop(undefined)).toEqual({});
+    expect(buildCategoryTop({})).toEqual({});
+    expect(buildCategoryTop({ web: {} })).toEqual({ web: { top: [], otherCount: 0, otherTotal: 0 } });
   });
 });

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -11,8 +11,10 @@ import ReactCountryFlag from 'react-country-flag';
 import CountUp from 'react-countup';
 
 import { CC_COLLATERAL_CUMULUS, CC_COLLATERAL_NIMBUS, CC_COLLATERAL_STRATUS } from 'content';
-import { APP_CATEGORY_META, CATEGORY_TOOLTIPS } from 'content/appCategoryMeta';
+import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { CategoryTooltip } from 'components/CategoryTooltip';
 import { fluxos_version_string } from 'main/flux_version';
+import { shortImageName } from 'utils';
 
 // ── Format helpers ─────────────────────────────────────────────────────────────
 
@@ -34,13 +36,6 @@ function blocksToHuman(blocks) {
   const h = Math.floor(totalMinutes / 60);
   const m = totalMinutes % 60;
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
-}
-
-function shortImageName(image) {
-  return image
-    .replace(/^(docker\.io\/|registry\.hub\.docker\.com\/)/, '')
-    .replace(/^library\//, '')
-    .split(':')[0];
 }
 
 // ── Shared sub-components ──────────────────────────────────────────────────────
@@ -292,7 +287,7 @@ function NetworkResourcesPanel({ gstore }) {
 // ── Panel 3: App Ecosystem ─────────────────────────────────────────────────────
 
 function AppEcosystemPanel({ gstore }) {
-  const { runningCategoryMap, node_count, runningAppsStatus, runningAppsFetchedAt } = gstore;
+  const { runningCategoryMap, runningCategoryTop, node_count, runningAppsStatus, runningAppsFetchedAt } = gstore;
   const hasRunning = Object.keys(runningCategoryMap).length > 0;
 
   // Still loading if no node data at all
@@ -379,7 +374,7 @@ function AppEcosystemPanel({ gstore }) {
           const { label, Icon, color } = meta;
           const barPct = (totalInstances / maxVal) * 100;
           const sharePct = ((totalInstances / grandTotal) * 100).toFixed(0);
-          const tooltip = CATEGORY_TOOLTIPS[category] || category;
+          const tooltip = <CategoryTooltip category={category} breakdown={runningCategoryTop?.[category]} />;
 
           return (
             <div key={category} className="hov-eco-row">
@@ -472,7 +467,8 @@ function SpecHeader() {
 function SpecCategoryIcon({ category }) {
   const meta = APP_CATEGORY_META[category] || APP_CATEGORY_META.other;
   const { Icon, color } = meta;
-  const tooltip = CATEGORY_TOOLTIPS[category] || CATEGORY_TOOLTIPS.other;
+  // Per-app row: the network-wide breakdown would be misleading here.
+  const tooltip = <CategoryTooltip category={category} />;
   return (
     <Tooltip2 content={tooltip} placement="top" hoverOpenDelay={200} popoverClassName="hov-cat-tooltip">
       <span className="hov-spec-cat" style={{ color }}>

--- a/client/src/main/AppsSection/index.jsx
+++ b/client/src/main/AppsSection/index.jsx
@@ -7,7 +7,8 @@ import { IconContext } from 'react-icons';
 import { FiBox } from 'react-icons/fi';
 import { FaGithub, FaDocker, FaLock } from 'react-icons/fa';
 import { LayoutContext } from 'contexts/LayoutContext';
-import { APP_CATEGORY_META, CATEGORY_TOOLTIPS } from 'content/appCategoryMeta';
+import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { CategoryTooltip } from 'components/CategoryTooltip';
 import { categorizeAppSpec } from 'main/Gamification/appCategories';
 import { fetch_global_app_specs } from 'main/apidata';
 import { hide_sensitive_number, blocksToHumanLong } from 'utils';
@@ -179,7 +180,7 @@ export function AppsSection({ walletNodes, gstore }) {
             const meta = APP_CATEGORY_META[cat] || APP_CATEGORY_META.other;
             const CatIcon = meta.Icon || FiBox;
             return (
-              <Tooltip2 key={cat} content={CATEGORY_TOOLTIPS[cat] || cat} placement="top" hoverOpenDelay={200}>
+              <Tooltip2 key={cat} content={<CategoryTooltip category={cat} />} placement="top" hoverOpenDelay={200}>
                 <span className="apps-summary__chip" style={{ borderColor: `${meta.color}44` }}>
                   <IconContext.Provider value={{ size: '12px' }}>
                     <span style={{ color: meta.color }}><CatIcon /></span>
@@ -260,7 +261,7 @@ export function AppsSection({ walletNodes, gstore }) {
                       </td>
                       <td className="apps-td--name">{row.appName}</td>
                       <td className="apps-td--cat">
-                        <Tooltip2 content={CATEGORY_TOOLTIPS[row.category] || row.category} placement="top" hoverOpenDelay={200}>
+                        <Tooltip2 content={<CategoryTooltip category={row.category} />} placement="top" hoverOpenDelay={200}>
                           <span style={{ color: meta.color }}>
                             <IconContext.Provider value={{ size: '13px' }}><CatIcon /></IconContext.Provider>
                           </span>

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -185,3 +185,11 @@ export function calculate_float_number(amount) {
 
   return Math.round(amount * 100) / 100;
 }
+
+/** "ghcr.io/girderworks/feather:1.0.14" -> "girderworks/feather" */
+export function shortImageName(image) {
+  return (image || '')
+    .replace(/^(docker\.io\/|registry\.hub\.docker\.com\/|ghcr\.io\/|quay\.io\/)/, '')
+    .replace(/^library\//, '')
+    .split(':')[0];
+}


### PR DESCRIPTION
Closes #146.

## Why

The bar chart implies a dozen comparably-composed ecosystems. In practice several categories are one app wearing a category's clothes:

| Category | Total | Top app | Share |
|---|---|---|---|
| Computing | 2,276 | `folding-at-home` 2,260 | **99%** |
| Monitoring | 216 | `globalping-probe` 202 | **94%** |
| Gaming | 440 | `palworld-server-docker` 222 | 51% |
| Blockchain | 1,330 | `girderworks/feather` 527 | 40% |

Naming the members makes that visible. It also removes a maintenance trap — the old tooltips listed examples by hand, so they drifted. Two were already wrong before being corrected recently: Gaming named CS:GO while Palworld was half the category, DevOps named Gitea/Jenkins while the actual residents were ssh, n8n and Budibase.

## Cost

None. `fetchTotalDeployedApps` already built the full image tally and threw everything away except per-category totals and a global top 10. It now also keeps a per-category top 3 — **no new request**, ~1 KB added to the store.

## The three decisions from the issue

**Tags merged.** `feather:1.0.13` + `feather:1.0.14` = one app (527), not two (439 + 88).

Worth being precise about what this does *not* merge: genuinely different images stay separate, so `itzg/minecraft-server` and `itzg/minecraft-bedrock-server` remain two entries. That is correct — Java and Bedrock are different apps, not different versions of one.

**Exactly three, most to least**, with a `+N others` line so the top 3 aren't mistaken for the whole category.

**Ties break alphabetically.** Media has three apps on 3 containers each; sorting by count alone reshuffled them on every refresh.

## Where it appears

Only the **App Ecosystem panel** passes the breakdown. The Apps tab chips are per-wallet and the Expiring/Deployed rows are per-app — network-wide totals would be misleading in both. They render the description alone, through the same component so the styling stays consistent.

## Structure

Shaping lives in `fluxinfo.js` as `buildCategoryTop()` rather than inline in `apidata.js`, so it is unit testable. `shortImageName` moves to `utils.js` so the tooltip and the Top Hosted Apps panel share one implementation; it now also strips `ghcr.io` and `quay.io`, so `ghcr.io/girderworks/feather` reads as `girderworks/feather`.

## Verification

**126 tests** (6 new): ordering, the three-item cap, remainder reconciliation, tie stability, categories with fewer than three apps, and empty/missing input.

Against live data, every category reconciles exactly:

```
allReconcile: true      // top 3 + otherTotal === categoryTotal, for all 12
neverMoreThan3: true
```

Build exit 0, no warnings in any changed file.

**Note on manual verification:** I confirmed the data layer against the live network but could not get a reliable hover screenshot — the browser viewport kept resizing between automation calls. The tooltip renders through Blueprint `Tooltip2` exactly as the previous string-based tooltips did, so the risk is low, but a quick hover check before merge would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W