### PR TITLE
Theme the donor unlock dialog to match dark mode

### DIFF
--- a/client/src/donor/DonorUnlockDialog/index.jsx
+++ b/client/src/donor/DonorUnlockDialog/index.jsx
@@ -54,7 +54,18 @@ export function DonorUnlockDialog({ isOpen, onClose }) {
   }, [onClose]);
 
   return (
-    <Dialog isOpen={isOpen} onClose={handleClose} title="Unlock premium features" className="donor-unlock-dialog">
+    <Dialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Unlock premium features"
+      className="donor-unlock-dialog"
+      // Blueprint portals dialogs to document.body by default — a sibling
+      // of .App, not a descendant, so neither Blueprint's own .bp4-dark
+      // theme nor this app's dark-mode CSS custom properties (both set on
+      // .App) would reach it. Rendering inline instead keeps it a real
+      // descendant, so both inherit correctly with no extra plumbing.
+      usePortal={false}
+    >
       <div className="donor-unlock-body">
         <p className="donor-unlock-intro">
           Send at least {DONOR_THRESHOLD_FLUX} FLUX to our donation address within the

--- a/client/src/donor/DonorUnlockDialog/index.scss
+++ b/client/src/donor/DonorUnlockDialog/index.scss
@@ -1,3 +1,38 @@
+/*
+ * Blueprint's Dialog renders into a portal attached to document.body — it
+ * sits entirely outside .App's .app-mode-dark/.bp4-dark class, so without
+ * this it falls back to Blueprint's plain light chrome regardless of the
+ * site's theme. Styled directly against FluxNode's own tokens (not
+ * Blueprint's generic dark theme) so it actually matches the surrounding
+ * panels rather than a library default.
+ */
+.donor-unlock-dialog.bp4-dialog {
+  background: var(--surface-elevated);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-hover);
+}
+
+.donor-unlock-dialog .bp4-dialog-header {
+  background: var(--surface-elevated);
+  border-bottom: 1px solid var(--border-primary);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  box-shadow: none;
+}
+
+.donor-unlock-dialog .bp4-dialog-header .bp4-heading {
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.donor-unlock-dialog .bp4-dialog-close-button .bp4-icon {
+  color: var(--text-tertiary);
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--text-primary);
+  }
+}
+
 .donor-unlock-body {
   display: flex;
   flex-direction: column;
@@ -15,6 +50,25 @@
   display: flex;
   gap: 8px;
   align-items: center;
+
+  // Same portal-detachment issue as the dialog chrome above — the input
+  // otherwise renders with Blueprint's plain white background.
+  .bp4-input {
+    background: var(--surface-inset);
+    color: var(--text-primary);
+
+    &::placeholder {
+      color: var(--text-tertiary);
+    }
+  }
+
+  // The button's own text was wrapping to two lines at this width — hold
+  // it to one, and stop it from being squeezed as the input (which fills
+  // available space) grows.
+  .bp4-button {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
 }
 
 .donor-unlock-message {


### PR DESCRIPTION
Blueprint's \`Dialog\` portals to \`document.body\`, outside \`.App\`'s dark-mode class, so it was rendering with plain light-mode Blueprint chrome regardless of the site's theme. Set \`usePortal={false}\` so it's a real descendant of \`.App\` again (inherits everything correctly, no manual theme prop needed), and styled the chrome directly against FluxNode's own tokens rather than Blueprint's generic dark theme. Also fixed the "Check wallet" button text wrapping to two lines.

Verified live: locked state, empty dialog, and both a donor and non-donor result all render correctly, no positioning regression from dropping the portal.

239/239 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)