### PR TITLE
Fix: Apps count undercounts when nodes share an app name

### DIFF
--- a/client/src/components/NodeGridTable/index.jsx
+++ b/client/src/components/NodeGridTable/index.jsx
@@ -43,15 +43,12 @@ export const NodeGridTable = ({
   const [ipFilter, setIpFilter] = useState('');
   const [activeTab, setActiveTab] = useState('nodes');
 
-  const uniqueAppCount = useMemo(() => {
+  // Raw count of app instances across the wallet's nodes. Two different
+  // nodes can each host an app with the same name — those must both count
+  // (GH #162), so this sums installedApps.length rather than deduping names.
+  const totalAppCount = useMemo(() => {
     if (!data || data.length === 0) return 0;
-    const seen = new Set();
-    for (const node of data) {
-      for (const app of (node.installedApps || [])) {
-        seen.add(app.name);
-      }
-    }
-    return seen.size;
+    return data.reduce((sum, node) => sum + (node.installedApps?.length || 0), 0);
   }, [data]);
 
   const { earnedCount, totalCount } = useMemo(() => {
@@ -257,8 +254,8 @@ export const NodeGridTable = ({
             >
               <FiPackage className='chrome-tab__icon' />
               <span className='chrome-tab__label'>Apps</span>
-              {uniqueAppCount > 0 && (
-                <span className='chrome-tab__badge chrome-tab__badge--green'>{uniqueAppCount}</span>
+              {totalAppCount > 0 && (
+                <span className='chrome-tab__badge chrome-tab__badge--green'>{totalAppCount}</span>
               )}
             </button>
           </div>

--- a/client/src/main/AppsSection/index.jsx
+++ b/client/src/main/AppsSection/index.jsx
@@ -133,32 +133,28 @@ export function AppsSection({ walletNodes, gstore }) {
     });
   }, [filteredRows, sortKey, sortDir]);
 
+  // Each row is one (node, app) instance, so counting every row — rather
+  // than deduping by app name — keeps chip/header totals matching the
+  // table's actual row count. Two nodes hosting an app with the same name
+  // must both count (GH #162).
   const categoryChips = useMemo(() => {
     const catMap = {};
-    const seenApps = {};
     for (const row of sortedRows) {
-      if (!seenApps[row.appName]) {
-        seenApps[row.appName] = true;
-        catMap[row.category] = (catMap[row.category] || 0) + 1;
-      }
+      catMap[row.category] = (catMap[row.category] || 0) + 1;
     }
     return Object.entries(catMap)
       .map(([cat, count]) => ({ cat, count }))
       .sort((a, b) => b.count - a.count);
   }, [sortedRows]);
 
-  const uniqueAppCount = useMemo(() => {
-    const seen = new Set();
-    for (const row of sortedRows) seen.add(row.appName);
-    return seen.size;
-  }, [sortedRows]);
+  const totalAppCount = sortedRows.length;
 
   const sortArrow = (key) => sortKey === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ' ⇅';
 
   return (
     <div className="apps-section">
       <div className="apps-summary">
-        <span className="apps-summary__title adp-text-muted">Apps ({uniqueAppCount}):</span>
+        <span className="apps-summary__title adp-text-muted">Apps ({totalAppCount}):</span>
         <div className="apps-summary__chips">
           {categoryChips.map(({ cat, count }) => {
             const meta = APP_CATEGORY_META[cat] || APP_CATEGORY_META.other;


### PR DESCRIPTION
## Summary
Fixes #162 — the wallet dashboard's "Apps" totals deduped apps by name across a wallet's nodes, so two different nodes each hosting an app with the same name were counted once instead of twice.

## Root cause
- `client/src/components/NodeGridTable/index.jsx` — the green badge on the Apps tab collected `app.name` into a `Set` across all nodes.
- `client/src/main/AppsSection/index.jsx` — the "Apps (N):" header and per-category chip counts used a `seenApps` map keyed on app name, so only the first row per name counted.

The underlying apps table itself was never deduped (one row per node+app instance), which is why opening the panel showed the "missing" app — only the summary counters disagreed with it.

## Fix
Both counters now count raw (node, app) instances instead of distinct names:
- `NodeGridTable`: sum `installedApps.length` per node.
- `AppsSection`: count every row for the header total and each category chip.

## Testing
- `yarn test` — 183/183 passing.
- Manually confirmed via the reported repro shape (two nodes hosting an app with the same name) that the tab badge, header count, and category chip totals all agree with the per-node Apps column and the table's row count.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)