### PR TITLE
Premium-gate skeleton + Docker testing toggle for /live

### DIFF
--- a/client/public/runtime/app-content.js
+++ b/client/public/runtime/app-content.js
@@ -11,6 +11,17 @@ window.gContent.EMAIL = '2ndtlmining@gmail.com';
 /* Address for donations (FLUX only) */
 window.gContent.ADDRESS_FLUX = 't1aUmu7HDr7BtwmdR1Y9i2K6KFRZs4Bumbt';
 
+/*
+ * Testing-only bypass for premium features (see client/src/donor/config.js
+ * and PREMIUM_FEATURES_PLAN.md). Always false here — this is the source
+ * file, baked into every build. For a Docker deployment this line is
+ * patched in place at container start by service/container-entrypoint.sh
+ * when the PREMIUM_TESTING_MODE environment variable is set, no rebuild
+ * needed. For local `yarn start` testing, flip the value on this line
+ * directly instead.
+ */
+window.gContent.PREMIUM_TESTING_MODE = false;
+
 
 // prettier-ignore
 {

--- a/client/src/Application.jsx
+++ b/client/src/Application.jsx
@@ -12,9 +12,11 @@ import { Helmet } from 'react-helmet';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import LayoutConfigurationProvider from 'contexts/LayoutContext';
+import { DonorProvider } from 'contexts/DonorContext';
 import { FocusStyleManager } from '@blueprintjs/core';
 import { lazy_load_currency_rate } from 'main/apidata';
 import ErrorBoundary from 'components/ErrorBoundary';
+import { PremiumGate } from 'donor/PremiumGate';
 
 const MainApp = React.lazy(() => import('main/MainApp'));
 const Home = React.lazy(() => import('home/Home'));
@@ -100,6 +102,7 @@ class Application extends React.Component {
     return (
       <ScreenClassProvider>
         <LayoutConfigurationProvider>
+        <DonorProvider>
           <Helmet defaultTitle='FluxNode' titleTemplate='%s | FluxNode'>
             <meta charSet='utf-8' />
             <meta name='description' content='Overview for flux node wallets' />
@@ -150,7 +153,9 @@ class Application extends React.Component {
                   element={
                     <ErrorBoundary>
                       <React.Suspense fallback={<PageLoader />}>
-                        <Live />
+                        <PremiumGate feature='Live'>
+                          <Live />
+                        </PremiumGate>
                       </React.Suspense>
                     </ErrorBoundary>
                   }
@@ -167,6 +172,7 @@ class Application extends React.Component {
               </div>
               {FooterRendered}
           </div>
+        </DonorProvider>
         </LayoutConfigurationProvider>
       </ScreenClassProvider>
     );

--- a/client/src/components/Navbar/index.jsx
+++ b/client/src/components/Navbar/index.jsx
@@ -3,8 +3,10 @@ import './index.scss';
 
 import { Alignment, Button, Menu, Navbar, Switch } from '@blueprintjs/core';
 
-import { MenuItem2, Popover2 } from '@blueprintjs/popover2';
+import { MenuItem2, Popover2, Tooltip2 } from '@blueprintjs/popover2';
+import { Lock } from 'lucide-react';
 import { LayoutContext } from 'contexts/LayoutContext';
+import { useDonorStatus } from 'contexts/DonorContext';
 import { matchPath, useMatch } from 'react-router';
 import { useNavigate } from 'react-router-dom';
 import { CurrencyMenuItem } from 'components/Navbar/CurrencyMenuItem';
@@ -30,6 +32,7 @@ export function AppNavbar({ onThemeSwitch, theme, currencyRates }) {
   let nodesBtnProps = useMatch('/nodes') == null ? inActiveProps : activeProps;
   let demoBtnProps = useMatch('/demo') == null ? inActiveProps : activeProps;
   let liveBtnProps = useMatch('/live') == null ? inActiveProps : activeProps;
+  const { isUnlocked: premiumUnlocked } = useDonorStatus();
 
   if (onThemeSwitch == undefined) onThemeSwitch = no_op;
 
@@ -47,7 +50,16 @@ export function AppNavbar({ onThemeSwitch, theme, currencyRates }) {
         <Button className='margin-r-s' icon='home' text='Home' {...homeBtnProps} onClick={() => navigate('/home')} />
         <Button className='margin-r-s' icon='layout-auto' text='Nodes' {...nodesBtnProps} onClick={() => navigate('/nodes')} />
         <Button icon='build' text='Demo' {...demoBtnProps} onClick={() => navigate('/demo')} />
-        <Button className='margin-r-s' icon='pulse' text='Live' {...liveBtnProps} onClick={() => navigate('/live')} />
+        <Tooltip2 content={premiumUnlocked ? 'Real-time block activity' : 'Premium feature — donor unlocking coming soon'}>
+          <Button
+            className={'margin-r-s' + (premiumUnlocked ? '' : ' navbar-btn--locked')}
+            icon={premiumUnlocked ? 'pulse' : undefined}
+            rightIcon={premiumUnlocked ? undefined : <Lock size={13} />}
+            text='Live'
+            {...liveBtnProps}
+            onClick={() => navigate('/live')}
+          />
+        </Tooltip2>
         <Navbar.Divider />
         <Button
           large

--- a/client/src/components/Navbar/index.scss
+++ b/client/src/components/Navbar/index.scss
@@ -1,3 +1,11 @@
+// Same locked-feature treatment as Gamification's AchievementCard
+// (main/Gamification/index.scss) — opacity + grayscale, not a size/layout
+// change, so it reads as "locked" without disrupting the navbar's rhythm.
+.navbar-btn--locked {
+    opacity: 0.55;
+    filter: grayscale(1);
+}
+
 .currency-menu {
     margin-left: 7px;
     margin-right: 7px;

--- a/client/src/contexts/DonorContext.jsx
+++ b/client/src/contexts/DonorContext.jsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { isPremiumTestingUnlocked } from 'donor/config';
+
+export const DonorContext = createContext(null);
+
+/*
+ * Gates premium features (currently just /live). Shaped to match what
+ * PREMIUM_FEATURES_PLAN.md specs out for the real donor-check mechanism
+ * (donorWallet, donorStatus, setDonorWallet, refreshDonorStatus) so that
+ * work slots in here later without changing any consumer of this context —
+ * for now, `isUnlocked` only ever reflects the PREMIUM_TESTING_MODE flag,
+ * since there is no real wallet verification yet.
+ */
+export function DonorProvider({ children }) {
+  const isUnlocked = isPremiumTestingUnlocked();
+
+  const value = useMemo(() => ({
+    isUnlocked,
+    donorWallet: null,
+    donorStatus: null,
+    // Placeholders — real implementations land with the donor-check build.
+    setDonorWallet: () => {},
+    refreshDonorStatus: async () => {},
+  }), [isUnlocked]);
+
+  return <DonorContext.Provider value={value}>{children}</DonorContext.Provider>;
+}
+
+export function useDonorStatus() {
+  return useContext(DonorContext);
+}

--- a/client/src/donor/PremiumGate/index.jsx
+++ b/client/src/donor/PremiumGate/index.jsx
@@ -1,0 +1,25 @@
+import { Lock } from 'lucide-react';
+import { useDonorStatus } from 'contexts/DonorContext';
+import './index.scss';
+
+/*
+ * Wraps a premium route. Real donor verification isn't built yet (see
+ * PREMIUM_FEATURES_PLAN.md), so today this only ever unlocks via the
+ * PREMIUM_TESTING_MODE flag (client/src/donor/config.js) — every real
+ * visitor sees the locked explainer below.
+ */
+export function PremiumGate({ feature, children }) {
+  const { isUnlocked } = useDonorStatus();
+
+  if (isUnlocked) return children;
+
+  return (
+    <div className="premium-gate-locked">
+      <Lock size={28} className="premium-gate-locked-icon" />
+      <span className="premium-gate-locked-title">{feature} is a premium feature</span>
+      <span className="premium-gate-locked-body">
+        Donor-based unlocking (send FLUX to our donation address to unlock) is coming soon.
+      </span>
+    </div>
+  );
+}

--- a/client/src/donor/PremiumGate/index.scss
+++ b/client/src/donor/PremiumGate/index.scss
@@ -1,0 +1,28 @@
+.premium-gate-locked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: 360px;
+  margin: 15vh auto;
+  padding: 32px 24px;
+  text-align: center;
+  background: var(--surface-inset);
+  border-radius: var(--radius-md);
+}
+
+.premium-gate-locked-icon {
+  color: var(--text-tertiary);
+  opacity: 0.7;
+}
+
+.premium-gate-locked-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.premium-gate-locked-body {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}

--- a/client/src/donor/config.js
+++ b/client/src/donor/config.js
@@ -1,0 +1,15 @@
+/*
+ * The full donor-gate mechanism (wallet -> chain-donation check -> unlock)
+ * is specced in PREMIUM_FEATURES_PLAN.md but not built yet. Until it is,
+ * this flag is the ONLY way premium features (currently just /live) unlock
+ * — real users see the locked state unconditionally.
+ *
+ * Set via the PREMIUM_TESTING_MODE Docker environment variable at container
+ * start (see service/container-entrypoint.sh, which patches this value into
+ * public/runtime/app-content.js before nginx serves it — no rebuild needed).
+ * For local `yarn start` testing, flip the value directly in
+ * client/public/runtime/app-content.js instead.
+ */
+export function isPremiumTestingUnlocked() {
+  return window.gContent?.PREMIUM_TESTING_MODE === true;
+}

--- a/service/container-entrypoint.sh
+++ b/service/container-entrypoint.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# Testing-only bypass for premium features (see client/src/donor/config.js
+# and PREMIUM_FEATURES_PLAN.md) — patches the runtime config file's default
+# `false` in place when PREMIUM_TESTING_MODE is set on the container, e.g.
+# `docker run -e PREMIUM_TESTING_MODE=true ...`. No rebuild needed. Unset
+# (or any value other than exactly "true") leaves the shipped default, so
+# real deployments stay locked unless this is deliberately set.
+RUNTIME_CONTENT_FILE=/usr/share/nginx/html/runtime/app-content.js
+if [ "$PREMIUM_TESTING_MODE" = "true" ] && [ -f "$RUNTIME_CONTENT_FILE" ]; then
+  sed -i 's/window\.gContent\.PREMIUM_TESTING_MODE = false;/window.gContent.PREMIUM_TESTING_MODE = true;/' "$RUNTIME_CONTENT_FILE"
+fi
+
 # Start nginx in background
 /docker-entrypoint.sh nginx -g "daemon on;"
 


### PR DESCRIPTION
## Summary

First slice of the donor-gate feature scoped in `PREMIUM_FEATURES_PLAN.md` — just enough to let you test the locked/unlocked UX in a real environment before the actual wallet-based donor verification is built.

- `DonorContext` shaped to match the full plan's eventual API, so real verification slots in later without touching any consumer.
- `PremiumGate` wraps `/live`, showing a plain locked explainer instead of the real page when not unlocked.
- Navbar's Live button greys out with a tooltip when locked (reusing the Gamification locked-card look).
- **`PREMIUM_TESTING_MODE`** — set it as a real Docker environment variable (`docker run -e PREMIUM_TESTING_MODE=true ...`) and `container-entrypoint.sh` patches it into the runtime config at container start, no rebuild needed. For local `yarn start`, flip the value directly in `client/public/runtime/app-content.js`.

**Not included** — still spec-only in `PREMIUM_FEATURES_PLAN.md`: real chain-based donor verification, the unlock dialog, the donor badge, `/analytics`. Until that's built, every real visitor sees `/live` locked; the testing flag is the only way in.

**Stacked on #164** (`feat/live-page-and-home-updates`) since this gates `/live` — please merge #164 first, then rebase/retarget this onto `main`.

## Test plan
- `cd client && CI=true npx react-scripts test --watchAll=false` — 224/224 pass
- `npx react-scripts build` — clean, same single pre-existing baseline warning (Navbar `alt-text`), nothing new
- Manual: verified the Live nav button/route lock and unlock states by toggling `PREMIUM_TESTING_MODE` in `app-content.js` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)