### PR TITLE
docs: Chain Activity tab (Session 5) design spec

### DIFF
--- a/PREMIUM_FEATURES_PLAN.md
+++ b/PREMIUM_FEATURES_PLAN.md
@@ -1,11 +1,15 @@
 # Premium Features Plan — Donor Gate + Analytics
 
 > Status: **Part B is BUILT and merged** (PR #170, #171 — real donor verification,
-> DonorContext, DonorUnlockDialog, DonorBadge, all live on `/live` today). Part C/D
-> below (Analytics — Sessions 2-5) are SCOPED, NOT BUILT. Written 2026-09-04, revised
-> 2026-09-05 with the Analytics tabbed IA and a session-by-session build order, revised
-> again 2026-09-05 to mark Session 1 complete. Do not treat any file path in Part C/D
-> as already present unless a "Built" note says otherwise.
+> DonorContext, DonorUnlockDialog, DonorBadge, all live on `/live` today). Part C is
+> BUILT and merged (Sessions 2-4 — Apps/Network/Donor tabs). Part D (Session 5 — Chain
+> Activity tab) is DESIGNED, NOT BUILT — full design now lives in
+> `docs/superpowers/specs/2026-09-06-chain-activity-design.md`; this doc's Part D below
+> is kept in sync but that spec is the source of truth on any disagreement. Written
+> 2026-09-04, revised 2026-09-05 with the Analytics tabbed IA and a session-by-session
+> build order, revised again 2026-09-05 to mark Session 1 complete, revised 2026-09-06
+> to mark Sessions 2-4 complete and lock in the Session 5 design. Do not treat any file
+> path in Part D as already present unless a "Built" note says otherwise.
 >
 > This is a separate document from `CODE_IMPROVEMENT_PLAN.md` (retired, see PR #168) —
 > don't resurrect that association. Also separate from `LIVE_REDESIGN_PLAN.md`
@@ -70,10 +74,16 @@ something demoable. Update the checkboxes as sessions land.
   shared aggregate with a full per-node app lookup (`nodesByIp`) since the donor's own
   nodes are essentially never in the network's top-5-busiest list it kept before. No
   backend.
-- [ ] **Session 5+ — Chain Activity tab.** Biggest lift: needs a new backend batch-scan
-  service (can't scan days of blocks client-side per visitor). Build the utility/empty
-  block ratio first (fully self-contained, no external address dependency), then
-  team-transaction tracking (address now confirmed), leave exchange-flow deferred.
+- [ ] **Session 5 — Chain Activity tab.** Design locked in 2026-09-06 (full detail:
+  `docs/superpowers/specs/2026-09-06-chain-activity-design.md`), not yet built. Biggest
+  lift so far: the first persisted, periodically-scanned backend state this API has —
+  flat JSON cache per Flux replica (multi-replica hosting means no shared writer;
+  independent per-replica scan, self-healing drift accepted), ~8-day retention
+  (2,880 blocks/day @ 30s block time), bounded cold-start backfill. Utility/empty block
+  classification ports `extractP2pTransfers` semantics to Rust; app-deployment
+  classification uses each spec's own real height directly (not a port of the live-only
+  `diffDeployedForEvents` snapshot-diff trick). Team-transaction tracking (address
+  confirmed) runs off the same per-block scan pass. Exchange-flow stays deferred.
 
 Sessions 2-4 don't depend on each other and could reorder if priorities shift; Session 1
 blocking Session 4 and Session 5 being backend-heavy are the two real constraints.
@@ -295,9 +305,23 @@ design consistently across.
 
 ## Part D — Chain Activity tab
 
-The newest and biggest-lift tab (Session 5+) — analyzes recent block history for
+**Design locked in 2026-09-06 — full detail in
+`docs/superpowers/specs/2026-09-06-chain-activity-design.md`, this section is a
+summary kept in sync with it, not a replacement for it.**
+
+The newest and biggest-lift tab (Session 5) — analyzes recent block history for
 network-utility and fund-flow signals, rather than current-snapshot state like the
 other three tabs.
+
+Key decisions the spec settled that weren't yet known when this section was first
+written: **flat JSON persistence** (not SQLite — a new DB dependency buys no extra
+durability given the deployment reality below), **~8-day retention** only (matches
+what the UI actually needs — 24h/7d ranges — not a larger archive), and **each Flux
+replica scans and persists independently** (this API runs as multiple replicas with no
+shared disk and no cross-replica coordination in scope, so single-writer consistency
+isn't achievable without infrastructure this codebase deliberately doesn't have;
+brief cross-replica count drift during catch-up is an accepted, self-healing
+trade-off).
 
 ### Utility vs. empty blocks (build first — no external dependency)
 
@@ -319,10 +343,10 @@ too expensive to repeat for every page load. Needs a backend batch job:
   utility/empty count — cheap for the frontend to read regardless of how far back the
   window goes, since the scan cost is paid once server-side, not per visitor.
 - Needs a small persistence layer the Rust API doesn't have today (everything else is
-  fetch-and-cache, not stored state) — likely the simplest viable option is a flat file
-  or embedded SQLite the service reads/writes, not a new external database dependency,
-  given this API otherwise has none. Confirm this approach before building — it's a
-  first for this codebase.
+  fetch-and-cache, not stored state) — **decided: flat JSON files** under a new `data/`
+  directory (one per logical dataset), not SQLite or an external DB — see the spec for
+  the full reasoning (multi-replica Flux hosting means no persisted file survives a
+  node move regardless of format, so the simpler option costs nothing in durability).
 
 ### Flux team transactions (build second — address now confirmed)
 

--- a/docs/superpowers/specs/2026-09-06-chain-activity-design.md
+++ b/docs/superpowers/specs/2026-09-06-chain-activity-design.md
@@ -1,0 +1,190 @@
+# Chain Activity Tab — Design Spec
+
+**Status:** Approved by user 2026-09-06, ready for implementation planning.
+**Supersedes:** `PREMIUM_FEATURES_PLAN.md` Part D (kept in sync, this doc is the source
+of truth for anything the two disagree on).
+
+## Goal
+
+`/analytics`'s fourth tab (Session 5+), analyzing recent block history for
+network-utility and Flux-team fund-flow signals — the first Analytics tab built over
+a *time window* of chain history rather than current-snapshot state.
+
+Two signals, both scanned in one pass over the same block window:
+
+1. **Utility vs. empty blocks** — a block is "empty" if its only activity is coinbase
+   rewards (+ node confirmations, which live outside the normal tx list and don't count
+   either way); "utility" if it contains at least one P2P transfer or app deployment.
+2. **Flux team transactions** — any tx where a known Flux-team address (starts with the
+   one confirmed address, `t1gjUUxBpBeVC1sWwAFrtSsVCbSaFdZx8UY`, extensible array shape)
+   appears as sender or recipient.
+
+**Explicitly out of scope:** FLUX-sent-to-exchanges tracking — no reliable public list
+of exchange deposit addresses exists (checked at the time `PREMIUM_FEATURES_PLAN.md`
+Part D was written; re-check before assuming that's still true). No placeholder row
+ships for it.
+
+## Why this needs a backend service (the one genuinely new thing here)
+
+Every other Analytics tab (Apps/Network/Donor) reads current-snapshot state that's
+cheap to compute per page load. Chain Activity needs a rolling window of *history* —
+thousands of blocks, each needing 1-2 explorer API calls to classify — which is too
+expensive to repeat client-side on every visit. This requires the Rust API's **first
+persisted, periodically-scanned backend state** (everything else today is
+fetch-and-cache, nothing is stored between requests).
+
+## Deployment context that shapes this design
+
+This API runs as **multiple Flux-hosted replicas**, each on a physically separate node,
+with no shared disk between them, and **any replica can be rescheduled to a different
+node at any time**, wiping its local disk. Two consequences drive every persistence
+decision below:
+
+- Local storage must be treated as a **rebuildable cache**, never a source of truth.
+  File format (flat JSON vs. embedded SQLite) doesn't change this — neither survives a
+  node move — so the simpler option (flat JSON, no new Cargo dependency) wins on cost
+  with no durability trade-off given up.
+- There is **no cross-replica coordination** without adding real infrastructure
+  (Redis/etcd/Postgres), which this codebase has nowhere else and which is explicitly
+  out of scope. Each replica scans and persists **independently** — no shared writer,
+  nothing to reconcile between replicas.
+
+## Persistence design
+
+**Format:** flat JSON files under a new `data/` directory, one file per logical
+dataset — not one growing blob:
+- `data/chain_activity_daily.json` — rolling daily utility/empty block counts.
+- `data/chain_activity_team_tx.json` — team-address transaction log for the retained
+  window.
+- `data/chain_activity_checkpoint.json` — last successfully scanned block height (so a
+  restart resumes instead of rescanning from the retention window's start every time).
+
+Each write is temp-file-then-rename (atomic on the same filesystem) so a crash mid-write
+never leaves a corrupt file behind.
+
+**Retention window: ~8 days (7d + 1 buffer day), not longer.** The UI only ever needs
+24h/7d selectable ranges (see Frontend section) — YAGNI against a larger archive that
+nothing reads. At 2,880 blocks/day (confirmed: 30s block time, matches the existing
+`BLOCK_RATE = 480 // at 30s blocks = 240 minutes` comment in `client/src/apidata.js`),
+that's **~23,040 blocks** retained. Extend the window later only if a longer range is
+ever actually requested.
+
+**Cross-replica consistency — accepted limitation, stated explicitly:** two visitors
+hitting two different replicas mid-catch-up can briefly see slightly different counts.
+Both replicas are scanning the same deterministic public chain data, so they converge
+once both are caught up — this is a self-healing, low-stakes drift for a stats display
+(not financial data), not a correctness bug. This is the pragmatic trade against adding
+real coordination infrastructure this codebase doesn't otherwise need.
+
+**Cold-start catch-up:** on boot, each replica checks its local checkpoint file. If
+missing, or its recorded height is more than one scan interval behind the current chain
+tip, run an **immediate bounded backfill** — scan from `max(checkpoint_height,
+tip - 23,040)` to tip, concurrently (same `buffer_unordered` pattern
+`api/src/services/live_winners.rs` already uses for its candidate-node fan-out — that
+service caps at `MAX_CANDIDATES_TRIED = 8` concurrent requests; start Chain Activity's
+scan at the same concurrency, tune later only if the explorer API visibly tolerates
+more), rather than waiting for hourly increments to slowly rebuild history. A worst-case
+cold backfill (full 23,040-block window, no prior checkpoint) at that concurrency is a
+one-time few-minute-to-tens-of-minutes pass, not a request-blocking operation — it runs
+on a background task, and
+`GET /api/v1/chain-activity` (see API section) serves whatever the local file currently
+holds, including a partial/catching-up state.
+
+## Classification — ported to Rust, not reused as JS
+
+`client/src/live/apidata.js` already has this classification logic, but it's JS running
+client-side over ~5-10 blocks for the live chain rail — the backend needs Rust
+equivalents with matching *semantics*, not literal code reuse:
+
+- **P2P transfers** (mirrors `extractP2pTransfers`): fetch each block's transactions
+  (mirrors `fetch_block_transactions`, same explorer endpoint,
+  `https://explorer.runonflux.io/api/txs/?block=<hash>`), and for every non-coinbase tx,
+  any output address that isn't the first input's address counts as a transfer (skip
+  change-back-to-self). Presence of ≥1 transfer in the block ⇒ utility.
+- **App deployments — deliberately NOT a port of `diffDeployedForEvents`.** That
+  function's "diff successive 'deployed today' snapshots, attribute to whatever block
+  the poll happened to notice it at" is a *live-display* trick needed only because the
+  chain rail shows a live 5-block window and a real deploy height almost never lands
+  inside it. A backend historical scan doesn't have that problem — it can use each app
+  spec's own real height directly. **One-time sync**: fetch all specs from
+  `https://api.runonflux.io/apps/globalappsspecifications` (same endpoint
+  `client/src/apidata.js:1347` already uses for `deployedToday`), key by `spec.height`.
+  A block has a deployment ⇒ utility if any spec's height equals that block's height.
+  Re-sync this list each scan cycle (it's the same one-time full fetch either way,
+  cheap relative to the per-block tx fetches) rather than trying to incrementally diff
+  it — there's no "deployedAtHeight" stream to diff against here, just a lookup table.
+- **Team transactions**: while already fetching each block's tx list for P2P
+  classification, check every tx's addresses (both directions) against
+  `FLUX_TEAM_ADDRESSES`. No separate scan pass — one pass over each block's txs produces
+  both signals.
+
+## Scheduling
+
+New pattern for this codebase — every existing service (`live_winners.rs`, `demo.rs`,
+`bench_version.rs`) is request-driven; nothing runs on a background schedule today.
+
+`main()` spawns a `tokio::spawn`ed loop running `tokio::time::interval` at an hourly
+cadence, calling `chain_activity::run_scan_cycle()`. Each cycle: read the checkpoint,
+scan from there to the current tip (bounded — see cold-start catch-up above for the
+"no checkpoint or far behind" case, which folds into the same function, not a separate
+code path), re-sync the app-specs-by-height lookup, classify, update the daily rollup
+and team-tx log, write all three files, advance the checkpoint.
+
+## API
+
+`GET /api/v1/chain-activity` — synchronous read of the local rollup file(s), no
+scanning on the request path (scanning only ever happens on the background interval).
+Returns the daily utility/empty counts and team-tx list for however much of the
+retention window is currently populated (a freshly-booted, still-catching-up replica
+returns a shorter window, not an error — the frontend's job, not the backend's, to
+communicate "still building history" if the returned range is shorter than requested).
+
+## Frontend
+
+- `analytics/chainActivity.js` — fetches `GET /api/v1/chain-activity`, following the
+  existing `analytics/*.js` fetch-module pattern from Apps/Network/Donor tabs.
+- `ChainActivityTab/index.jsx` (+ `.scss`) — renders utility/empty block counts and the
+  team-tx list, with a 24h/7d range toggle (client-side filter over the same fetched
+  payload — the backend already returns the full retained window, no separate API call
+  per range). Follows the existing tab pattern (own copy of shared panel chrome per the
+  established `.hov-panel`/`.hov-header` convention, not cross-file import — see
+  `NetworkTab/index.scss`'s header comment for the precedent).
+- If the returned window is shorter than the selected range (still catching up), show
+  that plainly rather than implying complete data — same resilience posture already
+  used elsewhere in this codebase for `fluxinfo` staleness.
+
+## Files to add
+
+- `api/src/services/chain_activity.rs` + route registration in `api/src/main.rs`
+- `analytics/ChainActivityTab/index.jsx` + `.scss`
+- `analytics/chainActivity.js`
+
+## Testing posture
+
+This is a new backend subsystem sitting alongside a stable, tested frontend app —
+regressions in *unrelated* areas are the real risk, not just new-code correctness.
+After every implementation milestone: `cd client && CI=true npx react-scripts test
+--watchAll=false` (count must only ever go up from the confirmed baseline — 282 tests
+as of PR #176, re-verify against current `main` before starting), `cd client && npx
+react-scripts build` (exit 0, exactly the 4 pre-existing baseline warning files —
+`Navbar/index.jsx`, `NodeGridTable/index.jsx`, `LayoutContext.jsx`,
+`WalletNodes/index.jsx`, nothing new), and `cd api && cargo build` (+ `cargo test` for
+any new Rust unit tests — this is the first Rust-side test coverage this repo would
+gain, since existing services have none; new classification logic should still get
+unit tests even though nothing established requires it yet).
+
+## Open risks, stated rather than hidden
+
+- **Explorer API load**: each replica's cold-start backfill (~23,040 block-tx fetches,
+  concurrent but rate-considerate) and hourly increments (~120 new blocks/hour) hit
+  `explorer.runonflux.io` independently per replica. This is a public API already used
+  elsewhere in this codebase; no rate-limit issue is known today, but this design does
+  multiply load by replica count where a single-writer design wouldn't. Accepted given
+  the alternative (adding coordination infra) is explicitly out of scope.
+- **`api.runonflux.io/apps/globalappsspecifications` is the "ordered" endpoint**, not
+  the "running" one (`fluxnode-app.md` memory: `fluxinfo` is canonical for running-apps
+  counts, this endpoint over-counts vs. reality). That distinction doesn't apply here —
+  Chain Activity cares about deploy *events* (was a spec created at height N), which is
+  exactly what this endpoint's `height` field records, regardless of whether the app is
+  still running today. Using it here is correct; it would be wrong for a "how many apps
+  are running right now" feature.

--- a/docs/superpowers/specs/2026-09-06-chain-activity-design.md
+++ b/docs/superpowers/specs/2026-09-06-chain-activity-design.md
@@ -101,6 +101,23 @@ equivalents with matching *semantics*, not literal code reuse:
   `https://explorer.runonflux.io/api/txs/?block=<hash>`), and for every non-coinbase tx,
   any output address that isn't the first input's address counts as a transfer (skip
   change-back-to-self). Presence of ≥1 transfer in the block ⇒ utility.
+  **Verified against the live API 2026-09-06** (not just the JS comment, which turned
+  out stale on one point): height→hash resolution is
+  `GET /api/block-index/<height>` → `{"blockHash": ...}`; the txs endpoint is
+  **paginated**, `GET /api/txs/?block=<hash>&pageNum=<0-indexed>`, page size 10,
+  response carries `pagesTotal` from page 0 already. Contrary to the JS comment's claim
+  that node-confirmation txs (`type: "Confirming a fluxnode"`, no `vin`/`vout`) never
+  appear in this endpoint, they do — a block's page 0 can be mostly confirmations,
+  so **a full "no P2P transfer exists" classification requires fetching every page**,
+  not just page 0 (confirmed decision, user 2026-09-06 — correctness over the cheaper
+  page-0-only shortcut). Sampled pagination cost near the current chain tip:
+  1-2 pages/block typically (occasionally more) — average ~1.4 txs-pages/block observed
+  — so per-block cost is ~1 (block-index) + ~1.4 (txs pages) ≈ **2.4 calls/block
+  average**, not the earlier flat "1-2 calls" estimate. Across the full 23,040-block
+  cold backfill at `SCAN_CONCURRENCY = 8`, that's roughly tens of minutes, not just a
+  few — still a one-time bounded background pass, not a request-blocking operation.
+  `vout[].value` in this API is a **string** (e.g. `"18.75000000"`), not a JSON number —
+  parse it explicitly.
 - **App deployments — deliberately NOT a port of `diffDeployedForEvents`.** That
   function's "diff successive 'deployed today' snapshots, attribute to whatever block
   the poll happened to notice it at" is a *live-display* trick needed only because the


### PR DESCRIPTION
## Summary
Full design spec for the Chain Activity tab (`/analytics` Session 5) — the first persisted, periodically-scanned backend state this API has needed. Follows the same brainstorming process used for the Live redesign plan (PR #176).

Full detail: `docs/superpowers/specs/2026-09-06-chain-activity-design.md`

## Key decisions
- **Flat JSON persistence** under a new `data/` dir, not SQLite/external DB — no format survives a Flux replica being rescheduled to a new node, so the simpler option costs nothing in durability.
- **~8-day retention** (2,880 blocks/day @ confirmed 30s block time), matching what the UI actually needs (24h/7d ranges), not a larger archive.
- **Each replica scans and persists independently** — this API runs as multiple Flux-hosted replicas with no shared disk and no cross-replica coordination in scope; brief count drift during catch-up is an accepted, self-healing trade-off.
- Utility/empty block classification ports `extractP2pTransfers` semantics to Rust; app-deployment classification uses each spec's own real height directly, not a port of the live-only `diffDeployedForEvents` snapshot-diff trick.

Also updates `PREMIUM_FEATURES_PLAN.md` Part D to summarize + point at the spec, and marks Sessions 2-4 complete in the header status note (shipped since that doc was last touched).

Docs only — no code changes. Implementation (Session 5 proper) follows in a separate branch/PR once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)