### PR TITLE
Fix #96: navbar controls were unreachable on mobile

### DIFF
--- a/client/src/components/Navbar/index.scss
+++ b/client/src/components/Navbar/index.scss
@@ -37,3 +37,66 @@
         }
     }
 }
+
+// ── Mobile ────────────────────────────────────────────────────────────────────
+//
+// The navbar needs ~606px of intrinsic width: logo, four labelled buttons
+// (Home / Nodes / Guides / Demo), a divider, theme and settings. Blueprint's
+// navbar groups clip rather than scroll, so there was no horizontal overflow to
+// notice — the content was simply cut off. On a 390px phone the Flux logo and
+// the whole Home button sat off-screen at x -85..-3 and could not be tapped
+// (issue #96).
+//
+// Icons already carry the meaning, so dropping the labels is what buys the
+// room: 606px -> 388px at the first tier, -> 283px at the second, which fits a
+// 320px phone with every control reachable.
+
+@media (max-width: 768px) {
+  .bp4-navbar {
+    padding-left: 6px;
+    padding-right: 6px;
+
+    .bp4-button-text {
+      display: none;
+    }
+
+    .bp4-button {
+      margin-right: 2px !important;
+      padding-left: 8px;
+      padding-right: 8px;
+    }
+
+    .bp4-navbar-group.bp4-align-right {
+      margin-right: 0 !important;
+    }
+
+    img {
+      margin-left: 4px !important;
+      height: 26px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .bp4-navbar {
+    padding-left: 4px;
+    padding-right: 4px;
+
+    .bp4-button {
+      margin-right: 0 !important;
+      padding-left: 7px;
+      padding-right: 7px;
+      min-width: 38px;
+    }
+
+    // The divider is decoration, and it is the cheapest thing to drop.
+    .bp4-navbar-divider {
+      display: none;
+    }
+
+    img {
+      margin-left: 2px !important;
+      height: 22px;
+    }
+  }
+}


### PR DESCRIPTION
Closes #96.

## What is actually broken

The navbar had **no responsive handling at all** — no media queries anywhere for `.bp4-navbar`. It needs ~606px of intrinsic width for logo + four labelled buttons + divider + theme + settings.

Blueprint's navbar groups **clip rather than scroll**, so there was no horizontal overflow to notice — `scrollWidth === clientWidth` at every width. The content was just silently cut off.

Measured at 390px (iPhone 15), positions relative to the navbar's left edge:

| Control | left | right | reachable |
|---|---|---|---|
| **Home** | **−85** | **−3** | **no** |
| Nodes | 3 | 86 | yes |
| Guides | 92 | 178 | yes |
| Demo | 178 | 258 | yes |
| theme | 279 | 319 | yes |
| settings | 319 | 359 | yes |

The Flux logo was pushed off-screen entirely, and **Home was completely untappable**.

## The fix

Icons already carry the meaning, so dropping the labels is what buys the room:

| Tier | Intrinsic width | Changes |
|---|---|---|
| ≤768px | 606px → **388px** | labels hidden, tighter button spacing, smaller logo |
| ≤480px | 388px → **283px** | divider dropped, tighter still |

## Verification

On the built app, applying each tier's rules and measuring every control:

| Width | All buttons reachable | Logo visible | Smallest button |
|---|---|---|---|
| 320px | ✅ | ✅ | 38px |
| 360px | ✅ | ✅ | 38px |
| 390px | ✅ | ✅ | 38–39px |
| 430px | ✅ | ✅ | 39px |
| 768px | ✅ | ✅ | 39px |

**Desktop untouched** — confirmed at 1907px: labels still render (`Home`, `Nodes`, `Guides`, `Demo`), logo keeps its original 16px margin and 31px height.

## A note on the issue wording

#96 asked for the logo further left and the options centred. That described the 2023 navbar, which has since been rebuilt — the current logo is already left-aligned and the options are right-aligned. Rather than apply the original wording to a layout it no longer describes, this fixes what is broken today: controls the user cannot reach.

If you would prefer a hamburger menu or centred icons instead of the icon row, that is a straightforward follow-up — this deliberately keeps the change to CSS with no new components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W