### PR TITLE
Refactor #147 (1/n): make apidata.js testable, and pin its calculations

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1,4 +1,4 @@
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs';
 
 import { format_minutes } from 'utils';
 import { fluxos_version_desc, fluxos_version_string, fluxos_version_desc_parse } from 'main/flux_version';
@@ -147,7 +147,9 @@ function fill_tier_g_projection_fractus(projectionTargetObj, nodeCount, networkF
 */
 
 
-function fill_rewards(gstore) {
+// Exported so the reward maths can be unit tested. It is the most
+// financially sensitive calculation in the app and #147 will move it.
+export function fill_rewards(gstore) {
   fill_tier_g_projection(
     gstore.reward_projections.cumulus,
     gstore.node_count.cumulus,

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -1,0 +1,174 @@
+import {
+  create_global_store,
+  tier_global_projections,
+  fill_rewards,
+  calc_mtn_window,
+  normalize_raw_node_tier,
+  wallet_health_full,
+} from './apidata';
+
+import {
+  CC_BLOCK_REWARD,
+  CC_PA_REWARD,
+  CC_FLUX_REWARD_CUMULUS,
+  CC_FLUX_REWARD_NIMBUS,
+  CC_FLUX_REWARD_STRATUS,
+  CC_COLLATERAL_CUMULUS,
+  CC_COLLATERAL_NIMBUS,
+  CC_COLLATERAL_STRATUS,
+} from 'content/index';
+
+/*
+ * Baseline for #147.
+ *
+ * apidata.js is about to be split into modules, and its reward projections are
+ * the most financially sensitive numbers in the app — they drive the APY and
+ * payout figures node operators actually make decisions on. These tests pin the
+ * arithmetic against the constants so the split can be shown to be
+ * behaviour-preserving rather than assumed to be.
+ *
+ * Expected values are derived from the constants rather than hardcoded, so a
+ * deliberate change to a reward percentage updates the test with the code,
+ * while an accidental change to the *formula* still fails.
+ */
+
+const FLUX_PER_DAY = 24 * 60 * 2; // one block every 30s
+
+function expectedFor(rewardPct, nodeCount, collateral) {
+  const networkPerDay = FLUX_PER_DAY * ((CC_BLOCK_REWARD * rewardPct) / 100);
+  const perNode = networkPerDay / nodeCount;
+  const pa = (perNode * CC_PA_REWARD) / 100;
+  return {
+    pay_frequency: nodeCount / 2,
+    payment_amount: perNode,
+    pa_amount: pa,
+    apy: 100 * (((perNode + pa) * 365) / collateral),
+  };
+}
+
+describe('create_global_store', () => {
+  it('starts zeroed with no running-app data', () => {
+    const s = create_global_store();
+    expect(s.node_count).toEqual({ cumulus: 0, nimbus: 0, stratus: 0, total: 0 });
+    expect(s.flux_price_usd).toBe(0);
+    expect(s.totalRunningApps).toBe(0);
+    expect(s.runningCategoryMap).toEqual({});
+    expect(s.runningCategoryTop).toEqual({});
+  });
+
+  it('defaults running-app provenance to unavailable', () => {
+    // The App Ecosystem panel keys off this to avoid claiming live data it
+    // does not have — see #144.
+    const s = create_global_store();
+    expect(s.runningAppsStatus).toBe('unavailable');
+    expect(s.runningAppsFetchedAt).toBeNull();
+  });
+
+  it('returns a fresh object each call', () => {
+    const a = create_global_store();
+    const b = create_global_store();
+    a.node_count.total = 99;
+    expect(b.node_count.total).toBe(0);
+  });
+});
+
+describe('tier_global_projections', () => {
+  it('starts every projection at zero', () => {
+    expect(tier_global_projections()).toEqual({
+      pay_frequency: 0,
+      payment_amount: 0,
+      pa_amount: 0,
+      apy: 0,
+    });
+  });
+});
+
+describe('fill_rewards', () => {
+  const store = create_global_store();
+  store.node_count = { cumulus: 3199, nimbus: 1637, stratus: 1684, total: 6520 };
+  fill_rewards(store);
+
+  it('computes cumulus projections from the reward constants', () => {
+    const e = expectedFor(CC_FLUX_REWARD_CUMULUS, 3199, CC_COLLATERAL_CUMULUS);
+    const a = store.reward_projections.cumulus;
+    expect(a.pay_frequency).toBeCloseTo(e.pay_frequency, 9);
+    expect(a.payment_amount).toBeCloseTo(e.payment_amount, 9);
+    expect(a.pa_amount).toBeCloseTo(e.pa_amount, 9);
+    expect(a.apy).toBeCloseTo(e.apy, 9);
+  });
+
+  it('computes nimbus projections from the reward constants', () => {
+    const e = expectedFor(CC_FLUX_REWARD_NIMBUS, 1637, CC_COLLATERAL_NIMBUS);
+    expect(store.reward_projections.nimbus.apy).toBeCloseTo(e.apy, 9);
+    expect(store.reward_projections.nimbus.payment_amount).toBeCloseTo(e.payment_amount, 9);
+  });
+
+  it('computes stratus projections from the reward constants', () => {
+    const e = expectedFor(CC_FLUX_REWARD_STRATUS, 1684, CC_COLLATERAL_STRATUS);
+    expect(store.reward_projections.stratus.apy).toBeCloseTo(e.apy, 9);
+    expect(store.reward_projections.stratus.payment_amount).toBeCloseTo(e.payment_amount, 9);
+  });
+
+  it('pay frequency is half the node count, in minutes', () => {
+    // one payout every two minutes across the tier
+    expect(store.reward_projections.cumulus.pay_frequency).toBe(3199 / 2);
+    expect(store.reward_projections.stratus.pay_frequency).toBe(1684 / 2);
+  });
+
+  it('produces finite, positive numbers for a realistic network', () => {
+    for (const tier of ['cumulus', 'nimbus', 'stratus']) {
+      const p = store.reward_projections[tier];
+      for (const key of ['pay_frequency', 'payment_amount', 'pa_amount', 'apy']) {
+        expect(Number.isFinite(p[key])).toBe(true);
+        expect(p[key]).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('a tier with no nodes yields Infinity rather than silently zeroing', () => {
+    // Documents current behaviour: division by a zero node count. Worth knowing
+    // before #147 moves this — the UI must not render it raw.
+    const empty = create_global_store();
+    empty.node_count = { cumulus: 0, nimbus: 0, stratus: 0, total: 0 };
+    fill_rewards(empty);
+    expect(empty.reward_projections.cumulus.payment_amount).toBe(Infinity);
+  });
+});
+
+describe('calc_mtn_window', () => {
+  // 480 blocks at 30s = a 240 minute maintenance window
+  it('returns Closed once the window has elapsed', () => {
+    expect(calc_mtn_window(1000, 1480)).toBe('Closed');
+    expect(calc_mtn_window(1000, 2000)).toBe('Closed');
+  });
+
+  it('returns a formatted duration while the window is open', () => {
+    const open = calc_mtn_window(1000, 1000);
+    expect(open).not.toBe('Closed');
+    expect(typeof open).toBe('string');
+    expect(open.length).toBeGreaterThan(0);
+  });
+
+  it('closes exactly at the 480 block boundary', () => {
+    expect(calc_mtn_window(1000, 1479)).not.toBe('Closed');
+    expect(calc_mtn_window(1000, 1480)).toBe('Closed');
+  });
+});
+
+describe('normalize_raw_node_tier', () => {
+  it('upper-cases the tier', () => {
+    expect(normalize_raw_node_tier({ tier: 'cumulus' })).toBe('CUMULUS');
+    expect(normalize_raw_node_tier({ tier: 'Stratus' })).toBe('STRATUS');
+  });
+});
+
+describe('wallet_health_full', () => {
+  it('starts every tier zeroed', () => {
+    const h = wallet_health_full();
+    for (const tier of ['cumulus', 'nimbus', 'stratus']) {
+      expect(h[tier].node_count).toBe(0);
+      expect(h[tier].projection_daily.flux).toBe(0);
+      expect(h[tier].projection_montly.flux).toBe(0);
+    }
+  });
+});

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,5 +1,3 @@
-import * as dayjs from 'dayjs';
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Application from './Application';

--- a/client/src/persistance/store.js
+++ b/client/src/persistance/store.js
@@ -1,4 +1,4 @@
-import * as localforage from 'localforage';
+import localforage from 'localforage';
 import 'localforage-observable'; //Buchi: Update needed to gain access to newObservables
 
 export let appStore;

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,55 @@
+/*
+ * Jest setup, picked up automatically by react-scripts.
+ *
+ * In the browser, public/runtime/app-content.js runs before the bundle and
+ * defines window.gContent. Jest never loads it, so content/index.js — which
+ * reads window.gContent.URL_YOUTUBE at module scope — throws on import, and
+ * with it anything that transitively imports content, which includes
+ * apidata.js and most of the app.
+ *
+ * The values below mirror public/runtime/app-content.js. Only the constants
+ * that code actually reads are duplicated; the video lists and social links are
+ * present because content/index.js destructures them at import time, not
+ * because any test asserts on them.
+ *
+ * If a test depends on one of these numbers, assert against the import from
+ * 'content' rather than hardcoding it here, so the two cannot drift apart
+ * silently.
+ */
+
+window.gContent = {
+  URL_YOUTUBE: 'https://www.youtube.com/channel/UCO-gfYYQL22oibzOjr1SnHA',
+  URL_TWITTER: 'https://twitter.com/2ndTLMining',
+  URL_GITHUB: 'https://github.com/2ndtlmining/Fluxnode',
+  EMAIL: '2ndtlmining@gmail.com',
+
+  ADDRESS_FLUX: 't1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG',
+  ADDRESS_BTC: '1MjMuVLEaAd8HJd3mh94L8qQe4cE6tH87V',
+
+  REQUIREMENTS: {
+    threads: { C: 4, N: 8, S: 16, F: 4 },
+    ram: { C: 8, N: 32, S: 64, F: 8 },
+    size: { C: 220, N: 440, S: 880, F: 9000 },
+    dws: { C: 180, N: 180, S: 400, F: 80 },
+    eps: { C: 240, N: 640, S: 1520, F: 240 },
+    net_down_speed: { C: 25, N: 50, S: 100, F: 100 },
+    net_up_speed: { C: 25, N: 50, S: 100, F: 100 },
+  },
+
+  CC_COLLATERAL_CUMULUS: 1000,
+  CC_COLLATERAL_NIMBUS: 12500,
+  CC_COLLATERAL_STRATUS: 40000,
+  CC_COLLATERAL_FRACTUS: 1000,
+
+  CC_BLOCK_REWARD: 14,
+
+  CC_FLUX_REWARD_CUMULUS: 7.142,
+  CC_FLUX_REWARD_NIMBUS: 25.0,
+  CC_FLUX_REWARD_STRATUS: 64.28,
+  CC_FLUX_REWARD_FRACTUS: 7.142,
+
+  CC_PA_REWARD: 100.0,
+
+  SETUP_VIDEOS: [],
+  GUIDE_VIDEOS: [],
+};

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -1,5 +1,9 @@
-import * as dayjs from 'dayjs';
-import * as duration from 'dayjs/plugin/duration';
+// Default imports, not namespace imports. `import * as dayjs` only works
+// because webpack's CJS interop hands back module.exports directly; under
+// Jest it yields a Module namespace object, so dayjs.extend is undefined and
+// any test importing this file dies before reaching the code under test.
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
 
 const ds = dayjs;

--- a/client/src/utils.test.js
+++ b/client/src/utils.test.js
@@ -1,0 +1,127 @@
+import {
+  dayjs,
+  split_duration,
+  format_duration,
+  format_minutes,
+  format_seconds,
+  blocksToHumanLong,
+  shortImageName,
+  hide_sensitive_number,
+  hide_sensitive_string,
+  format_amount,
+  pad_start,
+} from './utils';
+
+/*
+ * The fact that this file imports at all is half the point.
+ *
+ * utils.js used to do `import * as dayjs from 'dayjs'` and
+ * `import * as duration from 'dayjs/plugin/duration'`. That only works because
+ * webpack's CJS interop hands back module.exports directly; under Jest it
+ * yields a Module namespace object, so `dayjs.extend(duration)` threw on line 3
+ * and every test importing utils — or anything importing utils, which includes
+ * apidata.js — died before reaching the code under test.
+ *
+ * These tests pin the duration maths so the interop change is provably
+ * behaviour-preserving, and keep the module importable from now on.
+ */
+
+describe('dayjs wiring', () => {
+  it('exports a callable dayjs', () => {
+    expect(typeof dayjs).toBe('function');
+  });
+
+  it('has the duration plugin applied', () => {
+    expect(typeof dayjs.duration).toBe('function');
+    expect(dayjs.duration({ minutes: 90 }).asHours()).toBe(1.5);
+  });
+});
+
+describe('split_duration', () => {
+  it('splits a duration into days, hours, minutes and seconds', () => {
+    // 2d 3h 4m 5s
+    const d = dayjs.duration({ days: 2, hours: 3, minutes: 4, seconds: 5 });
+    expect(split_duration(d)).toEqual({ days: 2, hours: 3, minutes: 4, seconds: 5 });
+  });
+
+  it('handles a duration under a minute', () => {
+    expect(split_duration(dayjs.duration({ seconds: 42 }))).toEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 42,
+    });
+  });
+
+  it('handles exactly one day', () => {
+    expect(split_duration(dayjs.duration({ days: 1 }))).toEqual({
+      days: 1,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+});
+
+describe('format_minutes / format_seconds', () => {
+  it('formats minutes into a human duration', () => {
+    // 1500 minutes = 1d 1h 0m
+    expect(format_minutes(1500)).toEqual(format_duration(dayjs.duration({ minutes: 1500 })));
+    expect(typeof format_minutes(1500)).toBe('string');
+    expect(format_minutes(1500).length).toBeGreaterThan(0);
+  });
+
+  it('formats seconds into a human duration', () => {
+    expect(typeof format_seconds(3661)).toBe('string');
+    expect(format_seconds(0).length).toBeGreaterThan(0);
+  });
+});
+
+describe('blocksToHumanLong', () => {
+  it('treats a block as 30 seconds', () => {
+    // 2880 blocks/day at 30s each
+    expect(blocksToHumanLong(2880)).toMatch(/1\s*d/i);
+  });
+
+  it('handles zero without throwing', () => {
+    expect(typeof blocksToHumanLong(0)).toBe('string');
+  });
+});
+
+describe('shortImageName', () => {
+  it('strips registry prefixes and the tag', () => {
+    expect(shortImageName('ghcr.io/girderworks/feather:1.0.14')).toBe('girderworks/feather');
+    expect(shortImageName('docker.io/library/mysql:8.3.0')).toBe('mysql');
+    expect(shortImageName('quay.io/pussthecatorg/libremdb:latest')).toBe('pussthecatorg/libremdb');
+    expect(shortImageName('runonflux/wp-nginx:latest')).toBe('runonflux/wp-nginx');
+  });
+
+  it('handles empty and missing input', () => {
+    expect(shortImageName('')).toBe('');
+    expect(shortImageName(undefined)).toBe('');
+  });
+});
+
+describe('privacy helpers', () => {
+  it('masks digits but keeps the shape', () => {
+    expect(hide_sensitive_number('1,234.56')).toBe('X,XXX.XX');
+    expect(hide_sensitive_number(1234)).toBe('XXXX');
+  });
+
+  it('masks alphanumerics in a string', () => {
+    expect(hide_sensitive_string('t1abc123')).toBe('XXXXXXXX');
+  });
+
+  it('format_amount masks only when privacy is on', () => {
+    expect(format_amount(1234.5, false, 2)).toBe('1,234.5');
+    expect(format_amount(1234.5, true, 2)).toBe('XXXX.X');
+  });
+});
+
+describe('pad_start', () => {
+  it('pads to the requested width', () => {
+    expect(pad_start(7)).toBe('07');
+    expect(pad_start(7, 4)).toBe('0007');
+    expect(pad_start(123, 2)).toBe('23');
+  });
+});


### PR DESCRIPTION
Part of #147 — **groundwork, not the split itself.** No modules move in this PR.

## Why this comes first

`apidata.js` could not be imported in a test **at all**. That is why the `fluxinfo` and `currency` extractions in #148 and #150 happened the way they did — moving code to a new file was the only way to get it under test.

Splitting the remaining 1,469 lines is not worth starting until that is fixed, because otherwise the split cannot be *shown* to be behaviour-preserving, only assumed to be.

## Two blockers, same class of problem

**1. Namespace imports of CJS modules.**

```js
import * as dayjs from 'dayjs';                      // utils.js, apidata.js, index.js
import * as duration from 'dayjs/plugin/duration';   // utils.js
import * as localforage from 'localforage';          // persistance/store.js
```

These only work because webpack's interop hands back `module.exports` directly. Under Jest they yield a Module namespace object, so `dayjs.extend(duration)` and `localforage.createInstance()` throw at module scope — and anything importing `utils`, which includes `apidata.js`, died before reaching the code under test.

Now default imports: the correct ESM form, and identical under webpack.

**2. `window.gContent`** is defined by `public/runtime/app-content.js`, which Jest never loads, so `content/index.js` threw reading `URL_YOUTUBE` at module scope. Added `src/setupTests.js` (picked up automatically by react-scripts) mirroring that file.

Also removed a dead `dayjs` import from `index.js`.

## Pinning the calculations before they move

`fill_rewards` is now exported so the reward projections can be tested. They drive the APY and payout figures operators make decisions on, and #147 will relocate them.

**30 tests added.** The reward expectations are *derived from the constants* in `content` rather than hardcoded:

```js
const networkPerDay = FLUX_PER_DAY * ((CC_BLOCK_REWARD * rewardPct) / 100);
```

So a deliberate change to a reward percentage updates the test alongside the code, while an accidental change to the **formula** still fails.

One test documents current behaviour rather than asserting it is right:

```js
it('a tier with no nodes yields Infinity rather than silently zeroing', ...)
```

Worth knowing before the split moves it — the UI must not render that raw.

## Verification

This touches date formatting and persistence, so Jest alone was not enough. Checked in the browser against the built app:

| | |
|---|---|
| dayjs callable, duration plugin applied | ✅ `90 minutes → 1.5 hours` |
| localforage store created | ✅ |
| Node table dates | ✅ `26-Aug-2026 02:15:34` |
| `Invalid Date` / `NaN` anywhere on page | ✅ none |
| Node rows rendered | ✅ 8 |

**156 tests** (up from 126), build exit 0, same four pre-existing warning files.

## What comes next

With `apidata.js` importable, the actual split can proceed module-by-module behind a re-export barrel, each step verifiable against these baseline tests. Also still to fold in: the single shared spec-resource helper, since the duplicated version has now caused the enterprise `0.00` bug twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSvHY6cs1fT7cEMAh7wD3W