### PR TITLE
chore: rename PREMIUM_TESTING_MODE flag to TESTING

### DIFF
--- a/client/public/runtime/app-content.js
+++ b/client/public/runtime/app-content.js
@@ -13,14 +13,14 @@ window.gContent.ADDRESS_FLUX = 't1aUmu7HDr7BtwmdR1Y9i2K6KFRZs4Bumbt';
 
 /*
  * Testing-only bypass for premium features (see client/src/donor/config.js
- * and PREMIUM_FEATURES_PLAN.md). Always false here — this is the source
+ * and todo.md). Always false here — this is the source
  * file, baked into every build. For a Docker deployment this line is
  * patched in place at container start by service/container-entrypoint.sh
- * when the PREMIUM_TESTING_MODE environment variable is set, no rebuild
+ * when the TESTING environment variable is set, no rebuild
  * needed. For local `yarn start` testing, flip the value on this line
  * directly instead.
  */
-window.gContent.PREMIUM_TESTING_MODE = false;
+window.gContent.TESTING = false;
 
 
 // prettier-ignore

--- a/client/src/contexts/DonorContext.jsx
+++ b/client/src/contexts/DonorContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { isPremiumTestingUnlocked } from 'donor/config';
+import { isTestingUnlocked } from 'donor/config';
 import { fetch_donor_status } from 'donor/donorStatus';
 
 export const DonorContext = createContext(null);
@@ -16,7 +16,7 @@ function readStoredWallet() {
 
 /*
  * Gates premium features (currently /live). `isUnlocked` is true when either
- * the PREMIUM_TESTING_MODE flag is set (see donor/config.js) OR a verified
+ * the TESTING flag is set (see donor/config.js) OR a verified
  * donor wallet is active — the testing flag is an override on top of real
  * verification, not a replacement for it.
  *
@@ -59,7 +59,7 @@ export function DonorProvider({ children }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [donorWallet]);
 
-  const isUnlocked = isPremiumTestingUnlocked() || donorStatus?.isDonor === true;
+  const isUnlocked = isTestingUnlocked() || donorStatus?.isDonor === true;
 
   const value = useMemo(() => ({
     isUnlocked, donorWallet, donorStatus, setDonorWallet, refreshDonorStatus,

--- a/client/src/donor/config.js
+++ b/client/src/donor/config.js
@@ -17,16 +17,16 @@ export const DONOR_MAX_PAGES_FETCHED = 20;
  * fetch_donor_status and gates premium features (currently just /live) on
  * the result. This flag is a dev/QA override that sits ON TOP OF that real
  * verification, not a replacement for it — DonorContext's `isUnlocked` is
- * `isPremiumTestingUnlocked() || donorStatus?.isDonor`, so flipping this on
+ * `isTestingUnlocked() || donorStatus?.isDonor`, so flipping this on
  * unlocks premium features without needing a real donor wallet, while real
  * users are still gated by actual verified donations when it's off.
  *
- * Set via the PREMIUM_TESTING_MODE Docker environment variable at container
+ * Set via the TESTING Docker environment variable at container
  * start (see service/container-entrypoint.sh, which patches this value into
  * public/runtime/app-content.js before nginx serves it — no rebuild needed).
  * For local `yarn start` testing, flip the value directly in
  * client/public/runtime/app-content.js instead.
  */
-export function isPremiumTestingUnlocked() {
-  return window.gContent?.PREMIUM_TESTING_MODE === true;
+export function isTestingUnlocked() {
+  return window.gContent?.TESTING === true;
 }

--- a/service/container-entrypoint.sh
+++ b/service/container-entrypoint.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 # Testing-only bypass for premium features (see client/src/donor/config.js
-# and PREMIUM_FEATURES_PLAN.md) — patches the runtime config file's default
-# `false` in place when PREMIUM_TESTING_MODE is set on the container, e.g.
-# `docker run -e PREMIUM_TESTING_MODE=true ...`. No rebuild needed. Unset
+# and todo.md) — patches the runtime config file's default
+# `false` in place when TESTING is set on the container, e.g.
+# `docker run -e TESTING=true ...`. No rebuild needed. Unset
 # (or any value other than exactly "true") leaves the shipped default, so
 # real deployments stay locked unless this is deliberately set.
 RUNTIME_CONTENT_FILE=/usr/share/nginx/html/runtime/app-content.js
-if [ "$PREMIUM_TESTING_MODE" = "true" ] && [ -f "$RUNTIME_CONTENT_FILE" ]; then
-  sed -i 's/window\.gContent\.PREMIUM_TESTING_MODE = false;/window.gContent.PREMIUM_TESTING_MODE = true;/' "$RUNTIME_CONTENT_FILE"
+if [ "$TESTING" = "true" ] && [ -f "$RUNTIME_CONTENT_FILE" ]; then
+  sed -i 's/window\.gContent\.TESTING = false;/window.gContent.TESTING = true;/' "$RUNTIME_CONTENT_FILE"
 fi
 
 # Start nginx in background


### PR DESCRIPTION
## Summary
- Renames the dev/QA testing-bypass flag from `PREMIUM_TESTING_MODE` to the simpler `TESTING`, everywhere it's referenced: `window.gContent.TESTING`, `isTestingUnlocked()` (was `isPremiumTestingUnlocked()`), and the `TESTING` Docker env var read by `service/container-entrypoint.sh`.
- Behavior is unchanged — set `TESTING=true` on the container, or flip the value directly in `client/public/runtime/app-content.js` for local `yarn start`, to unlock premium features (currently just `/live`) without a real donor wallet.
- Fixed two dangling comment references to `PREMIUM_FEATURES_PLAN.md`, retired in a prior commit in favor of `todo.md`.

## Test plan
- [x] `cd client && CI=true npx react-scripts test --watchAll=false` — 290 tests passing
- [x] `npx react-scripts build` — exit 0, only the 4 pre-existing baseline warning files (Navbar, NodeGridTable, LayoutContext, WalletNodes)
- [x] `grep -rn "PREMIUM_TESTING_MODE\|isPremiumTestingUnlocked"` across `client/src`, `client/public`, `service` — no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)