### PR TITLE
Fix: FLUX Price on the Overview intermittently stuck at $0.0000

### DIFF
--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -8,7 +8,10 @@ import { FaGamepad, FaTrophy } from 'react-icons/fa';
 import { LuBrainCircuit } from 'react-icons/lu';
 import { Gpu } from 'lucide-react';
 import ReactCountryFlag from 'react-country-flag';
-import CountUp from 'react-countup';
+// The project's own wrapper, which honours REACT_APP_ENABLE_NUMBER_SPINNING.
+// HomeOverview was the only file importing react-countup directly, so the home
+// page animated while the rest of the app did not.
+import CountUp from 'components/CountUp';
 
 import { CC_COLLATERAL_CUMULUS, CC_COLLATERAL_NIMBUS, CC_COLLATERAL_STRATUS } from 'content';
 import { APP_CATEGORY_META, CATEGORY_TOOLTIPS } from 'content/appCategoryMeta';
@@ -130,7 +133,7 @@ function NetworkStatsPanel({ gstore, gpuPrices }) {
         badgeContent={
           total > 0 ? (
             <span className="hov-header-badge hov-header-badge--hero">
-              <CountUp end={total} separator="," duration={1.5} />
+              <CountUp end={total} />
             </span>
           ) : null
         }
@@ -163,7 +166,7 @@ function NetworkStatsPanel({ gstore, gpuPrices }) {
           <span className="hov-kv-label">FLUX Price</span>
           <span className="hov-kv-value hov-green" style={{ fontSize: '1.1rem', fontWeight: 700 }}>
             {gstore.flux_price_usd > 0
-              ? <CountUp end={gstore.flux_price_usd} decimals={4} prefix="$" duration={1.5} />
+              ? <CountUp end={gstore.flux_price_usd} decimals={4} prefix="$" />
               : '—'}
           </span>
         </div>
@@ -366,7 +369,7 @@ function AppEcosystemPanel({ gstore }) {
               popoverClassName="hov-cat-tooltip"
             >
               <span className="hov-header-badge hov-header-badge--hero">
-                <CountUp end={grandTotal} separator="," duration={1.5} />
+                <CountUp end={grandTotal} />
               </span>
             </Tooltip2>
           ) : null


### PR DESCRIPTION
## The symptom

The FLUX Price on the home Overview intermittently rendered `$0.0000` while the store held the correct value:

```
storeValue: 0.04362070021687448
rendered:   ["$0.0000", "$0.0000", "$0.0000", "$0.0000", "$0.0000", "$0.0000"]
```

Six samples over six seconds — not an animation caught mid-flight. On other loads it rendered correctly, which is what made it look like a data problem.

## Root cause

`HomeOverview` is the **only** file in the app that imports `react-countup` directly:

```
$ grep -rn "from 'react-countup'" --include=*.jsx src/
src/components/CountUp/index.jsx     ← the wrapper
src/home/HomeOverview/index.jsx      ← bypasses it
```

Everything else goes through `components/CountUp`, the project's own wrapper, which honours `REACT_APP_ENABLE_NUMBER_SPINNING` — set to **`false`** in `.env`:

```jsx
return process.env.REACT_APP_ENABLE_NUMBER_SPINNING === 'true'
  ? <CountUp {...props} decimals={decimalPlaces} />
  : <span>{prefix}{format_amount(end, false, decimalPlaces)}{suffix}</span>;
```

So the home page animated its counters while the rest of the app rendered static numbers, and that animation sometimes never completed.

## Confirmed pre-existing

I built the branch point and reproduced the identical `$0.0000` there, so this is not a regression from any of the recent work.

## The fix

Route the three home counters through the wrapper. This makes them deterministic and consistent with every other number in the app, and honours a configuration flag the home page was silently ignoring.

The wrapper's static path formats via `format_amount` → `toLocaleString('en-US')`, so thousands separators survive without the explicit `separator=","` prop.

## Verification

Live build, five samples over 3.5 seconds:

| | Rendered | Store |
|---|---|---|
| FLUX Price | `$0.0439` | `0.04393104284364881` |
| Flux Network badge | `6,511` | `6511` |
| App Ecosystem badge | `6,738` | `6738` |

Identical across all five samples — no flicker, no stuck zero. 120 tests pass, build exit 0, no warnings in the changed file.

## If you want the animation back

Flip `REACT_APP_ENABLE_NUMBER_SPINNING` to `true` in `.env`. It would then apply consistently across the whole app rather than to one panel — which is presumably what the flag was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W