### PR TITLE
fix: restore running-app categorization after fluxinfo API change (#187)

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -3,7 +3,8 @@ import { Spinner, Button } from '@blueprintjs/core';
 import { Lock } from 'lucide-react';
 import { useDonorStatus } from 'contexts/DonorContext';
 import { DonorUnlockDialog } from 'donor/DonorUnlockDialog';
-import { fetch_global_stats, fetch_total_network_utils } from 'apidata';
+import { fetch_global_stats, fetch_total_network_utils, fetch_global_app_specs_raw } from 'apidata';
+import { buildSpecIndex } from 'appSpecs';
 import { fetch_donor_nodes, sortByRank, mostRecentPayout } from 'analytics/donorNodes';
 import { fetch_donor_utilization } from 'analytics/donorUtilization';
 import { aggregateDonorAppsByCategory } from 'analytics/donorApps';
@@ -211,10 +212,14 @@ export function DonorTab() {
 
       setUtilization(util);
 
-      const gstore = await fetch_total_network_utils(stage1);
+      const [gstore, rawSpecs] = await Promise.all([
+        fetch_total_network_utils(stage1),
+        fetch_global_app_specs_raw(),
+      ]);
       if (cancelled) return;
 
-      setAppCategories(aggregateDonorAppsByCategory(gstore.nodesByIp || {}, addresses));
+      const specIndex = buildSpecIndex(rawSpecs);
+      setAppCategories(aggregateDonorAppsByCategory(gstore.nodesByIp || {}, addresses, specIndex));
       setNetworkPct({
         cores: gstore.utilized.cores_percentage,
         ram: gstore.utilized.ram_percentage,

--- a/client/src/analytics/donorApps.js
+++ b/client/src/analytics/donorApps.js
@@ -1,43 +1,38 @@
-import { categorizeApp } from 'main/Gamification/appCategories';
 import { addressOf } from 'networkNodes';
 
 /*
  * Pure: tally the donor's own running apps by category, from the IP-keyed
- * lookup Task 1 added to fluxinfo.js's fetch_fluxinfo_aggregate() output
- * (nodesByIp — added specifically so a wallet's own, typically-not-top-5
- * nodes are visible here at all; the pre-existing topNodesByApps only ever
- * covers the network's 5 busiest nodes).
+ * lookup fetch_fluxinfo_aggregate() carries as nodesByIp, joined against a
+ * name-keyed spec index (appSpecs.js's buildSpecIndex) for category —
+ * fluxinfo no longer reports a docker image (issue #187), so category can
+ * only be recovered by joining the running app's name to its
+ * globalappsspecifications repotag, same as runningAppsCategorized.js does
+ * network-wide. A running app whose spec can't be found (e.g. it expired
+ * between the two independent fetches) falls back to 'other' rather than
+ * being dropped from the tally.
  *
- * Categorizes by DOCKER IMAGE (repotag), not app name — this codebase's
- * established preference (main/Gamification/appCategories.js's own header
- * comment, and categorizeAppSpec's identical choice): the repotag is right
- * far more often than the user-chosen name.
- *
- * Tallies one entry per running CONTAINER, matching the network-wide App
- * Ecosystem panel's own convention — a multi-component compose app
- * contributes one count per component, not one per app. containrrr/watchtower
- * is excluded from that tally: every Flux node runs it to auto-update its
- * own containers, so it's infrastructure the node runs for itself, not
- * something the donor deployed — apidata.js's own totalRunningApps figure
- * (apidata.js:505) already excludes it network-wide for the same reason.
+ * containrrr/watchtower is excluded from the tally by its resolved repotag:
+ * every Flux node runs it to auto-update its own containers, so it's
+ * infrastructure the node runs for itself, not something the donor deployed.
  *
  * Addresses are normalized via addressOf() before lookup, matching
- * donorUtilization.js's own normalization — a whitespace/format mismatch
- * here would otherwise silently render "no apps" indistinguishable from a
- * real empty result.
+ * donorUtilization.js's own normalization.
  */
-export function aggregateDonorAppsByCategory(nodesByIp, donorAddresses) {
+export function aggregateDonorAppsByCategory(nodesByIp, donorAddresses, specIndex) {
   const perCategory = {};
   let totalApps = 0;
+  const index = specIndex || {};
 
   for (const rawAddr of donorAddresses || []) {
     const node = nodesByIp?.[addressOf(rawAddr)];
     if (!node) continue;
 
-    for (const image of node.images || []) {
-      if (image.toLowerCase().includes('containrrr/watchtower')) continue;
+    for (const name of node.containerAppNames || []) {
+      const spec = index[name];
+      const repotag = spec?.repotag || '';
+      if (repotag.toLowerCase().includes('containrrr/watchtower')) continue;
 
-      const cat = categorizeApp(image);
+      const cat = spec?.category || 'other';
       perCategory[cat] = (perCategory[cat] || 0) + 1;
       totalApps++;
     }

--- a/client/src/analytics/donorApps.test.js
+++ b/client/src/analytics/donorApps.test.js
@@ -1,17 +1,24 @@
 import { aggregateDonorAppsByCategory } from './donorApps';
 
+const specIndex = {
+  'folding1': { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  'wp1': { repotag: 'runonflux/wp-nginx:latest', category: 'web' },
+  'mc1': { repotag: 'itzg/minecraft-server:latest', category: 'gaming' },
+  'boinc1': { repotag: 'boinc/client:latest', category: 'computing' },
+  'watchtower': { repotag: 'containrrr/watchtower:latest', category: 'other' },
+};
+
 const nodesByIp = {
-  '1.2.3.4:16127': { images: ['yurinnick/folding-at-home:latest', 'runonflux/wp-nginx:latest'] },
-  '5.6.7.8:16127': { images: ['itzg/minecraft-server:latest'] },
-  '9.9.9.9:16127': { images: ['someone/unrelated-node-not-the-donors:latest'] },
+  '1.2.3.4:16127': { containerAppNames: ['folding1', 'wp1'] },
+  '5.6.7.8:16127': { containerAppNames: ['mc1'] },
+  '9.9.9.9:16127': { containerAppNames: ['unrelated'] },
 };
 
 describe('aggregateDonorAppsByCategory', () => {
-  it('tallies one entry per running container (image), by category, across the donor\'s own nodes only', () => {
-    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127', '5.6.7.8:16127']);
+  it('tallies one entry per running container, by category, across the donor\'s own nodes only', () => {
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127', '5.6.7.8:16127'], specIndex);
 
     expect(totalApps).toBe(3);
-    // computing: folding-at-home, web: wp-nginx, gaming: minecraft
     const byCat = Object.fromEntries(categories.map((c) => [c.category, c.count]));
     expect(byCat.computing).toBe(1);
     expect(byCat.web).toBe(1);
@@ -20,43 +27,49 @@ describe('aggregateDonorAppsByCategory', () => {
 
   it('sorts categories descending by count', () => {
     const twoOnOneNode = {
-      '1.1.1.1:1': { images: ['yurinnick/folding-at-home:latest', 'boinc/client:latest', 'itzg/minecraft-server:latest'] },
+      '1.1.1.1:1': { containerAppNames: ['folding1', 'boinc1', 'mc1'] },
     };
-    const { categories } = aggregateDonorAppsByCategory(twoOnOneNode, ['1.1.1.1:1']);
+    const { categories } = aggregateDonorAppsByCategory(twoOnOneNode, ['1.1.1.1:1'], specIndex);
     expect(categories[0]).toEqual({ category: 'computing', count: 2 });
     expect(categories[1]).toEqual({ category: 'gaming', count: 1 });
   });
 
   it('never counts an address that is not the donor\'s own', () => {
-    const { totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127']);
+    const { totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127'], specIndex);
     expect(totalApps).toBe(2); // not 3 — 9.9.9.9's app is excluded
   });
 
   it('skips a donor address with no matching nodesByIp entry, rather than throwing', () => {
-    expect(() => aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0'])).not.toThrow();
-    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0']);
+    expect(() => aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0'], specIndex)).not.toThrow();
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0'], specIndex);
     expect(categories).toEqual([]);
     expect(totalApps).toBe(0);
   });
 
   it('returns an empty result for no donor addresses or an empty/undefined lookup', () => {
-    expect(aggregateDonorAppsByCategory(nodesByIp, [])).toEqual({ categories: [], totalApps: 0 });
-    expect(aggregateDonorAppsByCategory({}, ['1.2.3.4:16127'])).toEqual({ categories: [], totalApps: 0 });
-    expect(aggregateDonorAppsByCategory(undefined, undefined)).toEqual({ categories: [], totalApps: 0 });
+    expect(aggregateDonorAppsByCategory(nodesByIp, [], specIndex)).toEqual({ categories: [], totalApps: 0 });
+    expect(aggregateDonorAppsByCategory({}, ['1.2.3.4:16127'], specIndex)).toEqual({ categories: [], totalApps: 0 });
+    expect(aggregateDonorAppsByCategory(undefined, undefined, specIndex)).toEqual({ categories: [], totalApps: 0 });
   });
 
-  it('excludes containrrr/watchtower from the tally — infrastructure every node runs, not a donor-deployed app', () => {
+  it('excludes containrrr/watchtower from the tally by resolved repotag', () => {
     const nodesByIpWithWatchtower = {
-      '1.2.3.4:16127': { images: ['yurinnick/folding-at-home:latest', 'containrrr/watchtower:latest'] },
+      '1.2.3.4:16127': { containerAppNames: ['folding1', 'watchtower'] },
     };
-    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIpWithWatchtower, ['1.2.3.4:16127']);
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIpWithWatchtower, ['1.2.3.4:16127'], specIndex);
     expect(totalApps).toBe(1);
     expect(categories).toEqual([{ category: 'computing', count: 1 }]);
   });
 
-  it('normalizes the donor address before lookup (trims whitespace), matching donorUtilization.js\'s own normalization', () => {
-    const cleanNodesByIp = { '1.2.3.4:16127': { images: ['itzg/minecraft-server:latest'] } };
-    const { totalApps } = aggregateDonorAppsByCategory(cleanNodesByIp, [' 1.2.3.4:16127 ']);
+  it('normalizes the donor address before lookup (trims whitespace)', () => {
+    const cleanNodesByIp = { '1.2.3.4:16127': { containerAppNames: ['mc1'] } };
+    const { totalApps } = aggregateDonorAppsByCategory(cleanNodesByIp, [' 1.2.3.4:16127 '], specIndex);
     expect(totalApps).toBe(1);
+  });
+
+  it('falls back to "other" for a running app whose spec is missing, without throwing', () => {
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['9.9.9.9:16127'], specIndex);
+    expect(totalApps).toBe(1);
+    expect(categories).toEqual([{ category: 'other', count: 1 }]);
   });
 });

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1305,7 +1305,7 @@ export async function fetch_global_app_specs_raw() {
     const raw = sessionStorage.getItem(RAW_APP_SPECS_CACHE_KEY);
     if (raw) {
       const cached = JSON.parse(raw);
-      if (cached && Date.now() - cached.timestamp < RAW_APP_SPECS_CACHE_TTL) {
+      if (cached && Array.isArray(cached.data) && Date.now() - cached.timestamp < RAW_APP_SPECS_CACHE_TTL) {
         return cached.data;
       }
     }
@@ -1317,7 +1317,12 @@ export async function fetch_global_app_specs_raw() {
     try {
       const res = await fetch('https://api.runonflux.io/apps/globalappsspecifications');
       const json = await res.json();
-      if (json.status === 'error' || !json.data) return [];
+      // Array.isArray, not a truthiness check: this function's callers iterate
+      // the result and three of them (AppsSection, AppsTab, and
+      // fetchTotalDeployedApps inside fetch_global_stats' bare Promise.all)
+      // have no .catch — a `data` object rather than an array would take the
+      // whole Home page load down with it.
+      if (json.status === 'error' || !Array.isArray(json.data)) return [];
 
       try {
         sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: json.data, timestamp: Date.now() }));
@@ -1337,47 +1342,59 @@ export async function fetch_global_app_specs_raw() {
   }
 }
 
+/*
+ * Never rejects — deliberately. Three callers have no .catch of their own
+ * (AppsSection, analytics/AppsTab, and fetchTotalDeployedApps, which sits in
+ * fetch_global_stats' bare Promise.all where a rejection would fail the entire
+ * Home page load: price, wallet, node counts, everything). Any failure here,
+ * fetch or compute, resolves to the same empty shape instead.
+ */
 export async function fetch_global_app_specs(gstore) {
   const specs = await fetch_global_app_specs_raw();
   const empty = { expiringToday: [], deployedToday: [], networkCategories: [], rawSpecs: [] };
-  if (specs.length === 0) return empty;
+  if (!Array.isArray(specs) || specs.length === 0) return empty;
 
-  const currentBlock = gstore.fluxBlockHeight || 0;
-  const expiringToday = [];
-  const deployedToday = [];
-  const categoryMap = {};
+  try {
+    const currentBlock = gstore.fluxBlockHeight || 0;
+    const expiringToday = [];
+    const deployedToday = [];
+    const categoryMap = {};
 
-  for (const spec of specs) {
-    const instances = spec.instances || 1;
-    const { cpuPerInst, ramGBPerInst, ssdGBPerInst } = specResources(spec);
-    const cat = categorizeAppSpec(spec);
-    categoryMap[cat] = (categoryMap[cat] || 0) + instances;
+    for (const spec of specs) {
+      const instances = spec.instances || 1;
+      const { cpuPerInst, ramGBPerInst, ssdGBPerInst } = specResources(spec);
+      const cat = categorizeAppSpec(spec);
+      categoryMap[cat] = (categoryMap[cat] || 0) + instances;
 
-    const specHeight = spec.height || 0;
-    const deployedAgeBlocks = currentBlock - specHeight;
-    const enriched = { ...spec, instances, cpuPerInst, ramGBPerInst, ssdGBPerInst, category: cat };
+      const specHeight = spec.height || 0;
+      const deployedAgeBlocks = currentBlock - specHeight;
+      const enriched = { ...spec, instances, cpuPerInst, ramGBPerInst, ssdGBPerInst, category: cat };
 
-    if (currentBlock > 0 && deployedAgeBlocks >= 0 && deployedAgeBlocks < BLOCKS_PER_DAY) {
-      deployedToday.push({ ...enriched, deployedAgeBlocks });
-    }
+      if (currentBlock > 0 && deployedAgeBlocks >= 0 && deployedAgeBlocks < BLOCKS_PER_DAY) {
+        deployedToday.push({ ...enriched, deployedAgeBlocks });
+      }
 
-    if (spec.expire) {
-      const expiryBlock = specHeight + spec.expire;
-      const expiresInBlocks = expiryBlock - currentBlock;
-      if (currentBlock > 0 && expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY) {
-        expiringToday.push({ ...enriched, expiresInBlocks });
+      if (spec.expire) {
+        const expiryBlock = specHeight + spec.expire;
+        const expiresInBlocks = expiryBlock - currentBlock;
+        if (currentBlock > 0 && expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY) {
+          expiringToday.push({ ...enriched, expiresInBlocks });
+        }
       }
     }
+
+    expiringToday.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
+    deployedToday.sort((a, b) => a.deployedAgeBlocks - b.deployedAgeBlocks);
+
+    const networkCategories = Object.entries(categoryMap)
+      .map(([category, totalInstances]) => ({ category, totalInstances }))
+      .sort((a, b) => b.totalInstances - a.totalInstances);
+
+    return { expiringToday, deployedToday, networkCategories, rawSpecs: specs };
+  } catch (e) {
+    console.warn('[AppSpecs] Failed to compute:', e);
+    return empty;
   }
-
-  expiringToday.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
-  deployedToday.sort((a, b) => a.deployedAgeBlocks - b.deployedAgeBlocks);
-
-  const networkCategories = Object.entries(categoryMap)
-    .map(([category, totalInstances]) => ({ category, totalInstances }))
-    .sort((a, b) => b.totalInstances - a.totalInstances);
-
-  return { expiringToday, deployedToday, networkCategories, rawSpecs: specs };
 }
 
 const HOME_GEO_CACHE_KEY = 'homeGeoCounts_v1';

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1302,107 +1302,112 @@ export async function fetch_global_performance_rankings() {
 /* =================== GLOBAL APP SPECIFICATIONS ================= */
 /* ================================================================ */
 
-// v2: enterprise apps now report null (unknown) resources instead of 0, so the
-// cached shape changed. Older code does spec.cpuPerInst.toFixed(2) unguarded
-// and would crash on a v1-keyed cache written by this version — bumping the key
-// keeps a rollback safe.
-const HOME_APP_SPECS_CACHE_KEY = 'homeAppSpecs_v2';
+const BLOCKS_PER_DAY = 2880; // 30 sec/block
 
-/*
- * Keys this module used to write. sessionStorage runs ~85% full on a normal
- * load (globalPerfRankings_v3 alone is ~2.9 MB of a ~5 MB quota), so leaving a
- * ~1.3 MB orphan behind after a key bump is enough to push the new write over
- * the limit. setItem is wrapped in a silent catch, so that failure is invisible
- * and caching just quietly stops working.
- */
-const HOME_APP_SPECS_STALE_KEYS = ['homeAppSpecs_v1'];
+const RAW_APP_SPECS_CACHE_KEY = 'homeAppSpecsRaw_v1';
+const RAW_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const RAW_APP_SPECS_STALE_KEYS = ['homeAppSpecs_v2']; // old key cached the full computed (height-dependent) result
+
+let _rawAppSpecsInFlight = null;
 
 function _prune_stale_app_spec_caches() {
-  for (const key of HOME_APP_SPECS_STALE_KEYS) {
+  for (const key of RAW_APP_SPECS_STALE_KEYS) {
     try {
       sessionStorage.removeItem(key);
     } catch {}
   }
 }
-const HOME_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-const BLOCKS_PER_DAY = 2880; // 30 sec/block
 
-export async function fetch_global_app_specs(gstore) {
+/*
+ * Raw globalappsspecifications array only — no block-height-dependent
+ * computation, so this is safe to cache and safe to call from more than one
+ * place in a page load. fetch_global_app_specs() below layers the height-
+ * dependent expiring/deployed-today lists on top, recomputed fresh every
+ * call, specifically so a caller with a not-yet-populated fluxBlockHeight
+ * (fetchTotalDeployedApps runs concurrently with fetchDaemonInfo) can never
+ * poison this cache with a wrong result that a later, correct caller then
+ * reads back within the TTL.
+ */
+export async function fetch_global_app_specs_raw() {
   _prune_stale_app_spec_caches();
 
   try {
-    const raw = sessionStorage.getItem(HOME_APP_SPECS_CACHE_KEY);
+    const raw = sessionStorage.getItem(RAW_APP_SPECS_CACHE_KEY);
     if (raw) {
       const cached = JSON.parse(raw);
-      if (cached && Date.now() - cached.timestamp < HOME_APP_SPECS_CACHE_TTL) {
+      if (cached && Date.now() - cached.timestamp < RAW_APP_SPECS_CACHE_TTL) {
         return cached.data;
       }
     }
   } catch {}
 
-  const currentBlock = gstore.fluxBlockHeight || 0;
-  const empty = { expiringToday: [], deployedToday: [], networkCategories: [], rawSpecs: [] };
+  if (_rawAppSpecsInFlight) return _rawAppSpecsInFlight;
+
+  _rawAppSpecsInFlight = (async () => {
+    try {
+      const res = await fetch('https://api.runonflux.io/apps/globalappsspecifications');
+      const json = await res.json();
+      if (json.status === 'error' || !json.data) return [];
+
+      try {
+        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: json.data, timestamp: Date.now() }));
+      } catch {}
+
+      return json.data;
+    } catch (e) {
+      console.warn('[AppSpecs] Failed to fetch:', e);
+      return [];
+    }
+  })();
 
   try {
-    const res = await fetch('https://api.runonflux.io/apps/globalappsspecifications');
-    const json = await res.json();
+    return await _rawAppSpecsInFlight;
+  } finally {
+    _rawAppSpecsInFlight = null;
+  }
+}
 
-    if (json.status === 'error' || !json.data) return empty;
+export async function fetch_global_app_specs(gstore) {
+  const specs = await fetch_global_app_specs_raw();
+  const empty = { expiringToday: [], deployedToday: [], networkCategories: [], rawSpecs: [] };
+  if (specs.length === 0) return empty;
 
-    const specs = json.data;
-    const expiringToday = [];
-    const deployedToday = [];
-    const categoryMap = {};
+  const currentBlock = gstore.fluxBlockHeight || 0;
+  const expiringToday = [];
+  const deployedToday = [];
+  const categoryMap = {};
 
-    for (const spec of specs) {
-      const instances = spec.instances || 1;
+  for (const spec of specs) {
+    const instances = spec.instances || 1;
+    const { cpuPerInst, ramGBPerInst, ssdGBPerInst } = specResources(spec);
+    const cat = categorizeAppSpec(spec);
+    categoryMap[cat] = (categoryMap[cat] || 0) + instances;
 
-      // Resource per instance — see specResources: enterprise specs report null
-      // rather than a misleading zero.
-      const { cpuPerInst, ramGBPerInst, ssdGBPerInst } = specResources(spec);
+    const specHeight = spec.height || 0;
+    const deployedAgeBlocks = currentBlock - specHeight;
+    const enriched = { ...spec, instances, cpuPerInst, ramGBPerInst, ssdGBPerInst, category: cat };
 
-      // Categorize by compose image names first (more accurate than app name),
-      // and give encrypted enterprise specs their own bucket instead of Other.
-      const cat = categorizeAppSpec(spec);
-      categoryMap[cat] = (categoryMap[cat] || 0) + instances;
-
-      // Deployed / expiring — spec.height is lowercase in the API
-      const specHeight = spec.height || 0;
-      const deployedAgeBlocks = currentBlock - specHeight;
-
-      const enriched = { ...spec, instances, cpuPerInst, ramGBPerInst, ssdGBPerInst, category: cat };
-
-      if (currentBlock > 0 && deployedAgeBlocks >= 0 && deployedAgeBlocks < BLOCKS_PER_DAY) {
-        deployedToday.push({ ...enriched, deployedAgeBlocks });
-      }
-
-      if (spec.expire) {
-        const expiryBlock = specHeight + spec.expire;
-        const expiresInBlocks = expiryBlock - currentBlock;
-        if (currentBlock > 0 && expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY) {
-          expiringToday.push({ ...enriched, expiresInBlocks });
-        }
-      }
+    if (currentBlock > 0 && deployedAgeBlocks >= 0 && deployedAgeBlocks < BLOCKS_PER_DAY) {
+      deployedToday.push({ ...enriched, deployedAgeBlocks });
     }
 
-    expiringToday.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
-    deployedToday.sort((a, b) => a.deployedAgeBlocks - b.deployedAgeBlocks);
-
-    const networkCategories = Object.entries(categoryMap)
-      .map(([category, totalInstances]) => ({ category, totalInstances }))
-      .sort((a, b) => b.totalInstances - a.totalInstances);
-
-    const data = { expiringToday, deployedToday, networkCategories, rawSpecs: specs };
-
-    try {
-      sessionStorage.setItem(HOME_APP_SPECS_CACHE_KEY, JSON.stringify({ data, timestamp: Date.now() }));
-    } catch {}
-
-    return data;
-  } catch (e) {
-    console.warn('[AppSpecs] Failed to fetch:', e);
-    return empty;
+    if (spec.expire) {
+      const expiryBlock = specHeight + spec.expire;
+      const expiresInBlocks = expiryBlock - currentBlock;
+      if (currentBlock > 0 && expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY) {
+        expiringToday.push({ ...enriched, expiresInBlocks });
+      }
+    }
   }
+
+  expiringToday.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
+  deployedToday.sort((a, b) => a.deployedAgeBlocks - b.deployedAgeBlocks);
+
+  const networkCategories = Object.entries(categoryMap)
+    .map(([category, totalInstances]) => ({ category, totalInstances }))
+    .sort((a, b) => b.totalInstances - a.totalInstances);
+
+  return { expiringToday, deployedToday, networkCategories, rawSpecs: specs };
 }
 
 const HOME_GEO_CACHE_KEY = 'homeGeoCounts_v1';

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -2,9 +2,10 @@ import dayjs from 'dayjs';
 
 import { format_minutes } from 'utils';
 import { fluxos_version_desc, fluxos_version_string, fluxos_version_desc_parse } from 'main/flux_version';
-import { categorizeApp, categorizeAppSpec, isOpaqueRuntimeImage } from 'main/Gamification/appCategories';
-import { fetch_fluxinfo_aggregate, buildCategoryTop } from 'fluxinfo';
-import { specResources } from 'appSpecs';
+import { categorizeAppSpec } from 'main/Gamification/appCategories';
+import { fetch_fluxinfo_aggregate } from 'fluxinfo';
+import { specResources, buildSpecIndex } from 'appSpecs';
+import { categorizeRunningApps } from 'runningAppsCategorized';
 import {
   fetch_node_benchmarks,
   fetch_node_resources,
@@ -108,7 +109,7 @@ export function create_global_store() {
       ram_percentage: 0,
       ssd_percentage: 0
     },
-    topRunningImages: [],
+    topRunningApps: [],
     runningCategoryMap: {},
     runningCategoryTop: {},
     topNodesByApps: [],
@@ -498,62 +499,31 @@ export async function fetch_global_stats(walletAddress = null) {
     store.runningAppsStatus = status;
     store.runningAppsFetchedAt = fetchedAt;
 
-    // No data and no cache: leave the zeroed defaults in place. The UI reports
-    // this as unavailable rather than substituting a different dataset.
     if (!aggregate) return;
 
-    store.totalRunningApps = aggregate.totalContainers - aggregate.watchtowerContainers;
-    store.streamrRunningApps = aggregate.streamrNodes;
-    store.presearchRunningApps = aggregate.presearchNodes;
-    store.wordpressCount = aggregate.wordpressContainers;
-
-    const imageEntries = Object.entries(aggregate.imageCounts);
-
-    store.topRunningImages = [...imageEntries]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 10)
-      .map(([image, nodeCount]) => ({ image, nodeCount }));
-
-    // Category breakdown from actual running containers (more accurate than spec data)
-    const categoryMap = {};
-    // Per-category image tallies, keyed on the image name with the tag stripped
-    // so feather:1.0.13 and feather:1.0.14 count as one app rather than two.
-    // Genuinely different images stay separate — minecraft-server and
-    // minecraft-bedrock-server are two apps, not two versions of one.
-    const categoryImages = {};
-
-    for (const [image, count] of imageEntries) {
-      // Git-deployed apps all run the same wrapper image, which says nothing
-      // about the workload inside — keep them uncategorized rather than
-      // reporting 175 containers of "DevOps".
-      const cat = isOpaqueRuntimeImage(image) ? 'other' : categorizeApp(image.toLowerCase());
-      categoryMap[cat] = (categoryMap[cat] || 0) + count;
-
-      const base = image.split(':')[0];
-      categoryImages[cat] = categoryImages[cat] || {};
-      categoryImages[cat][base] = (categoryImages[cat][base] || 0) + count;
-    }
-
-    store.runningCategoryMap = categoryMap;
-
-    /*
-     * Top 3 apps per category, for the category tooltips. Several categories
-     * are effectively a single app — Computing is 99% Folding@Home, Monitoring
-     * 94% Globalping — which the bar chart alone does not convey.
-     *
-     * Ties are broken alphabetically: Media currently has three apps on 3
-     * containers each, so sorting by count alone reshuffles them on every
-     * refresh.
-     */
-    store.runningCategoryTop = buildCategoryTop(categoryImages);
-
-    // Carried on the store so fetch_total_network_utils can build the Workhorse
-    // showcase without asking for the aggregate a second time.
+    // Carried on the store before the spec join below, same as before —
+    // the Workhorse showcase and DonorTab both read these directly off
+    // aggregate's shape.
     store.topNodesByApps = aggregate.topNodesByApps || [];
-
-    // Same reasoning, for the Donor tab: carried here rather than having
-    // DonorTab call fetch_fluxinfo_aggregate() a second time itself.
     store.nodesByIp = aggregate.nodesByIp || {};
+
+    // fluxinfo no longer reports a docker image (#187) — category, repotag,
+    // wordpress/streamr/presearch detection all now require joining each
+    // running app's NAME against globalappsspecifications. That fetch is
+    // its own safe, shared, sessionStorage-cached layer (Task 2), so this
+    // costs a real network request only on a cold cache.
+    const rawSpecs = await fetch_global_app_specs_raw();
+    const specIndex = buildSpecIndex(rawSpecs);
+
+    const categorized = categorizeRunningApps(aggregate, specIndex);
+
+    store.totalRunningApps = categorized.totalRunningApps;
+    store.streamrRunningApps = categorized.streamrRunningApps;
+    store.presearchRunningApps = categorized.presearchRunningApps;
+    store.wordpressCount = categorized.wordpressCount;
+    store.topRunningApps = categorized.topRunningApps;
+    store.runningCategoryMap = categorized.runningCategoryMap;
+    store.runningCategoryTop = categorized.runningCategoryTop;
   };
 
   const fetchUniqueWalletAddresses = async () => {

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -214,4 +214,59 @@ describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
     // Only one network fetch for both calls — the raw array is what's shared.
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
+
+  /*
+   * Neither of these may ever reject. Three callers have no .catch of their
+   * own — AppsSection, analytics/AppsTab, and fetchTotalDeployedApps, which
+   * sits in fetch_global_stats' bare Promise.all where a rejection takes the
+   * whole Home page load (price, wallet, node counts) down with it.
+   */
+  describe('never rejects', () => {
+    const EMPTY = { expiringToday: [], deployedToday: [], networkCategories: [], rawSpecs: [] };
+
+    it('resolves to empty when data is an object rather than an array', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: { not: 'an array' } }) });
+
+      await expect(fetch_global_app_specs_raw()).resolves.toEqual([]);
+      await expect(fetch_global_app_specs({ fluxBlockHeight: 100 })).resolves.toEqual(EMPTY);
+    });
+
+    it('does not read a malformed cache entry back as a spec array', async () => {
+      sessionStorage.setItem('homeAppSpecsRaw_v1', JSON.stringify({ data: { not: 'an array' }, timestamp: Date.now() }));
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+
+      // The bad cache entry is ignored and a real fetch happens instead.
+      await expect(fetch_global_app_specs_raw()).resolves.toEqual(SPECS);
+    });
+
+    it('resolves to empty when a spec in the array cannot be computed over', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: [null] }) });
+
+      await expect(fetch_global_app_specs({ fluxBlockHeight: 100 })).resolves.toEqual(EMPTY);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('resolves to empty when the request itself fails', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
+
+      await expect(fetch_global_app_specs_raw()).resolves.toEqual([]);
+      await expect(fetch_global_app_specs({ fluxBlockHeight: 100 })).resolves.toEqual(EMPTY);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('still returns the full shape on the success path', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+
+      const out = await fetch_global_app_specs({ fluxBlockHeight: 100 });
+
+      expect(Object.keys(out).sort()).toEqual(['deployedToday', 'expiringToday', 'networkCategories', 'rawSpecs']);
+      expect(out.rawSpecs).toEqual(SPECS);
+      expect(out.deployedToday).toHaveLength(1);
+      expect(out.networkCategories).toHaveLength(1);
+    });
+  });
 });

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -5,6 +5,8 @@ import {
   calc_mtn_window,
   normalize_raw_node_tier,
   wallet_health_full,
+  fetch_global_app_specs,
+  fetch_global_app_specs_raw,
 } from './apidata';
 
 import {
@@ -170,5 +172,46 @@ describe('wallet_health_full', () => {
       expect(h[tier].projection_daily.flux).toBe(0);
       expect(h[tier].projection_montly.flux).toBe(0);
     }
+  });
+});
+
+describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
+  const SPECS = [{ name: 'appA', height: 100, compose: [{ repotag: 'someimage/app:latest', cpu: 1, ram: 512, hdd: 5 }] }];
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('fetch_global_app_specs_raw returns the raw spec array', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+    const raw = await fetch_global_app_specs_raw();
+    expect(raw).toEqual(SPECS);
+  });
+
+  it('shares one in-flight request between concurrent callers', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+    const [a, b] = await Promise.all([fetch_global_app_specs_raw(), fetch_global_app_specs_raw()]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it('recomputes expiringToday/deployedToday fresh from the block height on every call, never from a stale cached value', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+
+    // First call at block height 0 (the race this task exists to fix):
+    // appA is not "deployed today" because there is no reliable height yet.
+    const first = await fetch_global_app_specs({ fluxBlockHeight: 0 });
+    expect(first.deployedToday).toEqual([]);
+
+    // Second call moments later, same 5-minute cache window, but with the
+    // real block height available — must NOT read back the first call's
+    // (wrong) cached deployedToday.
+    const second = await fetch_global_app_specs({ fluxBlockHeight: 100 });
+    expect(second.deployedToday).toHaveLength(1);
+    expect(second.deployedToday[0].name).toBe('appA');
+
+    // Only one network fetch for both calls — the raw array is what's shared.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/appSpecs.js
+++ b/client/src/appSpecs.js
@@ -61,11 +61,34 @@ export function buildSpecIndex(rawSpecs) {
   const index = {};
   for (const spec of rawSpecs || []) {
     if (!spec?.name) continue;
+    const composeList = Array.isArray(spec.compose) && spec.compose.length > 0 ? spec.compose : null;
     index[spec.name] = {
       ...specResources(spec),
       category: categorizeAppSpec(spec),
-      instances: spec.instances || 1
+      instances: spec.instances || 1,
+      // Per-component repotags, for consumers that need the EXACT image a
+      // specific running container is (not just the spec's primary/first
+      // one) — see repotagForComponent below. Only the name/repotag pairs are
+      // kept; nothing else off `compose` is needed here. null for
+      // single-component and enterprise specs, which have no distinct
+      // components to resolve.
+      compose: composeList ? composeList.map((c) => ({ name: c?.name, repotag: c?.repotag || '' })) : null
     };
   }
   return index;
+}
+
+/**
+ * The exact repotag for one component of a running app, given that app's
+ * buildSpecIndex() entry and the component name recovered from its container
+ * name (fluxinfo.js's componentFromContainer). Falls back to the entry's
+ * aggregate `.repotag` (component 0, or the spec's own top-level repotag for
+ * single-component apps) when the component can't be matched — a spec update
+ * mid-flight, or a null/empty component for a single-component app.
+ */
+export function repotagForComponent(indexEntry, component) {
+  if (!indexEntry) return '';
+  if (!indexEntry.compose || !component) return indexEntry.repotag || '';
+  const match = indexEntry.compose.find((c) => c.name === component);
+  return match?.repotag || indexEntry.repotag || '';
 }

--- a/client/src/appSpecs.test.js
+++ b/client/src/appSpecs.test.js
@@ -1,0 +1,77 @@
+import { specResources, buildSpecIndex, repotagForComponent } from './appSpecs';
+
+/*
+ * repotagForComponent is the join that stops a running container being
+ * attributed to the wrong image. fluxinfo reports which COMPONENT a container
+ * is; the spec index holds each component's own repotag. Resolving by app name
+ * alone (which is all the code used to do) collapsed every component of a
+ * compose app onto compose[0]'s image.
+ */
+
+const WORDPRESS_SPEC = {
+  name: 'wordpress1',
+  instances: 3,
+  compose: [
+    { name: 'wp', repotag: 'runonflux/wp-nginx:latest', cpu: 1, ram: 1024, hdd: 5 },
+    { name: 'mysql', repotag: 'mysql:8.3.0', cpu: 1, ram: 2048, hdd: 10 },
+    { name: 'operator', repotag: 'runonflux/shared-db:latest', cpu: 0.5, ram: 512, hdd: 1 },
+  ],
+};
+
+const SINGLE_SPEC = { name: 'Presearch', repotag: 'presearch/node:latest', cpu: 1, ram: 1024, hdd: 5 };
+
+const ENTERPRISE_SPEC = { name: 'secret1', enterprise: 'encrypted-blob', compose: [] };
+
+describe('buildSpecIndex', () => {
+  it('keeps each component name/repotag pair, and nothing else off compose', () => {
+    const index = buildSpecIndex([WORDPRESS_SPEC]);
+    expect(index.wordpress1.compose).toEqual([
+      { name: 'wp', repotag: 'runonflux/wp-nginx:latest' },
+      { name: 'mysql', repotag: 'mysql:8.3.0' },
+      { name: 'operator', repotag: 'runonflux/shared-db:latest' },
+    ]);
+  });
+
+  it('leaves compose null when there are no distinct components to resolve', () => {
+    const index = buildSpecIndex([SINGLE_SPEC, ENTERPRISE_SPEC]);
+    expect(index.Presearch.compose).toBeNull();
+    expect(index.secret1.compose).toBeNull();
+  });
+
+  it('still carries the aggregate resources and category every other consumer reads', () => {
+    const index = buildSpecIndex([WORDPRESS_SPEC]);
+    const { cpuPerInst, ramGBPerInst, ssdGBPerInst, repotag } = specResources(WORDPRESS_SPEC);
+    expect(index.wordpress1).toMatchObject({ cpuPerInst, ramGBPerInst, ssdGBPerInst, repotag, instances: 3 });
+    expect(typeof index.wordpress1.category).toBe('string');
+  });
+});
+
+describe('repotagForComponent', () => {
+  const index = buildSpecIndex([WORDPRESS_SPEC, SINGLE_SPEC, ENTERPRISE_SPEC]);
+
+  it('resolves each component to its OWN image, not to compose[0]', () => {
+    expect(repotagForComponent(index.wordpress1, 'wp')).toBe('runonflux/wp-nginx:latest');
+    expect(repotagForComponent(index.wordpress1, 'mysql')).toBe('mysql:8.3.0');
+    expect(repotagForComponent(index.wordpress1, 'operator')).toBe('runonflux/shared-db:latest');
+  });
+
+  it('falls back to the aggregate repotag when the component does not match', () => {
+    // e.g. the spec was updated between the two independent fetches
+    expect(repotagForComponent(index.wordpress1, 'renamedSinceLastFetch')).toBe('runonflux/wp-nginx:latest');
+  });
+
+  it('falls back to the aggregate repotag for a single-component app', () => {
+    expect(repotagForComponent(index.Presearch, null)).toBe('presearch/node:latest');
+    expect(repotagForComponent(index.Presearch, 'anything')).toBe('presearch/node:latest');
+  });
+
+  it('returns an empty string for an enterprise spec, which has no readable image', () => {
+    expect(repotagForComponent(index.secret1, null)).toBe('');
+    expect(repotagForComponent(index.secret1, 'wp')).toBe('');
+  });
+
+  it('returns an empty string for a missing spec, without throwing', () => {
+    expect(repotagForComponent(undefined, 'wp')).toBe('');
+    expect(repotagForComponent(null, null)).toBe('');
+  });
+});

--- a/client/src/components/TopHostedApps/index.jsx
+++ b/client/src/components/TopHostedApps/index.jsx
@@ -27,7 +27,7 @@ function PanelHeader({ title, badge, badgeClassName, badgeContent, right }) {
 }
 
 export function TopHostedApps({ gstore }) {
-  const images = gstore.topRunningImages || [];
+  const images = gstore.topRunningApps || [];
   const isLoading = images.length === 0 && gstore.node_count.total > 0;
   const maxCount = images[0]?.nodeCount || 1;
 

--- a/client/src/fluxinfo.js
+++ b/client/src/fluxinfo.js
@@ -23,9 +23,9 @@
 // Workhorse showcase ranks nodes by how many apps they host. Costs ~158 KB on
 // a call the page already makes, rather than a second request.
 const FLUXINFO_URL =
-  'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Image,apps.runningapps.Names,ip,tier';
-const FLUXINFO_CACHE_KEY = 'fluxinfoAggregate_v4'; // v4: adds nodesByIp (full per-node app lookup, not just top N)
-const FLUXINFO_STALE_KEYS = ['fluxinfoAggregate_v1', 'fluxinfoAggregate_v2', 'fluxinfoAggregate_v3'];
+  'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Names,ip,tier';
+const FLUXINFO_CACHE_KEY = 'fluxinfoAggregate_v5'; // v5: Image field removed from the API (#187) — imageCounts replaced by nameCounts, per-node `images` renamed `containerAppNames`
+const FLUXINFO_STALE_KEYS = ['fluxinfoAggregate_v1', 'fluxinfoAggregate_v2', 'fluxinfoAggregate_v3', 'fluxinfoAggregate_v4'];
 const FLUXINFO_STALE_MAX_AGE = 6 * 60 * 60 * 1000; // serve last-known-good for up to 6 hours
 // Enough to fill the showcase with a couple spare, in case one drops offline.
 const TOP_NODES_KEPT = 5;
@@ -75,99 +75,61 @@ async function _fluxinfo_fetch_once() {
  * used to throw a TypeError here and wipe the whole category map.
  */
 function _fluxinfo_aggregate(nodes) {
-  const streamrImage = process.env.REACT_APP_STREAMR || 'streamr/broker-node:latest';
-  const presearchImage = process.env.REACT_APP_PRE_SEARCH || 'presearch/node:latest';
-
-  const imageCounts = {};
-  // Per-node app lists, kept only for the busiest handful. Retaining all ~6,500
-  // would bloat the cached aggregate for no benefit — the showcase needs three.
+  // Per-app-name running-container tally. Category/repotag/watchtower/
+  // wordpress/streamr/presearch detection all used to be image-substring
+  // matches done right here — fluxinfo no longer reports an image at all
+  // (issue #187), so none of that can happen in this module any more. It now
+  // moves to runningAppsCategorized.js, which joins this name-keyed tally
+  // against globalappsspecifications (still has the real repotag) once both
+  // are available. This module stays a pure, spec-agnostic reader of
+  // fluxinfo, same as before.
+  const nameCounts = {};
   const perNode = [];
   let totalContainers = 0;
-  let watchtowerContainers = 0;
-  let wordpressContainers = 0;
-  let streamrNodes = 0;
-  let presearchNodes = 0;
 
   for (const item of nodes) {
     const running = Array.isArray(item?.apps?.runningapps) ? item.apps.runningapps : [];
     totalContainers += running.length;
 
-    // streamr / presearch are counted per NODE, matching the original behaviour
-    let hasStreamr = false;
-    let hasPresearch = false;
+    // One name per container, NOT deduped — a 3-component compose app
+    // contributes its app name 3 times, matching the pre-#187 per-container
+    // imageCounts convention (each component counted once).
+    const containerAppNames = running
+      .map((a) => appNameFromContainer(Array.isArray(a?.Names) ? a.Names[0] : null))
+      .filter(Boolean);
 
-    for (const app of running) {
-      const image = typeof app?.Image === 'string' ? app.Image : '';
-      if (!image) continue;
-
-      imageCounts[image] = (imageCounts[image] || 0) + 1;
-
-      const lower = image.toLowerCase();
-      if (lower.includes('containrrr/watchtower')) watchtowerContainers++;
-      if (lower === 'runonflux/wp-nginx' || lower.startsWith('runonflux/wp-nginx:')) wordpressContainers++;
-      if (image.includes(streamrImage)) hasStreamr = true;
-      if (image.includes(presearchImage)) hasPresearch = true;
+    for (const name of containerAppNames) {
+      nameCounts[name] = (nameCounts[name] || 0) + 1;
     }
-
-    if (hasStreamr) streamrNodes++;
-    if (hasPresearch) presearchNodes++;
 
     const ip = typeof item?.ip === 'string' ? item.ip : '';
     if (ip && running.length > 0) {
       perNode.push({
         ip,
-        // Tier comes from here rather than the benchmark projection: this call
-        // is ~726 KB and reliable, that one is 3.45 MB and has been observed
-        // returning status=error for minutes at a time.
         tier: typeof item?.tier === 'string' ? item.tier : null,
-        // Containers, kept for the utilisation reading. Not the ranking metric:
-        // a compose app runs one container per component, so a node with 13
-        // containers can be hosting as few as 6 apps.
         containerCount: running.length,
-        images: running.map((a) => (typeof a?.Image === 'string' ? a.Image : '')).filter(Boolean),
-        // Deployed app names, so the showcase can look each one up in the
-        // global app specs for its category and resource reservation.
-        appNames: []
+        containerAppNames,
+        appNames: [],
       });
 
-      // Distinct deployed apps — "hosting the most apps" means apps, not
-      // containers. Populated after the push so appCount can be derived from it.
-      const names = [
-        ...new Set(
-          running
-            .map((a) => appNameFromContainer(Array.isArray(a?.Names) ? a.Names[0] : null))
-            .filter(Boolean)
-        )
-      ];
+      const names = [...new Set(containerAppNames)];
       const entry = perNode[perNode.length - 1];
       entry.appNames = names;
       entry.appCount = names.length || running.length;
     }
   }
 
-  // Descending by app count, ties broken on ip so the order is stable between
-  // refreshes rather than reshuffling on equal counts.
   perNode.sort((a, b) => b.appCount - a.appCount || a.ip.localeCompare(b.ip));
   const topNodesByApps = perNode.slice(0, TOP_NODES_KEPT);
 
-  // Keyed lookup covering EVERY reporting node with running apps, not just
-  // the top N kept above. topNodesByApps exists for the Workhorse showcase's
-  // "busiest nodes network-wide" need; nodesByIp exists for the opposite
-  // need — "what's running on THIS SPECIFIC node" (e.g. a donor's own
-  // wallet's nodes, which are essentially never in the top N). Same
-  // underlying computation (perNode), just not thrown away.
   const nodesByIp = {};
   for (const entry of perNode) {
     nodesByIp[entry.ip.trim()] = entry;
   }
 
   return {
-    imageCounts,
+    nameCounts,
     totalContainers,
-    watchtowerContainers,
-    wordpressContainers,
-    streamrNodes,
-    presearchNodes,
     topNodesByApps,
     nodesByIp,
     nodesReporting: nodes.length
@@ -188,7 +150,7 @@ function _fluxinfo_read_cache() {
     const raw = localStorage.getItem(FLUXINFO_CACHE_KEY);
     if (!raw) return null;
     const cached = JSON.parse(raw);
-    if (!cached?.aggregate?.imageCounts) return null;
+    if (!cached?.aggregate?.nameCounts) return null;
     if (Date.now() - cached.timestamp > FLUXINFO_STALE_MAX_AGE) return null;
     return cached;
   } catch {

--- a/client/src/fluxinfo.js
+++ b/client/src/fluxinfo.js
@@ -14,9 +14,10 @@
  *
  * Now: one shared request per refresh, retried with backoff, with the derived
  * aggregate persisted so a failure serves last-known-good marked as stale
- * instead of switching datasets. Only the aggregate is cached (~365 image
- * counts), never the ~465 KB raw payload, and categories are recomputed from it
- * on every read so keyword changes take effect immediately.
+ * instead of switching datasets. Only the derived aggregate is cached, never
+ * the raw payload. Category/repotag detection no longer happens in this
+ * module at all (see the comment on _fluxinfo_aggregate) — it's recomputed
+ * downstream, in runningAppsCategorized.js, on every read.
  */
 
 // `ip` is included so per-node app counts can be attributed to a node — the
@@ -24,8 +25,19 @@
 // a call the page already makes, rather than a second request.
 const FLUXINFO_URL =
   'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Names,ip,tier';
-const FLUXINFO_CACHE_KEY = 'fluxinfoAggregate_v5'; // v5: Image field removed from the API (#187) — imageCounts replaced by nameCounts, per-node `images` renamed `containerAppNames`
-const FLUXINFO_STALE_KEYS = ['fluxinfoAggregate_v1', 'fluxinfoAggregate_v2', 'fluxinfoAggregate_v3', 'fluxinfoAggregate_v4'];
+// v5: Image field removed from the API (#187) — imageCounts replaced by nameCounts, per-node `images` renamed `containerAppNames`
+// v6: componentCounts + per-node containerComponents added, so running containers
+//     resolve to their OWN component's repotag rather than the app's compose[0].
+//     A v5 entry has neither, which would silently zero wordpressCount and
+//     topRunningApps for up to the 6h stale window, so it is dropped rather than served.
+const FLUXINFO_CACHE_KEY = 'fluxinfoAggregate_v6';
+const FLUXINFO_STALE_KEYS = [
+  'fluxinfoAggregate_v1',
+  'fluxinfoAggregate_v2',
+  'fluxinfoAggregate_v3',
+  'fluxinfoAggregate_v4',
+  'fluxinfoAggregate_v5'
+];
 const FLUXINFO_STALE_MAX_AGE = 6 * 60 * 60 * 1000; // serve last-known-good for up to 6 hours
 // Enough to fill the showcase with a couple spare, in case one drops offline.
 const TOP_NODES_KEPT = 5;
@@ -57,6 +69,42 @@ export function appNameFromContainer(containerName) {
   return name || null;
 }
 
+/**
+ * Recover the docker COMPONENT name from a container name, the counterpart
+ * to appNameFromContainer. Returns null for a single-component app (no
+ * underscore) — there is no distinct component name to resolve against in
+ * that case, since specResources()/appSpecs.js already falls back to the
+ * spec's own top-level repotag for those.
+ *
+ *   /fluxFoldingAtHome_FoldingAtRunOnFlux29  ->  FoldingAtHome
+ *   /fluxPresearch                           ->  null
+ */
+export function componentFromContainer(containerName) {
+  const raw = (containerName || '').replace(/^\//, '');
+  if (!raw.startsWith('flux')) return null;
+  const body = raw.slice(4);
+  const underscore = body.indexOf('_');
+  return underscore === -1 ? null : body.slice(0, underscore) || null;
+}
+
+/**
+ * The key componentCounts is tallied under, and its inverse.
+ *
+ * '\u0000' can appear in neither a Flux app name nor a docker component name,
+ * so unlike '_' or ':' it can never be ambiguous with the halves it joins.
+ */
+export const COMPONENT_KEY_SEP = '\u0000';
+
+export function componentCountKey(appName, component) {
+  return `${appName}${COMPONENT_KEY_SEP}${component || ''}`;
+}
+
+export function splitComponentCountKey(key) {
+  const sep = key.indexOf(COMPONENT_KEY_SEP);
+  if (sep === -1) return { name: key, component: null }; // not one of ours; treat as app-level
+  return { name: key.slice(0, sep), component: key.slice(sep + 1) || null };
+}
+
 async function _fluxinfo_fetch_once() {
   const res = await fetch(FLUXINFO_URL);
   if (!res.ok) throw new Error('fluxinfo HTTP ' + res.status);
@@ -84,6 +132,14 @@ function _fluxinfo_aggregate(nodes) {
   // are available. This module stays a pure, spec-agnostic reader of
   // fluxinfo, same as before.
   const nameCounts = {};
+  // Same tally, but split one level finer: keyed by app name AND the component
+  // the container actually is (componentCountKey above). An app-level tally
+  // alone cannot say which of a compose app's images a given container runs,
+  // so every container of a 3-component app resolved to compose[0]'s repotag —
+  // which triple-counted WordPress and dropped real images out of the Top
+  // Hosted Apps ranking. Category tallies stay on nameCounts (categorizeAppSpec
+  // already scans every component, so category is app-level by construction).
+  const componentCounts = {};
   const perNode = [];
   let totalContainers = 0;
 
@@ -91,15 +147,28 @@ function _fluxinfo_aggregate(nodes) {
     const running = Array.isArray(item?.apps?.runningapps) ? item.apps.runningapps : [];
     totalContainers += running.length;
 
-    // One name per container, NOT deduped — a 3-component compose app
+    // One entry per container, NOT deduped — a 3-component compose app
     // contributes its app name 3 times, matching the pre-#187 per-container
-    // imageCounts convention (each component counted once).
-    const containerAppNames = running
-      .map((a) => appNameFromContainer(Array.isArray(a?.Names) ? a.Names[0] : null))
-      .filter(Boolean);
+    // imageCounts convention (each component counted once). Containers whose
+    // name does not parse are dropped here, once, so every array derived below
+    // stays index-aligned with every other.
+    const parsedContainers = running
+      .map((a) => {
+        const containerName = Array.isArray(a?.Names) ? a.Names[0] : null;
+        return {
+          name: appNameFromContainer(containerName),
+          component: componentFromContainer(containerName)
+        };
+      })
+      .filter((c) => c.name);
 
-    for (const name of containerAppNames) {
+    const containerAppNames = parsedContainers.map((c) => c.name);
+    const containerComponents = parsedContainers.map((c) => c.component);
+
+    for (const { name, component } of parsedContainers) {
       nameCounts[name] = (nameCounts[name] || 0) + 1;
+      const key = componentCountKey(name, component);
+      componentCounts[key] = (componentCounts[key] || 0) + 1;
     }
 
     const ip = typeof item?.ip === 'string' ? item.ip : '';
@@ -109,6 +178,10 @@ function _fluxinfo_aggregate(nodes) {
         tier: typeof item?.tier === 'string' ? item.tier : null,
         containerCount: running.length,
         containerAppNames,
+        // Index-aligned with containerAppNames: containerComponents[i] is the
+        // component of the container named containerAppNames[i] (null for a
+        // single-component app).
+        containerComponents,
         appNames: [],
       });
 
@@ -129,6 +202,7 @@ function _fluxinfo_aggregate(nodes) {
 
   return {
     nameCounts,
+    componentCounts,
     totalContainers,
     topNodesByApps,
     nodesByIp,

--- a/client/src/fluxinfoResilience.test.js
+++ b/client/src/fluxinfoResilience.test.js
@@ -12,9 +12,9 @@ import { fetch_fluxinfo_aggregate, buildCategoryTop, appNameFromContainer } from
  */
 
 const NODES = [
-  { apps: { runningapps: [{ Image: 'yurinnick/folding-at-home:latest' }, { Image: 'runonflux/wp-nginx:latest' }] } },
-  { apps: { runningapps: [{ Image: 'presearch/node:latest' }] } },
-  { apps: { runningapps: [{ Image: 'yurinnick/folding-at-home:latest' }] } },
+  { apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux1'] }, { Names: ['/fluxwp_wordpress123'] }] } },
+  { apps: { runningapps: [{ Names: ['/fluxPresearch'] }] } },
+  { apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux2'] }] } },
 ];
 
 // A second fixture, WITH `ip` set (the existing NODES fixture above omits it
@@ -24,7 +24,7 @@ const NODES_WITH_IP = [
   {
     ip: '1.2.3.4:16127',
     tier: 'CUMULUS',
-    apps: { runningapps: [{ Image: 'yurinnick/folding-at-home:latest', Names: ['/fluxFoldingAtRunOnFlux1'] }] },
+    apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux1'] }] },
   },
   {
     ip: '5.6.7.8:16127',
@@ -49,9 +49,9 @@ describe('fetch_fluxinfo_aggregate', () => {
     expect(status).toBe('live');
     expect(aggregate.totalContainers).toBe(4);
     expect(aggregate.nodesReporting).toBe(3);
-    expect(aggregate.wordpressContainers).toBe(1);
-    expect(aggregate.presearchNodes).toBe(1);
-    expect(aggregate.imageCounts['yurinnick/folding-at-home:latest']).toBe(2);
+    expect(aggregate.nameCounts.FoldingAtRunOnFlux1).toBe(1);
+    expect(aggregate.nameCounts.FoldingAtRunOnFlux2).toBe(1);
+    expect(aggregate.nameCounts.wordpress123).toBe(1);
   });
 
   it('retries and succeeds after transient failures', async () => {
@@ -132,7 +132,7 @@ describe('fetch_fluxinfo_aggregate', () => {
     localStorage.setItem(
       'fluxinfoAggregate_v1',
       JSON.stringify({
-        aggregate: { imageCounts: { 'busybox:latest': 1 }, totalContainers: 1 },
+        aggregate: { nameCounts: { busybox: 1 }, totalContainers: 1 },
         timestamp: Date.now() - 7 * 60 * 60 * 1000, // window is 6h
       })
     );
@@ -221,7 +221,7 @@ describe('fetch_fluxinfo_aggregate nodesByIp', () => {
     expect(Object.keys(aggregate.nodesByIp)).toEqual(['1.2.3.4:16127']);
     expect(aggregate.nodesByIp['1.2.3.4:16127'].appCount).toBe(1);
     expect(aggregate.nodesByIp['1.2.3.4:16127'].tier).toBe('CUMULUS');
-    expect(aggregate.nodesByIp['1.2.3.4:16127'].images).toEqual(['yurinnick/folding-at-home:latest']);
+    expect(aggregate.nodesByIp['1.2.3.4:16127'].containerAppNames).toEqual(['FoldingAtRunOnFlux1']);
   });
 
   it('omits a node with no running apps from nodesByIp, same as topNodesByApps', async () => {

--- a/client/src/fluxinfoResilience.test.js
+++ b/client/src/fluxinfoResilience.test.js
@@ -1,4 +1,9 @@
-import { fetch_fluxinfo_aggregate, buildCategoryTop, appNameFromContainer } from './fluxinfo';
+import {
+  fetch_fluxinfo_aggregate,
+  buildCategoryTop,
+  appNameFromContainer,
+  componentFromContainer,
+} from './fluxinfo';
 
 /*
  * Regression tests for issue #144.
@@ -209,6 +214,99 @@ describe('appNameFromContainer', () => {
     expect(appNameFromContainer('/watchtower')).toBeNull();
     expect(appNameFromContainer('')).toBeNull();
     expect(appNameFromContainer(undefined)).toBeNull();
+  });
+});
+
+describe('componentFromContainer', () => {
+  it('takes the component name from a compose container', () => {
+    expect(componentFromContainer('/fluxFoldingAtHome_FoldingAtRunOnFlux29')).toBe('FoldingAtHome');
+  });
+
+  it('returns null for a single-component app with no underscore', () => {
+    // Nothing to resolve against: appSpecs falls back to the spec's own repotag.
+    expect(componentFromContainer('/fluxPresearch')).toBeNull();
+  });
+
+  it('splits on the first underscore, the same one appNameFromContainer does', () => {
+    expect(componentFromContainer('/fluxbackend_my_app_name')).toBe('backend');
+    expect(appNameFromContainer('/fluxbackend_my_app_name')).toBe('my_app_name');
+  });
+
+  it('ignores containers that are not Flux apps', () => {
+    expect(componentFromContainer('/watchtower')).toBeNull();
+    expect(componentFromContainer('')).toBeNull();
+    expect(componentFromContainer(undefined)).toBeNull();
+  });
+});
+
+describe('fetch_fluxinfo_aggregate componentCounts', () => {
+  it('tallies each container under its app name AND its component', async () => {
+    global.fetch = jest.fn().mockResolvedValue(okResponse(NODES));
+
+    const { aggregate } = await fetch_fluxinfo_aggregate();
+
+    expect(aggregate.componentCounts['FoldingAtRunOnFlux1\u0000FoldingAtHome']).toBe(1);
+    expect(aggregate.componentCounts['FoldingAtRunOnFlux2\u0000FoldingAtHome']).toBe(1);
+    expect(aggregate.componentCounts['wordpress123\u0000wp']).toBe(1);
+    // Single-component app: empty-string component half, never absent.
+    expect(aggregate.componentCounts['Presearch\u0000']).toBe(1);
+    // Every container is counted exactly once, same as nameCounts.
+    expect(Object.values(aggregate.componentCounts).reduce((s, n) => s + n, 0)).toBe(
+      Object.values(aggregate.nameCounts).reduce((s, n) => s + n, 0)
+    );
+  });
+
+  it('keeps each component of one multi-component app apart', async () => {
+    // The bug this exists to catch: all three of these used to collapse into
+    // one app-level tally, and so all resolved to compose[0]'s image.
+    const compose = [
+      {
+        ip: '9.9.9.9:16127',
+        apps: {
+          runningapps: [
+            { Names: ['/fluxwp_wordpress1'] },
+            { Names: ['/fluxmysql_wordpress1'] },
+            { Names: ['/fluxoperator_wordpress1'] },
+          ],
+        },
+      },
+    ];
+    global.fetch = jest.fn().mockResolvedValue(okResponse(compose));
+
+    const { aggregate } = await fetch_fluxinfo_aggregate();
+
+    expect(aggregate.nameCounts.wordpress1).toBe(3);
+    expect(aggregate.componentCounts['wordpress1\u0000wp']).toBe(1);
+    expect(aggregate.componentCounts['wordpress1\u0000mysql']).toBe(1);
+    expect(aggregate.componentCounts['wordpress1\u0000operator']).toBe(1);
+  });
+
+  it('keeps containerComponents index-aligned with containerAppNames on every node', async () => {
+    // An unparseable container in the middle must drop out of BOTH arrays, or
+    // every container after it resolves against the wrong component.
+    const mixed = [
+      {
+        ip: '1.2.3.4:16127',
+        apps: {
+          runningapps: [
+            { Names: ['/fluxwp_wordpress1'] },
+            { Names: ['/watchtower'] }, // not a Flux app
+            { Names: null }, // malformed
+            { Names: ['/fluxPresearch'] },
+          ],
+        },
+      },
+    ];
+    global.fetch = jest.fn().mockResolvedValue(okResponse(mixed));
+
+    const { aggregate } = await fetch_fluxinfo_aggregate();
+    const node = aggregate.nodesByIp['1.2.3.4:16127'];
+
+    expect(node.containerAppNames).toEqual(['wordpress1', 'Presearch']);
+    expect(node.containerComponents).toEqual(['wp', null]);
+    expect(node.containerComponents).toHaveLength(node.containerAppNames.length);
+    // containerCount still counts every reported container, parsed or not.
+    expect(node.containerCount).toBe(4);
   });
 });
 

--- a/client/src/home/WorkhorsePanel/index.jsx
+++ b/client/src/home/WorkhorsePanel/index.jsx
@@ -6,7 +6,6 @@ import { FiCpu, FiHardDrive, FiDownload, FiUpload, FiBox } from 'react-icons/fi'
 
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
 import { CategoryTooltip } from 'components/CategoryTooltip';
-import { categorizeApp, isOpaqueRuntimeImage } from 'main/Gamification/appCategories';
 import { buildSpecIndex } from 'appSpecs';
 
 const ROTATE_MS = 8000;
@@ -88,12 +87,12 @@ function NodeCard({ node, specsByName }) {
 
   const categories = useMemo(() => {
     const counts = {};
-    for (const image of node.images || []) {
-      const cat = isOpaqueRuntimeImage(image) ? 'other' : categorizeApp(image.toLowerCase());
+    for (const name of node.containerAppNames || []) {
+      const cat = specsByName?.[name]?.category || 'other';
       counts[cat] = (counts[cat] || 0) + 1;
     }
     return Object.entries(counts).sort((a, b) => b[1] - a[1]);
-  }, [node.images]);
+  }, [node.containerAppNames, specsByName]);
 
   const tierColor = TIER_COLOR[node.tier] || 'var(--text-tertiary)';
   const b = node.benchmark;

--- a/client/src/networkNodes.js
+++ b/client/src/networkNodes.js
@@ -156,7 +156,7 @@ export function buildWorkhorseNodes(
       host,
       appCount: node.appCount,
       containerCount: node.containerCount ?? node.appCount,
-      images: node.images,
+      containerAppNames: node.containerAppNames,
       appNames: node.appNames || [],
       paymentAddress: walletByAddr[addr] || null,
       tier: node.tier || benchEntry?.tier || null,

--- a/client/src/networkNodes.test.js
+++ b/client/src/networkNodes.test.js
@@ -7,9 +7,9 @@ import { buildWorkhorseNodes, hostOf, addressOf } from './networkNodes';
  */
 
 const topNodes = [
-  { ip: '82.66.83.104:16147', tier: 'CUMULUS', appCount: 15, images: ['a/one:latest', 'b/two:latest'], appNames: ['AppOne', 'AppTwo'] },
-  { ip: '99.56.151.69', tier: 'STRATUS', appCount: 13, images: ['c/three:latest'], appNames: ['AppThree'] },
-  { ip: '98.174.3.181', tier: 'CUMULUS', appCount: 11, images: ['d/four:latest'], appNames: ['AppFour'] },
+  { ip: '82.66.83.104:16147', tier: 'CUMULUS', appCount: 15, containerAppNames: ['a/one:latest', 'b/two:latest'], appNames: ['AppOne', 'AppTwo'] },
+  { ip: '99.56.151.69', tier: 'STRATUS', appCount: 13, containerAppNames: ['c/three:latest'], appNames: ['AppThree'] },
+  { ip: '98.174.3.181', tier: 'CUMULUS', appCount: 11, containerAppNames: ['d/four:latest'], appNames: ['AppFour'] },
 ];
 
 const paymentAddresses = [
@@ -101,8 +101,8 @@ describe('buildWorkhorseNodes', () => {
     });
   });
 
-  it('keeps the app images for the list', () => {
-    expect(out[0].images).toEqual(['a/one:latest', 'b/two:latest']);
+  it('keeps the app container names for the list', () => {
+    expect(out[0].containerAppNames).toEqual(['a/one:latest', 'b/two:latest']);
   });
 
   it('still renders nodes when benchmarks are unavailable', () => {
@@ -139,7 +139,7 @@ describe('buildWorkhorseNodes', () => {
     const nothing = buildWorkhorseNodes(topNodes, [], [], [], []);
     expect(nothing).toHaveLength(3);
     expect(nothing[0].appCount).toBe(15);
-    expect(nothing[0].images).toHaveLength(2);
+    expect(nothing[0].containerAppNames).toHaveLength(2);
   });
 
   it('respects the limit', () => {
@@ -163,7 +163,7 @@ describe('wallet linkage', () => {
   it("does not attribute a co-located node's wallet to its neighbour", () => {
     // 82.66.83.104 runs three nodes on different ports, each with its own
     // wallet. Joining on the bare IP silently merged them.
-    const sameMachine = [{ ip: '82.66.83.104:16167', tier: 'CUMULUS', appCount: 9, images: [], appNames: [] }];
+    const sameMachine = [{ ip: '82.66.83.104:16167', tier: 'CUMULUS', appCount: 9, containerAppNames: [], appNames: [] }];
     const res = buildWorkhorseNodes(sameMachine, benchmarks, geolocations, resources, paymentAddresses);
     expect(res[0].paymentAddress).toBe('t1DIFFERENTnodeSameMachine0000000000');
   });

--- a/client/src/networkNodes.test.js
+++ b/client/src/networkNodes.test.js
@@ -7,9 +7,9 @@ import { buildWorkhorseNodes, hostOf, addressOf } from './networkNodes';
  */
 
 const topNodes = [
-  { ip: '82.66.83.104:16147', tier: 'CUMULUS', appCount: 15, containerAppNames: ['a/one:latest', 'b/two:latest'], appNames: ['AppOne', 'AppTwo'] },
-  { ip: '99.56.151.69', tier: 'STRATUS', appCount: 13, containerAppNames: ['c/three:latest'], appNames: ['AppThree'] },
-  { ip: '98.174.3.181', tier: 'CUMULUS', appCount: 11, containerAppNames: ['d/four:latest'], appNames: ['AppFour'] },
+  { ip: '82.66.83.104:16147', tier: 'CUMULUS', appCount: 15, containerAppNames: ['AppOne', 'AppTwo'], appNames: ['AppOne', 'AppTwo'] },
+  { ip: '99.56.151.69', tier: 'STRATUS', appCount: 13, containerAppNames: ['AppThree'], appNames: ['AppThree'] },
+  { ip: '98.174.3.181', tier: 'CUMULUS', appCount: 11, containerAppNames: ['AppFour'], appNames: ['AppFour'] },
 ];
 
 const paymentAddresses = [
@@ -102,7 +102,7 @@ describe('buildWorkhorseNodes', () => {
   });
 
   it('keeps the app container names for the list', () => {
-    expect(out[0].containerAppNames).toEqual(['a/one:latest', 'b/two:latest']);
+    expect(out[0].containerAppNames).toEqual(['AppOne', 'AppTwo']);
   });
 
   it('still renders nodes when benchmarks are unavailable', () => {

--- a/client/src/runningAppsCategorized.js
+++ b/client/src/runningAppsCategorized.js
@@ -1,0 +1,96 @@
+import { buildCategoryTop } from 'fluxinfo';
+
+// Recognised via specIndex only now (issue #187 removed the docker image
+// fluxinfo used to report, so these can no longer be image-substring
+// matches — they're resolved by joining the running app's NAME to its
+// globalappsspecifications repotag, same source AppsSection/WorkhorsePanel
+// already trust for this).
+const WORDPRESS_REPO_BASE = 'runonflux/wp-nginx';
+const STREAMR_REPO_BASE = (process.env.REACT_APP_STREAMR || 'streamr/broker-node:latest').split(':')[0];
+const PRESEARCH_REPO_BASE = (process.env.REACT_APP_PRE_SEARCH || 'presearch/node:latest').split(':')[0];
+
+/**
+ * Join fluxinfo's running-app tally (name-keyed, since fluxinfo no longer
+ * reports an image — issue #187) against a globalappsspecifications index
+ * (name -> {repotag, category, ...}, from appSpecs.js's buildSpecIndex) to
+ * recover everything the old image-based aggregation used to compute.
+ *
+ * Grouping happens by REPOTAG, not by app name: Flux app names are unique
+ * per deployment (FoldingAtRunOnFlux13, palworld1786553912828, ...), so
+ * grouping by name would scatter one popular image's ~thousands of
+ * instances into as many single-count rows. A running app whose spec isn't
+ * in the index (e.g. it expired between the two independent fetches) falls
+ * back to being grouped under its own name rather than silently dropped, so
+ * its containers still count toward totals — just not toward any specific
+ * image's popularity ranking.
+ */
+export function categorizeRunningApps(aggregate, specIndex) {
+  const nameCounts = aggregate?.nameCounts || {};
+  const index = specIndex || {};
+
+  const runningCategoryMap = {};
+  const categoryImages = {}; // [category][repotagOrName] -> count, feeds buildCategoryTop
+  const repoCounts = {}; // repotag -> count, for topRunningApps (unresolved names excluded — see below)
+  let totalRunningApps = 0;
+
+  for (const [name, count] of Object.entries(nameCounts)) {
+    totalRunningApps += count;
+
+    const spec = index[name];
+    const category = spec?.category || 'other';
+    runningCategoryMap[category] = (runningCategoryMap[category] || 0) + count;
+
+    const repotag = spec?.repotag || '';
+    const imageKey = repotag ? repotag.split(':')[0] : name;
+    categoryImages[category] = categoryImages[category] || {};
+    categoryImages[category][imageKey] = (categoryImages[category][imageKey] || 0) + count;
+
+    if (repotag) {
+      repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
+    }
+  }
+
+  const topRunningApps = Object.entries(repoCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([image, nodeCount]) => ({ image, nodeCount }));
+
+  // Count wordpress containers by iterating over nameCounts (since every app can run anywhere)
+  let wordpressCount = 0;
+  for (const [name, count] of Object.entries(nameCounts)) {
+    const repotag = index[name]?.repotag || '';
+    const repoBase = repotag.split(':')[0];
+    if (repoBase === WORDPRESS_REPO_BASE) {
+      wordpressCount += count;
+    }
+  }
+
+  // Count streamr/presearch once per NODE that hosts them (from nodesByIp)
+  let streamrNodes = 0;
+  let presearchNodes = 0;
+
+  for (const node of Object.values(aggregate?.nodesByIp || {})) {
+    let hasStreamr = false;
+    let hasPresearch = false;
+
+    for (const name of node.containerAppNames || []) {
+      const repotag = index[name]?.repotag || '';
+      const repoBase = repotag.split(':')[0];
+      if (repoBase === STREAMR_REPO_BASE) hasStreamr = true;
+      if (repoBase === PRESEARCH_REPO_BASE) hasPresearch = true;
+    }
+
+    if (hasStreamr) streamrNodes++;
+    if (hasPresearch) presearchNodes++;
+  }
+
+  return {
+    runningCategoryMap,
+    runningCategoryTop: buildCategoryTop(categoryImages),
+    topRunningApps,
+    wordpressCount,
+    streamrRunningApps: streamrNodes,
+    presearchRunningApps: presearchNodes,
+    totalRunningApps
+  };
+}

--- a/client/src/runningAppsCategorized.js
+++ b/client/src/runningAppsCategorized.js
@@ -1,4 +1,6 @@
-import { buildCategoryTop } from 'fluxinfo';
+import { buildCategoryTop, splitComponentCountKey } from 'fluxinfo';
+import { repotagForComponent } from 'appSpecs';
+import { isOpaqueRuntimeImage } from 'main/Gamification/appCategories';
 
 // Recognised via specIndex only now (issue #187 removed the docker image
 // fluxinfo used to report, so these can no longer be image-substring
@@ -12,8 +14,25 @@ const PRESEARCH_REPO_BASE = (process.env.REACT_APP_PRE_SEARCH || 'presearch/node
 /**
  * Join fluxinfo's running-app tally (name-keyed, since fluxinfo no longer
  * reports an image — issue #187) against a globalappsspecifications index
- * (name -> {repotag, category, ...}, from appSpecs.js's buildSpecIndex) to
- * recover everything the old image-based aggregation used to compute.
+ * (name -> {repotag, category, compose, ...}, from appSpecs.js's
+ * buildSpecIndex) to recover everything the old image-based aggregation used
+ * to compute.
+ *
+ * Two tallies come out of fluxinfo and they are used for different things:
+ *
+ *   nameCounts      app-level, one entry per running container. Feeds the
+ *                   category map, which is app-level by construction —
+ *                   categorizeAppSpec already scans every compose component
+ *                   for the first keyword match, so an app has one category
+ *                   however many components it runs.
+ *   componentCounts the same containers keyed by app name AND component, so
+ *                   an image-level figure (Top Hosted Apps, the WordPress and
+ *                   streamr/presearch tallies) resolves the repotag of the
+ *                   component the container actually IS. Reading these off
+ *                   nameCounts instead attributed every container of a compose
+ *                   app to compose[0]'s image, which triple-counted the
+ *                   3-component WordPress deployments and hid the other two
+ *                   components' images from the ranking entirely.
  *
  * Grouping happens by REPOTAG, not by app name: Flux app names are unique
  * per deployment (FoldingAtRunOnFlux13, palworld1786553912828, ...), so
@@ -26,27 +45,46 @@ const PRESEARCH_REPO_BASE = (process.env.REACT_APP_PRE_SEARCH || 'presearch/node
  */
 export function categorizeRunningApps(aggregate, specIndex) {
   const nameCounts = aggregate?.nameCounts || {};
+  const componentCounts = aggregate?.componentCounts || {};
   const index = specIndex || {};
 
   const runningCategoryMap = {};
   const categoryImages = {}; // [category][repotagOrName] -> count, feeds buildCategoryTop
-  const repoCounts = {}; // repotag -> count, for topRunningApps (unresolved names excluded — see below)
   let totalRunningApps = 0;
 
   for (const [name, count] of Object.entries(nameCounts)) {
     totalRunningApps += count;
 
     const spec = index[name];
-    const category = spec?.category || 'other';
+    // runonflux/orbit is Flux's git-deployment wrapper: the real workload
+    // inside it is opaque, so categorising it by the operator's arbitrary
+    // deployment name is misleading. Pre-#187 aggregation forced these to
+    // 'other'; restore that here rather than in the shared categorizeAppSpec,
+    // which other pages (AppsSection, networkCategories) have never applied
+    // it to and whose behaviour is not this branch's to change.
+    const category = isOpaqueRuntimeImage(spec?.repotag) ? 'other' : spec?.category || 'other';
     runningCategoryMap[category] = (runningCategoryMap[category] || 0) + count;
 
+    // App-level repotag (compose[0], or the spec's own for single-component
+    // apps) — this loop has no per-container component context by design.
     const repotag = spec?.repotag || '';
     const imageKey = repotag ? repotag.split(':')[0] : name;
     categoryImages[category] = categoryImages[category] || {};
     categoryImages[category][imageKey] = (categoryImages[category][imageKey] || 0) + count;
+  }
 
-    if (repotag) {
-      repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
+  // Image-level tallies, resolved per component (see the note above).
+  const repoCounts = {}; // repotag -> count, for topRunningApps (unresolved names excluded)
+  let wordpressCount = 0;
+
+  for (const [key, count] of Object.entries(componentCounts)) {
+    const { name, component } = splitComponentCountKey(key);
+    const repotag = repotagForComponent(index[name], component);
+    if (!repotag) continue;
+
+    repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
+    if (repotag.split(':')[0] === WORDPRESS_REPO_BASE) {
+      wordpressCount += count;
     }
   }
 
@@ -55,26 +93,21 @@ export function categorizeRunningApps(aggregate, specIndex) {
     .slice(0, 10)
     .map(([image, nodeCount]) => ({ image, nodeCount }));
 
-  // Count wordpress containers by iterating over nameCounts (since every app can run anywhere)
-  let wordpressCount = 0;
-  for (const [name, count] of Object.entries(nameCounts)) {
-    const repotag = index[name]?.repotag || '';
-    const repoBase = repotag.split(':')[0];
-    if (repoBase === WORDPRESS_REPO_BASE) {
-      wordpressCount += count;
-    }
-  }
-
-  // Count streamr/presearch once per NODE that hosts them (from nodesByIp)
+  // Count streamr/presearch once per NODE that hosts them (from nodesByIp).
+  // containerComponents is index-aligned with containerAppNames, so container
+  // i resolves against its own component's repotag; a node counts once no
+  // matter how many of its containers match.
   let streamrNodes = 0;
   let presearchNodes = 0;
 
   for (const node of Object.values(aggregate?.nodesByIp || {})) {
     let hasStreamr = false;
     let hasPresearch = false;
+    const names = node.containerAppNames || [];
+    const components = node.containerComponents || [];
 
-    for (const name of node.containerAppNames || []) {
-      const repotag = index[name]?.repotag || '';
+    for (let i = 0; i < names.length; i++) {
+      const repotag = repotagForComponent(index[names[i]], components[i] || null);
       const repoBase = repotag.split(':')[0];
       if (repoBase === STREAMR_REPO_BASE) hasStreamr = true;
       if (repoBase === PRESEARCH_REPO_BASE) hasPresearch = true;

--- a/client/src/runningAppsCategorized.test.js
+++ b/client/src/runningAppsCategorized.test.js
@@ -1,0 +1,74 @@
+import { categorizeRunningApps } from './runningAppsCategorized';
+
+const specIndex = {
+  FoldingAtRunOnFlux1: { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  FoldingAtRunOnFlux2: { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  wordpress123: { repotag: 'runonflux/wp-nginx:latest', category: 'web' },
+  streamr1: { repotag: 'streamr/broker-node:latest', category: 'other' },
+  Presearch: { repotag: 'presearch/node:latest', category: 'other' },
+  minecraft1: { repotag: 'itzg/minecraft-server:latest', category: 'gaming' },
+};
+
+const aggregate = {
+  nameCounts: {
+    FoldingAtRunOnFlux1: 1,
+    FoldingAtRunOnFlux2: 1,
+    wordpress123: 1,
+    streamr1: 1,
+    Presearch: 1,
+    minecraft1: 1,
+    unknownApp: 2, // not in specIndex — must not throw, must not silently vanish
+  },
+  nodesByIp: {
+    '1.2.3.4:16127': { containerAppNames: ['streamr1', 'FoldingAtRunOnFlux1'] },
+    '5.6.7.8:16127': { containerAppNames: ['Presearch'] },
+  },
+};
+
+describe('categorizeRunningApps', () => {
+  it('groups by repotag (not app name) so many instances of one image collapse into one bucket', () => {
+    const { runningCategoryMap } = categorizeRunningApps(aggregate, specIndex);
+    expect(runningCategoryMap.computing).toBe(2); // two Folding@Home instances, one category total
+  });
+
+  it('falls back to an "other" bucket for a running app whose spec is missing, without throwing', () => {
+    const { runningCategoryMap, totalRunningApps } = categorizeRunningApps(aggregate, specIndex);
+    expect(runningCategoryMap.other).toBeGreaterThanOrEqual(2); // unknownApp's 2 containers land somewhere, not dropped
+    expect(totalRunningApps).toBe(8); // sum of every nameCounts value, unknownApp included
+  });
+
+  it('ranks topRunningApps by repotag popularity, most-instances first', () => {
+    const { topRunningApps } = categorizeRunningApps(aggregate, specIndex);
+    const folding = topRunningApps.find((r) => r.image === 'yurinnick/folding-at-home:latest');
+    expect(folding.nodeCount).toBe(2);
+  });
+
+  it('counts wordpress by resolved repotag, not by the (arbitrary) app name', () => {
+    const { wordpressCount } = categorizeRunningApps(aggregate, specIndex);
+    expect(wordpressCount).toBe(1);
+  });
+
+  it('counts streamr/presearch once per NODE that hosts one, not once per container', () => {
+    const twoOnOneNode = {
+      nameCounts: { streamr1: 2 },
+      nodesByIp: { '1.1.1.1:1': { containerAppNames: ['streamr1', 'streamr1'] } },
+    };
+    const { streamrRunningApps } = categorizeRunningApps(twoOnOneNode, specIndex);
+    expect(streamrRunningApps).toBe(1);
+  });
+
+  it('returns all-zero/empty output for an empty aggregate, without throwing', () => {
+    const result = categorizeRunningApps({ nameCounts: {}, nodesByIp: {} }, {});
+    expect(result.runningCategoryMap).toEqual({});
+    expect(result.topRunningApps).toEqual([]);
+    expect(result.totalRunningApps).toBe(0);
+    expect(result.wordpressCount).toBe(0);
+    expect(result.streamrRunningApps).toBe(0);
+    expect(result.presearchRunningApps).toBe(0);
+  });
+
+  it('does not throw when nodesByIp or specIndex is missing entirely', () => {
+    expect(() => categorizeRunningApps({ nameCounts: { a: 1 } }, undefined)).not.toThrow();
+    expect(() => categorizeRunningApps({}, {})).not.toThrow();
+  });
+});

--- a/client/src/runningAppsCategorized.test.js
+++ b/client/src/runningAppsCategorized.test.js
@@ -9,6 +9,9 @@ const specIndex = {
   minecraft1: { repotag: 'itzg/minecraft-server:latest', category: 'gaming' },
 };
 
+// Every app in this fixture is single-component, so each componentCounts key
+// carries an empty component half — the exact shape fluxinfo produces for
+// `/flux<appname>` containers.
 const aggregate = {
   nameCounts: {
     FoldingAtRunOnFlux1: 1,
@@ -19,9 +22,18 @@ const aggregate = {
     minecraft1: 1,
     unknownApp: 2, // not in specIndex — must not throw, must not silently vanish
   },
+  componentCounts: {
+    'FoldingAtRunOnFlux1\u0000': 1,
+    'FoldingAtRunOnFlux2\u0000': 1,
+    'wordpress123\u0000': 1,
+    'streamr1\u0000': 1,
+    'Presearch\u0000': 1,
+    'minecraft1\u0000': 1,
+    'unknownApp\u0000': 2,
+  },
   nodesByIp: {
-    '1.2.3.4:16127': { containerAppNames: ['streamr1', 'FoldingAtRunOnFlux1'] },
-    '5.6.7.8:16127': { containerAppNames: ['Presearch'] },
+    '1.2.3.4:16127': { containerAppNames: ['streamr1', 'FoldingAtRunOnFlux1'], containerComponents: [null, null] },
+    '5.6.7.8:16127': { containerAppNames: ['Presearch'], containerComponents: [null] },
   },
 };
 
@@ -51,14 +63,15 @@ describe('categorizeRunningApps', () => {
   it('counts streamr/presearch once per NODE that hosts one, not once per container', () => {
     const twoOnOneNode = {
       nameCounts: { streamr1: 2 },
-      nodesByIp: { '1.1.1.1:1': { containerAppNames: ['streamr1', 'streamr1'] } },
+      componentCounts: { 'streamr1\u0000': 2 },
+      nodesByIp: { '1.1.1.1:1': { containerAppNames: ['streamr1', 'streamr1'], containerComponents: [null, null] } },
     };
     const { streamrRunningApps } = categorizeRunningApps(twoOnOneNode, specIndex);
     expect(streamrRunningApps).toBe(1);
   });
 
   it('returns all-zero/empty output for an empty aggregate, without throwing', () => {
-    const result = categorizeRunningApps({ nameCounts: {}, nodesByIp: {} }, {});
+    const result = categorizeRunningApps({ nameCounts: {}, componentCounts: {}, nodesByIp: {} }, {});
     expect(result.runningCategoryMap).toEqual({});
     expect(result.topRunningApps).toEqual([]);
     expect(result.totalRunningApps).toBe(0);
@@ -70,5 +83,121 @@ describe('categorizeRunningApps', () => {
   it('does not throw when nodesByIp or specIndex is missing entirely', () => {
     expect(() => categorizeRunningApps({ nameCounts: { a: 1 } }, undefined)).not.toThrow();
     expect(() => categorizeRunningApps({}, {})).not.toThrow();
+  });
+});
+
+/*
+ * The regression this fix wave exists for.
+ *
+ * A WordPress deployment on Flux is one app running three containers — wp,
+ * mysql and an operator. Resolving each of those by APP NAME gave all three
+ * compose[0]'s image, so one deployment reported as three WordPress instances
+ * (258 network-wide against a true 86) and mysql/shared-db never appeared in
+ * Top Hosted Apps at all.
+ */
+describe('categorizeRunningApps with a multi-component (compose) app', () => {
+  const composeIndex = {
+    wordpressCompose1: {
+      repotag: 'runonflux/wp-nginx:latest', // compose[0], what the old code used for all three
+      category: 'web',
+      compose: [
+        { name: 'wp', repotag: 'runonflux/wp-nginx:latest' },
+        { name: 'mysql', repotag: 'mysql:8.3.0' },
+        { name: 'operator', repotag: 'runonflux/shared-db:latest' },
+      ],
+    },
+  };
+
+  const composeAggregate = {
+    nameCounts: { wordpressCompose1: 3 }, // three containers, one deployment
+    componentCounts: {
+      'wordpressCompose1\u0000wp': 1,
+      'wordpressCompose1\u0000mysql': 1,
+      'wordpressCompose1\u0000operator': 1,
+    },
+    nodesByIp: {
+      '1.2.3.4:16127': {
+        containerAppNames: ['wordpressCompose1', 'wordpressCompose1', 'wordpressCompose1'],
+        containerComponents: ['wp', 'mysql', 'operator'],
+      },
+    },
+  };
+
+  it('counts one WordPress instance for a 3-container deployment, not three', () => {
+    const { wordpressCount } = categorizeRunningApps(composeAggregate, composeIndex);
+    expect(wordpressCount).toBe(1);
+  });
+
+  it('ranks each component under its OWN image', () => {
+    const { topRunningApps } = categorizeRunningApps(composeAggregate, composeIndex);
+    const byImage = Object.fromEntries(topRunningApps.map((r) => [r.image, r.nodeCount]));
+    expect(byImage).toEqual({
+      'runonflux/wp-nginx:latest': 1,
+      'mysql:8.3.0': 1,
+      'runonflux/shared-db:latest': 1,
+    });
+  });
+
+  it('still counts every container toward the app-level category total', () => {
+    const { runningCategoryMap, totalRunningApps } = categorizeRunningApps(composeAggregate, composeIndex);
+    expect(runningCategoryMap.web).toBe(3); // category stays app-level, unchanged by this fix
+    expect(totalRunningApps).toBe(3);
+  });
+
+  it('detects streamr on the component that actually runs it, not just compose[0]', () => {
+    const index = {
+      bundle1: {
+        repotag: 'nginx:latest',
+        category: 'other',
+        compose: [
+          { name: 'front', repotag: 'nginx:latest' },
+          { name: 'broker', repotag: 'streamr/broker-node:latest' },
+        ],
+      },
+    };
+    const agg = {
+      nameCounts: { bundle1: 2 },
+      componentCounts: { 'bundle1\u0000front': 1, 'bundle1\u0000broker': 1 },
+      nodesByIp: {
+        '9.9.9.9:1': { containerAppNames: ['bundle1', 'bundle1'], containerComponents: ['front', 'broker'] },
+      },
+    };
+    expect(categorizeRunningApps(agg, index).streamrRunningApps).toBe(1);
+  });
+
+  it('falls back to the app-level repotag when a node carries no component info', () => {
+    // A cache entry written before containerComponents existed, or a spec
+    // updated mid-flight: resolution degrades to the old behaviour rather
+    // than dropping the node.
+    const agg = {
+      nameCounts: { streamr1: 1 },
+      componentCounts: { 'streamr1\u0000': 1 },
+      nodesByIp: { '1.1.1.1:1': { containerAppNames: ['streamr1'] } },
+    };
+    expect(categorizeRunningApps(agg, specIndex).streamrRunningApps).toBe(1);
+  });
+});
+
+/*
+ * runonflux/orbit is Flux's git-deployment wrapper: whatever it builds is
+ * opaque, so the operator's deployment name says nothing reliable about what
+ * the app does. The pre-#187 aggregation forced these to 'other'; that guard
+ * was lost when categories moved onto the spec index.
+ */
+describe('categorizeRunningApps opaque runtime images', () => {
+  it('puts a git-deployed (orbit) app in "other", not in whatever its name suggests', () => {
+    const index = { myMinecraftThing: { repotag: 'runonflux/orbit:latest', category: 'gaming' } };
+    const agg = { nameCounts: { myMinecraftThing: 4 }, componentCounts: { 'myMinecraftThing\u0000': 4 } };
+
+    const { runningCategoryMap } = categorizeRunningApps(agg, index);
+
+    expect(runningCategoryMap.other).toBe(4);
+    expect(runningCategoryMap.gaming).toBeUndefined();
+  });
+
+  it('leaves every other image categorised by its spec', () => {
+    const { runningCategoryMap } = categorizeRunningApps(aggregate, specIndex);
+    expect(runningCategoryMap.gaming).toBe(1); // minecraft1 is a real minecraft image
+    expect(runningCategoryMap.web).toBe(1);
   });
 });

--- a/docs/superpowers/plans/2026-09-09-fix-running-apps-categorization.md
+++ b/docs/superpowers/plans/2026-09-09-fix-running-apps-categorization.md
@@ -1,0 +1,1189 @@
+# Fix Running-App Categorization (Issue #187) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the Home page's running-app stats/categories, the Workhorse
+showcase's per-node category chips, and the Analytics Donor tab's "apps by
+category" panel, all of which silently broke when `stats.runonflux.io/fluxinfo`
+stopped returning a docker `Image` field on `apps.runningapps[]` entries
+(GitHub issue #187) — by re-deriving category/repotag from the app **name**
+joined against `globalappsspecifications` (which still has the real repotag),
+instead of matching a docker image string that the API no longer sends.
+
+**Architecture:** `fluxinfo.js`'s aggregation step can only recover the app
+**name** from each running container now (via the existing
+`appNameFromContainer`), not its image. A new pure module joins those names
+against a name-keyed index of `globalappsspecifications` (built with the
+existing `buildSpecIndex` helper) to recover repotag/category exactly the way
+`AppsSection` and `WorkhorsePanel`'s per-app table already do. Getting that
+index into the running-apps aggregation step safely (without racing the
+already-cached, block-height-dependent `fetch_global_app_specs` call) requires
+splitting that function's cache into a safe raw-specs cache plus a
+recompute-every-call layer on top.
+
+**Tech Stack:** React 18 (CRA), plain JS data modules under `client/src/`,
+Jest + `@testing-library` via `react-scripts test`.
+
+**Spec:** GitHub issue #187 (`gh issue view 187 --repo 2ndtlmining/Fluxnode`).
+No separate spec doc — this plan doubles as the spec write-up because the
+investigation (which files are actually affected) *is* most of the work; see
+"Investigation findings" below, which every task assumes as read.
+
+## Investigation findings (read first)
+
+Confirmed live against the real APIs on 2026-09-09:
+
+- `curl 'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps,ip'`
+  — every `runningapps[]` entry now has only `Names`, `State`, `Status`. No
+  `Image` field anywhere in a fresh ~7,200-container sample. This matches the
+  issue's screenshot exactly.
+- `curl 'http://<a live node>:<port>/apps/installedapps'` — **unchanged**,
+  still returns full specs with `compose[].repotag`. This is the endpoint the
+  Rust API's `/api/v1/node-single/` uses (`api/src/core.rs:54`,
+  `apps/installedapps`) and what `client/src/main/AppsSection/index.jsx` (the
+  Node page's Apps tab) is built on, joined against
+  `globalappsspecifications` for category. **Neither is touched by this
+  issue.** The issue's suspicion that the Node page's Apps tab and its
+  GitHub-vs-Docker icon would break does not hold up — no code change needed
+  there. Confirmed no other file under `client/src/` reads
+  `apps.runningapps.Image`; `grep -rn "\.Image\b" client/src` matches only
+  `fluxinfo.js` and its own test file.
+- The Live page (`client/src/live/`) is **also unaffected**. Its deploy/
+  confirm/reward event `repos` field comes from diffing successive
+  `globalappsspecifications` snapshots (`live/apidata.js`'s `composeRepos()`),
+  never from `fluxinfo`'s `runningapps`. `grep -rn "fluxinfo\|runningapps"
+  client/src/live` returns nothing.
+- Every actually-broken consumer traces back to one root: `client/src/
+  fluxinfo.js`'s `_fluxinfo_aggregate()` reads `app.Image`, which is now
+  always `undefined`. That empties `imageCounts` and every per-node `images`
+  array, which breaks, in order of visibility:
+  1. **Home page** (`/home`) — App Ecosystem panel (permanently "unavailable"),
+     Top Hosted Apps panel (**stuck on an infinite spinner** — worst of the
+     regressions, no error shown at all), header stat cells "Total Running
+     Apps instances" (silently **inflated** — watchtower no longer
+     subtracted), "Presearch/Streamr Running Apps" and "Wordpress Instances"
+     (all silently **0**), and the Workhorse showcase's per-node "Categories"
+     row (empty; the per-app name/repo/cpu/ram/ssd table next to it is fine —
+     it already joins by app name against specs).
+  2. **Analytics Apps tab** (`/analytics`) — reuses the exact same
+     `AppEcosystemBreakdown`/`TopHostedApps` components as Home (PR #173), so
+     it breaks identically.
+  3. **Analytics Donor tab** — `analytics/donorApps.js`'s
+     `aggregateDonorAppsByCategory` reads `nodesByIp[ip].images`, always
+     empty now, so a donor's own "apps by category" panel shows nothing.
+  4. Analytics Network/Chain Activity tabs are unaffected (owner/geolocation
+     fields and the Rust-side block scanner, no relation to `runningapps`).
+- Live-verified an important detail for the fix design: `appNameFromContainer`
+  already returns `null` for `/watchtower` (it requires a `flux`-prefixed
+  container name; watchtower's isn't), and a live scan of ~7,200 running
+  containers found **zero** matching `watchtower` by name either — so
+  watchtower containers are not present in this projection at all (whether
+  historically or now). `totalRunningApps` can safely become "containers
+  whose app name we could resolve" instead of "total minus an image match we
+  can no longer make" — see Task 4.
+- Grouping running containers by **app name** instead of image would badly
+  under-count popular apps: Flux app names are per-deployment-unique (e.g.
+  `FoldingAtRunOnFlux13`, `palworld1786553912828`), so ~2,400 Folding@Home
+  instances that used to collapse into one `yurinnick/folding-at-home:latest`
+  bucket would otherwise show as ~2,400 separate rows of count 1. The fix
+  must join name → spec → **repotag** before bucketing, not bucket by name
+  directly.
+
+## Global Constraints
+
+- No Rust/API changes — this is 100% client-side (`client/src/`); the Rust
+  API never touched `apps.runningapps` (confirmed: `grep -rn "runningapps"
+  api/src` is empty).
+- Test with `cd client && CI=true npx react-scripts test --watchAll=false`,
+  build with `npx react-scripts build`. Baseline before this plan: 317 tests,
+  build exit 0, exactly 4 pre-existing baseline warning files (Navbar/
+  index.jsx, NodeGridTable/index.jsx, LayoutContext.jsx, WalletNodes/
+  index.jsx) — anything beyond those four post-build is new work to fix.
+  Every task below ends by running the suite; only the final task builds.
+- Preserve every existing field name on `gstore` that downstream components
+  already read unless a task explicitly says to rename it (renames are
+  called out with every call site that must change).
+- Do not re-introduce the #144 regression: never silently fall back to
+  `globalappsspecifications`-derived counts as a *replacement* dataset when
+  `fluxinfo` is down — `runningAppsStatus`/`runningAppsFetchedAt` stay the
+  single source of truth for "is this live/stale/unavailable", untouched by
+  this plan.
+- `client/public/runtime/app-content.js`'s `PREMIUM_TESTING_MODE` toggle:
+  flip to `true` for local manual testing of the Donor tab, **always revert
+  to `false` before committing**.
+
+---
+
+## File Structure
+
+- Modify: `client/src/fluxinfo.js` — drop `Image` projection/parsing, emit
+  per-container app names instead of per-container images.
+- Modify: `client/src/fluxinfoResilience.test.js` — update fixtures/
+  assertions for the new field names.
+- Modify: `client/src/apidata.js` — split `fetch_global_app_specs`'s cache
+  so a safe, block-height-independent raw-specs layer can be reused from
+  `fetchTotalDeployedApps`; wire the new categorization module in; rename
+  `topRunningImages` → `topRunningApps`.
+- Create: `client/src/runningAppsCategorized.js` — the new pure join/
+  categorization module.
+- Create: `client/src/runningAppsCategorized.test.js` — its unit tests.
+- Modify: `client/src/home/WorkhorsePanel/index.jsx` — per-node "Categories"
+  row, joined by name instead of by (gone) image.
+- Modify: `client/src/components/TopHostedApps/index.jsx` — one-line field
+  rename to match `topRunningApps`.
+- Modify: `client/src/analytics/donorApps.js` — join by name against a spec
+  index instead of reading `.images`.
+- Modify: `client/src/analytics/donorApps.test.js` — update fixtures.
+- Modify: `client/src/analytics/DonorTab/index.jsx` — fetch the (now cheap,
+  shared-cache) raw specs alongside its existing fetches, pass the index in.
+
+---
+
+### Task 1: `fluxinfo.js` — stop depending on the removed `Image` field
+
+**Files:**
+- Modify: `client/src/fluxinfo.js`
+- Test: `client/src/fluxinfoResilience.test.js`
+
+**Interfaces:**
+- Produces: `fetch_fluxinfo_aggregate()`'s resolved `aggregate` now has
+  `nameCounts` (object, app name → running-container count) instead of
+  `imageCounts`; drops `watchtowerContainers`, `wordpressContainers`,
+  `streamrNodes`, `presearchNodes` (moved to Task 3, which needs spec data
+  this module doesn't have); each `nodesByIp`/`topNodesByApps` entry's
+  `images: string[]` field is renamed to `containerAppNames: string[]` (same
+  one-entry-per-running-container shape, now holding names instead of
+  images). `appNames` (deduped) and `appCount` on those entries are
+  unchanged.
+
+- [ ] **Step 1: Update the projection URL and write the failing aggregation test**
+
+Edit the `FLUXINFO_URL` constant (line 26) to drop the now-nonexistent
+`Image` field:
+
+```js
+const FLUXINFO_URL =
+  'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Names,ip,tier';
+```
+
+Bump the cache key version since the aggregate shape changes (matches the
+existing convention — `v3` bumped to `v4` for the same reason):
+
+```js
+const FLUXINFO_CACHE_KEY = 'fluxinfoAggregate_v5'; // v5: Image field removed from the API (#187) — imageCounts replaced by nameCounts, per-node `images` renamed `containerAppNames`
+const FLUXINFO_STALE_KEYS = ['fluxinfoAggregate_v1', 'fluxinfoAggregate_v2', 'fluxinfoAggregate_v3', 'fluxinfoAggregate_v4'];
+```
+
+In `client/src/fluxinfoResilience.test.js`, replace the `NODES` and
+`NODES_WITH_IP` fixtures (they currently carry `Image`, which the real API no
+longer sends) and the assertions that key off it:
+
+```js
+const NODES = [
+  { apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux1'] }, { Names: ['/fluxwp_wordpress123'] }] } },
+  { apps: { runningapps: [{ Names: ['/fluxPresearch'] }] } },
+  { apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux2'] }] } },
+];
+
+const NODES_WITH_IP = [
+  {
+    ip: '1.2.3.4:16127',
+    tier: 'CUMULUS',
+    apps: { runningapps: [{ Names: ['/fluxFoldingAtHome_FoldingAtRunOnFlux1'] }] },
+  },
+  {
+    ip: '5.6.7.8:16127',
+    tier: 'STRATUS',
+    apps: { runningapps: [] },
+  },
+];
+```
+
+Update the first test (`'aggregates a successful response and reports it as
+live'`) to match — the watchtower/wordpress/streamr/presearch counters no
+longer exist on this module's aggregate:
+
+```js
+  it('aggregates a successful response and reports it as live', async () => {
+    global.fetch = jest.fn().mockResolvedValue(okResponse(NODES));
+
+    const { aggregate, status } = await fetch_fluxinfo_aggregate();
+
+    expect(status).toBe('live');
+    expect(aggregate.totalContainers).toBe(4);
+    expect(aggregate.nodesReporting).toBe(3);
+    expect(aggregate.nameCounts.FoldingAtRunOnFlux1).toBe(1);
+    expect(aggregate.nameCounts.FoldingAtRunOnFlux2).toBe(1);
+    expect(aggregate.nameCounts.wordpress123).toBe(1);
+  });
+```
+
+Delete the `wordpressContainers`/`presearchNodes` assertions from the
+`'retries and succeeds...'` test (keep only `totalContainers`, already the
+case). In `'does not throw when a node reports without apps.runningapps'`,
+the fixture already reuses `NODES`, no change needed beyond the fixture edit
+above. In the `'ignores a cache entry older than the stale window'` test,
+change the seeded stale cache payload's shape from `imageCounts` to
+`nameCounts` (either key works to prove staleness is ignored, but keep it
+truthful):
+
+```js
+      JSON.stringify({
+        aggregate: { nameCounts: { busybox: 1 }, totalContainers: 1 },
+        timestamp: Date.now() - 7 * 60 * 60 * 1000, // window is 6h
+      })
+```
+
+In the `nodesByIp` describe block, change the `images` assertion:
+
+```js
+    expect(aggregate.nodesByIp['1.2.3.4:16127'].containerAppNames).toEqual(['FoldingAtRunOnFlux1']);
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern fluxinfoResilience`
+Expected: FAIL — `aggregate.nameCounts` is undefined, `containerAppNames` is undefined (the implementation hasn't changed yet).
+
+- [ ] **Step 3: Update `_fluxinfo_aggregate()`**
+
+Replace the body of `_fluxinfo_aggregate` (currently lines 77-175) with:
+
+```js
+function _fluxinfo_aggregate(nodes) {
+  // Per-app-name running-container tally. Category/repotag/watchtower/
+  // wordpress/streamr/presearch detection all used to be image-substring
+  // matches done right here — fluxinfo no longer reports an image at all
+  // (issue #187), so none of that can happen in this module any more. It now
+  // moves to runningAppsCategorized.js, which joins this name-keyed tally
+  // against globalappsspecifications (still has the real repotag) once both
+  // are available. This module stays a pure, spec-agnostic reader of
+  // fluxinfo, same as before.
+  const nameCounts = {};
+  const perNode = [];
+  let totalContainers = 0;
+
+  for (const item of nodes) {
+    const running = Array.isArray(item?.apps?.runningapps) ? item.apps.runningapps : [];
+    totalContainers += running.length;
+
+    // One name per container, NOT deduped — a 3-component compose app
+    // contributes its app name 3 times, matching the pre-#187 per-container
+    // imageCounts convention (each component counted once).
+    const containerAppNames = running
+      .map((a) => appNameFromContainer(Array.isArray(a?.Names) ? a.Names[0] : null))
+      .filter(Boolean);
+
+    for (const name of containerAppNames) {
+      nameCounts[name] = (nameCounts[name] || 0) + 1;
+    }
+
+    const ip = typeof item?.ip === 'string' ? item.ip : '';
+    if (ip && running.length > 0) {
+      perNode.push({
+        ip,
+        tier: typeof item?.tier === 'string' ? item.tier : null,
+        containerCount: running.length,
+        containerAppNames,
+        appNames: [],
+      });
+
+      const names = [...new Set(containerAppNames)];
+      const entry = perNode[perNode.length - 1];
+      entry.appNames = names;
+      entry.appCount = names.length || running.length;
+    }
+  }
+
+  perNode.sort((a, b) => b.appCount - a.appCount || a.ip.localeCompare(b.ip));
+  const topNodesByApps = perNode.slice(0, TOP_NODES_KEPT);
+
+  const nodesByIp = {};
+  for (const entry of perNode) {
+    nodesByIp[entry.ip.trim()] = entry;
+  }
+
+  return {
+    nameCounts,
+    totalContainers,
+    topNodesByApps,
+    nodesByIp,
+    nodesReporting: nodes.length
+  };
+}
+```
+
+Remove the now-unused `streamrImage`/`presearchImage` env-var reads from the
+top of the old function body (they move to Task 3, which is where the
+join against specs happens) — they are no longer referenced anywhere in this
+file.
+
+Also update `_fluxinfo_read_cache()`'s guard (currently `if
+(!cached?.aggregate?.imageCounts) return null;`) to check the new field:
+
+```js
+    if (!cached?.aggregate?.nameCounts) return null;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern fluxinfoResilience`
+Expected: PASS, all tests in this file green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/fluxinfo.js client/src/fluxinfoResilience.test.js
+git commit -m "fix(fluxinfo): stop reading the removed Image field, tally by app name (#187)"
+```
+
+---
+
+### Task 2: `apidata.js` — split the app-specs cache so a raw layer is safe to call twice
+
+**Files:**
+- Modify: `client/src/apidata.js:1309-1406` (the `fetch_global_app_specs`
+  region)
+- Test: `client/src/apidata.test.js` (new `describe` block)
+
+**Interfaces:**
+- Produces: `fetch_global_app_specs_raw()` — new export, `async () =>
+  Array<spec>`, in-flight-deduped and sessionStorage-cached (5 min TTL),
+  returning the raw `globalappsspecifications` array with no block-height-
+  dependent computation, so it is safe to call from more than one place at
+  more than one point in a page load without ever serving a stale
+  `expiringToday`/`deployedToday`. `fetch_global_app_specs(gstore)` keeps its
+  existing signature and return shape (`{expiringToday, deployedToday,
+  networkCategories, rawSpecs}`), now built by calling
+  `fetch_global_app_specs_raw()` internally and computing the block-height-
+  dependent fields fresh on every call instead of caching them.
+- Consumes: nothing new (same `categorizeAppSpec`, `specResources` imports
+  already present in this file).
+
+Why this task exists: Task 4 needs a name→spec index inside
+`fetchTotalDeployedApps()`, which runs concurrently with `fetchDaemonInfo()`
+in the same `Promise.all` in `fetch_global_stats` — so `store.fluxBlockHeight`
+is not reliably set yet at that point. The *existing*
+`fetch_global_app_specs(gstore)` caches its whole computed result, including
+`expiringToday`/`deployedToday`, which depend on that block height. Calling
+it a second time per page load (as Task 4 will) risks caching a result
+computed with `fluxBlockHeight: 0` and then Home.jsx's own later, correct
+call reading that same wrong cached result back within the 5-minute TTL —
+breaking the Expiring/Deployed Today panels. Splitting the cache so only the
+height-independent raw array is cached removes that risk entirely, for every
+caller (`AppsSection`, `AppsTab`, `Live.jsx`, `Home.jsx`, and the new call in
+Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `client/src/apidata.test.js`:
+
+```js
+import { fetch_global_app_specs, fetch_global_app_specs_raw } from './apidata';
+
+describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
+  const SPECS = [{ name: 'appA', height: 100, compose: [{ repotag: 'someimage/app:latest', cpu: 1, ram: 512, hdd: 5 }] }];
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('fetch_global_app_specs_raw returns the raw spec array', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+    const raw = await fetch_global_app_specs_raw();
+    expect(raw).toEqual(SPECS);
+  });
+
+  it('shares one in-flight request between concurrent callers', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+    const [a, b] = await Promise.all([fetch_global_app_specs_raw(), fetch_global_app_specs_raw()]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it('recomputes expiringToday/deployedToday fresh from the block height on every call, never from a stale cached value', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'success', data: SPECS }) });
+
+    // First call at block height 0 (the race this task exists to fix):
+    // appA is not "deployed today" because there is no reliable height yet.
+    const first = await fetch_global_app_specs({ fluxBlockHeight: 0 });
+    expect(first.deployedToday).toEqual([]);
+
+    // Second call moments later, same 5-minute cache window, but with the
+    // real block height available — must NOT read back the first call's
+    // (wrong) cached deployedToday.
+    const second = await fetch_global_app_specs({ fluxBlockHeight: 100 });
+    expect(second.deployedToday).toHaveLength(1);
+    expect(second.deployedToday[0].name).toBe('appA');
+
+    // Only one network fetch for both calls — the raw array is what's shared.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern apidata.test`
+Expected: FAIL — `fetch_global_app_specs_raw` is not exported yet.
+
+- [ ] **Step 3: Implement the split**
+
+Replace lines 1309-1406 of `client/src/apidata.js` (the
+`HOME_APP_SPECS_CACHE_KEY` constant through the end of `fetch_global_app_specs`)
+with:
+
+```js
+const RAW_APP_SPECS_CACHE_KEY = 'homeAppSpecsRaw_v1';
+const RAW_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const RAW_APP_SPECS_STALE_KEYS = ['homeAppSpecs_v2']; // old key cached the full computed (height-dependent) result
+
+let _rawAppSpecsInFlight = null;
+
+function _prune_stale_app_spec_caches() {
+  for (const key of RAW_APP_SPECS_STALE_KEYS) {
+    try {
+      sessionStorage.removeItem(key);
+    } catch {}
+  }
+}
+
+/*
+ * Raw globalappsspecifications array only — no block-height-dependent
+ * computation, so this is safe to cache and safe to call from more than one
+ * place in a page load. fetch_global_app_specs() below layers the height-
+ * dependent expiring/deployed-today lists on top, recomputed fresh every
+ * call, specifically so a caller with a not-yet-populated fluxBlockHeight
+ * (fetchTotalDeployedApps runs concurrently with fetchDaemonInfo) can never
+ * poison this cache with a wrong result that a later, correct caller then
+ * reads back within the TTL.
+ */
+export async function fetch_global_app_specs_raw() {
+  _prune_stale_app_spec_caches();
+
+  try {
+    const raw = sessionStorage.getItem(RAW_APP_SPECS_CACHE_KEY);
+    if (raw) {
+      const cached = JSON.parse(raw);
+      if (cached && Date.now() - cached.timestamp < RAW_APP_SPECS_CACHE_TTL) {
+        return cached.data;
+      }
+    }
+  } catch {}
+
+  if (_rawAppSpecsInFlight) return _rawAppSpecsInFlight;
+
+  _rawAppSpecsInFlight = (async () => {
+    try {
+      const res = await fetch('https://api.runonflux.io/apps/globalappsspecifications');
+      const json = await res.json();
+      if (json.status === 'error' || !json.data) return [];
+
+      try {
+        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: json.data, timestamp: Date.now() }));
+      } catch {}
+
+      return json.data;
+    } catch (e) {
+      console.warn('[AppSpecs] Failed to fetch:', e);
+      return [];
+    }
+  })();
+
+  try {
+    return await _rawAppSpecsInFlight;
+  } finally {
+    _rawAppSpecsInFlight = null;
+  }
+}
+
+export async function fetch_global_app_specs(gstore) {
+  const specs = await fetch_global_app_specs_raw();
+  const empty = { expiringToday: [], deployedToday: [], networkCategories: [], rawSpecs: [] };
+  if (specs.length === 0) return empty;
+
+  const currentBlock = gstore.fluxBlockHeight || 0;
+  const expiringToday = [];
+  const deployedToday = [];
+  const categoryMap = {};
+
+  for (const spec of specs) {
+    const instances = spec.instances || 1;
+    const { cpuPerInst, ramGBPerInst, ssdGBPerInst } = specResources(spec);
+    const cat = categorizeAppSpec(spec);
+    categoryMap[cat] = (categoryMap[cat] || 0) + instances;
+
+    const specHeight = spec.height || 0;
+    const deployedAgeBlocks = currentBlock - specHeight;
+    const enriched = { ...spec, instances, cpuPerInst, ramGBPerInst, ssdGBPerInst, category: cat };
+
+    if (currentBlock > 0 && deployedAgeBlocks >= 0 && deployedAgeBlocks < BLOCKS_PER_DAY) {
+      deployedToday.push({ ...enriched, deployedAgeBlocks });
+    }
+
+    if (spec.expire) {
+      const expiryBlock = specHeight + spec.expire;
+      const expiresInBlocks = expiryBlock - currentBlock;
+      if (currentBlock > 0 && expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY) {
+        expiringToday.push({ ...enriched, expiresInBlocks });
+      }
+    }
+  }
+
+  expiringToday.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
+  deployedToday.sort((a, b) => a.deployedAgeBlocks - b.deployedAgeBlocks);
+
+  const networkCategories = Object.entries(categoryMap)
+    .map(([category, totalInstances]) => ({ category, totalInstances }))
+    .sort((a, b) => b.totalInstances - a.totalInstances);
+
+  return { expiringToday, deployedToday, networkCategories, rawSpecs: specs };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern apidata.test`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite to confirm no other caller broke**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: PASS, same count as baseline plus the new tests (`AppsSection`,
+`Live.jsx`, `AppsTab` all still call `fetch_global_app_specs` with the same
+signature and shape, unaffected by the internal split).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/apidata.js client/src/apidata.test.js
+git commit -m "refactor(apidata): split app-specs cache into a safe raw layer + fresh height-dependent recompute"
+```
+
+---
+
+### Task 3: `runningAppsCategorized.js` — join running-app names to specs
+
+**Files:**
+- Create: `client/src/runningAppsCategorized.js`
+- Test: `client/src/runningAppsCategorized.test.js`
+
+**Interfaces:**
+- Consumes: a fluxinfo `aggregate` shaped like Task 1's output
+  (`{nameCounts, nodesByIp, totalContainers, ...}`) and a `specIndex` shaped
+  like `appSpecs.js`'s existing `buildSpecIndex(rawSpecs)` output (`{[name]:
+  {repotag, category, cpuPerInst, ramGBPerInst, ssdGBPerInst, isEnterprise,
+  instances}}`).
+- Produces: `categorizeRunningApps(aggregate, specIndex)` →
+  `{runningCategoryMap, runningCategoryTop, topRunningApps, wordpressCount,
+  streamrRunningApps, presearchRunningApps, totalRunningApps}`, exact shapes
+  below.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `client/src/runningAppsCategorized.test.js`:
+
+```js
+import { categorizeRunningApps } from './runningAppsCategorized';
+
+const specIndex = {
+  FoldingAtRunOnFlux1: { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  FoldingAtRunOnFlux2: { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  wordpress123: { repotag: 'runonflux/wp-nginx:latest', category: 'web' },
+  streamr1: { repotag: 'streamr/broker-node:latest', category: 'other' },
+  Presearch: { repotag: 'presearch/node:latest', category: 'other' },
+  minecraft1: { repotag: 'itzg/minecraft-server:latest', category: 'gaming' },
+};
+
+const aggregate = {
+  nameCounts: {
+    FoldingAtRunOnFlux1: 1,
+    FoldingAtRunOnFlux2: 1,
+    wordpress123: 1,
+    streamr1: 1,
+    Presearch: 1,
+    minecraft1: 1,
+    unknownApp: 2, // not in specIndex — must not throw, must not silently vanish
+  },
+  nodesByIp: {
+    '1.2.3.4:16127': { containerAppNames: ['streamr1', 'FoldingAtRunOnFlux1'] },
+    '5.6.7.8:16127': { containerAppNames: ['Presearch'] },
+  },
+};
+
+describe('categorizeRunningApps', () => {
+  it('groups by repotag (not app name) so many instances of one image collapse into one bucket', () => {
+    const { runningCategoryMap } = categorizeRunningApps(aggregate, specIndex);
+    expect(runningCategoryMap.computing).toBe(2); // two Folding@Home instances, one category total
+  });
+
+  it('falls back to an "other" bucket for a running app whose spec is missing, without throwing', () => {
+    const { runningCategoryMap, totalRunningApps } = categorizeRunningApps(aggregate, specIndex);
+    expect(runningCategoryMap.other).toBeGreaterThanOrEqual(2); // unknownApp's 2 containers land somewhere, not dropped
+    expect(totalRunningApps).toBe(8); // sum of every nameCounts value, unknownApp included
+  });
+
+  it('ranks topRunningApps by repotag popularity, most-instances first', () => {
+    const { topRunningApps } = categorizeRunningApps(aggregate, specIndex);
+    const folding = topRunningApps.find((r) => r.image === 'yurinnick/folding-at-home:latest');
+    expect(folding.nodeCount).toBe(2);
+  });
+
+  it('counts wordpress by resolved repotag, not by the (arbitrary) app name', () => {
+    const { wordpressCount } = categorizeRunningApps(aggregate, specIndex);
+    expect(wordpressCount).toBe(1);
+  });
+
+  it('counts streamr/presearch once per NODE that hosts one, not once per container', () => {
+    const twoOnOneNode = {
+      nameCounts: { streamr1: 2 },
+      nodesByIp: { '1.1.1.1:1': { containerAppNames: ['streamr1', 'streamr1'] } },
+    };
+    const { streamrRunningApps } = categorizeRunningApps(twoOnOneNode, specIndex);
+    expect(streamrRunningApps).toBe(1);
+  });
+
+  it('returns all-zero/empty output for an empty aggregate, without throwing', () => {
+    const result = categorizeRunningApps({ nameCounts: {}, nodesByIp: {} }, {});
+    expect(result.runningCategoryMap).toEqual({});
+    expect(result.topRunningApps).toEqual([]);
+    expect(result.totalRunningApps).toBe(0);
+    expect(result.wordpressCount).toBe(0);
+    expect(result.streamrRunningApps).toBe(0);
+    expect(result.presearchRunningApps).toBe(0);
+  });
+
+  it('does not throw when nodesByIp or specIndex is missing entirely', () => {
+    expect(() => categorizeRunningApps({ nameCounts: { a: 1 } }, undefined)).not.toThrow();
+    expect(() => categorizeRunningApps({}, {})).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern runningAppsCategorized`
+Expected: FAIL — module does not exist yet.
+
+- [ ] **Step 3: Implement `runningAppsCategorized.js`**
+
+Create `client/src/runningAppsCategorized.js`:
+
+```js
+import { buildCategoryTop } from 'fluxinfo';
+
+// Recognised via specIndex only now (issue #187 removed the docker image
+// fluxinfo used to report, so these can no longer be image-substring
+// matches — they're resolved by joining the running app's NAME to its
+// globalappsspecifications repotag, same source AppsSection/WorkhorsePanel
+// already trust for this).
+const WORDPRESS_REPO_BASE = 'runonflux/wp-nginx';
+const STREAMR_REPO_BASE = (process.env.REACT_APP_STREAMR || 'streamr/broker-node:latest').split(':')[0];
+const PRESEARCH_REPO_BASE = (process.env.REACT_APP_PRE_SEARCH || 'presearch/node:latest').split(':')[0];
+
+/**
+ * Join fluxinfo's running-app tally (name-keyed, since fluxinfo no longer
+ * reports an image — issue #187) against a globalappsspecifications index
+ * (name -> {repotag, category, ...}, from appSpecs.js's buildSpecIndex) to
+ * recover everything the old image-based aggregation used to compute.
+ *
+ * Grouping happens by REPOTAG, not by app name: Flux app names are unique
+ * per deployment (FoldingAtRunOnFlux13, palworld1786553912828, ...), so
+ * grouping by name would scatter one popular image's ~thousands of
+ * instances into as many single-count rows. A running app whose spec isn't
+ * in the index (e.g. it expired between the two independent fetches) falls
+ * back to being grouped under its own name rather than silently dropped, so
+ * its containers still count toward totals — just not toward any specific
+ * image's popularity ranking.
+ */
+export function categorizeRunningApps(aggregate, specIndex) {
+  const nameCounts = aggregate?.nameCounts || {};
+  const index = specIndex || {};
+
+  const runningCategoryMap = {};
+  const categoryImages = {}; // [category][repotagOrName] -> count, feeds buildCategoryTop
+  const repoCounts = {}; // repotag -> count, for topRunningApps (unresolved names excluded — see below)
+  let totalRunningApps = 0;
+
+  for (const [name, count] of Object.entries(nameCounts)) {
+    totalRunningApps += count;
+
+    const spec = index[name];
+    const category = spec?.category || 'other';
+    runningCategoryMap[category] = (runningCategoryMap[category] || 0) + count;
+
+    const repotag = spec?.repotag || '';
+    const imageKey = repotag ? repotag.split(':')[0] : name;
+    categoryImages[category] = categoryImages[category] || {};
+    categoryImages[category][imageKey] = (categoryImages[category][imageKey] || 0) + count;
+
+    if (repotag) {
+      repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
+    }
+  }
+
+  const topRunningApps = Object.entries(repoCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([image, nodeCount]) => ({ image, nodeCount }));
+
+  let wordpressCount = 0;
+  let streamrNodes = 0;
+  let presearchNodes = 0;
+
+  for (const node of Object.values(aggregate?.nodesByIp || {})) {
+    let hasStreamr = false;
+    let hasPresearch = false;
+
+    for (const name of node.containerAppNames || []) {
+      const repotag = index[name]?.repotag || '';
+      const repoBase = repotag.split(':')[0];
+      if (repoBase === WORDPRESS_REPO_BASE) wordpressCount++;
+      if (repoBase === STREAMR_REPO_BASE) hasStreamr = true;
+      if (repoBase === PRESEARCH_REPO_BASE) hasPresearch = true;
+    }
+
+    if (hasStreamr) streamrNodes++;
+    if (hasPresearch) presearchNodes++;
+  }
+
+  return {
+    runningCategoryMap,
+    runningCategoryTop: buildCategoryTop(categoryImages),
+    topRunningApps,
+    wordpressCount,
+    streamrRunningApps: streamrNodes,
+    presearchRunningApps: presearchNodes,
+    totalRunningApps
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern runningAppsCategorized`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/runningAppsCategorized.js client/src/runningAppsCategorized.test.js
+git commit -m "feat(apps): join running-app names to spec repotags for category/wordpress/streamr/presearch (#187)"
+```
+
+---
+
+### Task 4: Wire Tasks 2+3 into `apidata.js`'s `fetchTotalDeployedApps()`
+
+**Files:**
+- Modify: `client/src/apidata.js:5-7` (imports), `:61-123`
+  (`create_global_store`), `:490-557` (`fetchTotalDeployedApps`)
+- Modify: `client/src/components/TopHostedApps/index.jsx` (field rename)
+
+**Interfaces:**
+- Consumes: `fetch_global_app_specs_raw()` and `buildSpecIndex` (Task 2 +
+  existing `appSpecs.js`), `categorizeRunningApps` (Task 3).
+- Produces: `store.topRunningApps` (renamed from `topRunningImages` — every
+  other field name on `store` is unchanged: `runningCategoryMap`,
+  `runningCategoryTop`, `wordpressCount`, `streamrRunningApps`,
+  `presearchRunningApps`, `totalRunningApps`).
+
+- [ ] **Step 1: Update imports and `create_global_store`**
+
+In `client/src/apidata.js`, replace the import block at lines 5-7 (the
+`main/Gamification/appCategories`, `fluxinfo`, and `appSpecs` imports):
+
+```js
+import { categorizeAppSpec } from 'main/Gamification/appCategories';
+import { fetch_fluxinfo_aggregate } from 'fluxinfo';
+import { specResources, buildSpecIndex } from 'appSpecs';
+import { categorizeRunningApps } from 'runningAppsCategorized';
+```
+
+(`categorizeApp`, `isOpaqueRuntimeImage`, and `buildCategoryTop` are no
+longer used directly in this file — they moved into
+`runningAppsCategorized.js` in Task 3 — so drop them from the import to keep
+lint clean; `categorizeAppSpec` and `specResources` are still used elsewhere
+in this file for `fetch_global_app_specs`.)
+
+In `create_global_store()` (line 111), rename the field:
+
+```js
+    topRunningApps: [],
+```
+
+- [ ] **Step 2: Rewrite `fetchTotalDeployedApps`**
+
+Replace the body of `fetchTotalDeployedApps` (currently lines 495-557) with:
+
+```js
+  const fetchTotalDeployedApps = async () => {
+    const { aggregate, status, fetchedAt } = await fetch_fluxinfo_aggregate();
+
+    store.runningAppsStatus = status;
+    store.runningAppsFetchedAt = fetchedAt;
+
+    if (!aggregate) return;
+
+    // Carried on the store before the spec join below, same as before —
+    // the Workhorse showcase and DonorTab both read these directly off
+    // aggregate's shape.
+    store.topNodesByApps = aggregate.topNodesByApps || [];
+    store.nodesByIp = aggregate.nodesByIp || {};
+
+    // fluxinfo no longer reports a docker image (#187) — category, repotag,
+    // wordpress/streamr/presearch detection all now require joining each
+    // running app's NAME against globalappsspecifications. That fetch is
+    // its own safe, shared, sessionStorage-cached layer (Task 2), so this
+    // costs a real network request only on a cold cache.
+    const rawSpecs = await fetch_global_app_specs_raw();
+    const specIndex = buildSpecIndex(rawSpecs);
+
+    const categorized = categorizeRunningApps(aggregate, specIndex);
+
+    store.totalRunningApps = categorized.totalRunningApps;
+    store.streamrRunningApps = categorized.streamrRunningApps;
+    store.presearchRunningApps = categorized.presearchRunningApps;
+    store.wordpressCount = categorized.wordpressCount;
+    store.topRunningApps = categorized.topRunningApps;
+    store.runningCategoryMap = categorized.runningCategoryMap;
+    store.runningCategoryTop = categorized.runningCategoryTop;
+  };
+```
+
+- [ ] **Step 3: Update `TopHostedApps` for the field rename**
+
+In `client/src/components/TopHostedApps/index.jsx`, line 30:
+
+```js
+  const images = gstore.topRunningApps || [];
+```
+
+(No other line in that file changes — items are still `{image, nodeCount}`,
+and `shortImageName()` still applies since `image` is a real repotag in the
+common case.)
+
+- [ ] **Step 4: Search for any other reference to the old field name**
+
+Run: `cd client && grep -rn "topRunningImages" src`
+Expected: no matches. If any remain, update them the same way as Step 3.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: PASS. `apidata.test.js`'s existing `create_global_store` tests
+don't assert on `topRunningApps`/`topRunningImages` by name (checked in
+investigation — they only check `totalRunningApps`, `runningCategoryMap`,
+`runningCategoryTop`), so no update needed there.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/apidata.js client/src/components/TopHostedApps/index.jsx
+git commit -m "fix(home): recompute running-app stats via the name->spec join (#187)"
+```
+
+---
+
+### Task 5: `WorkhorsePanel` — fix the per-node "Categories" row
+
+**Files:**
+- Modify: `client/src/home/WorkhorsePanel/index.jsx`
+
+**Interfaces:**
+- Consumes: `node.containerAppNames` (Task 1's rename of the old
+  `node.images`) and the component's own existing `specsByName` (already
+  built via `buildSpecIndex(appSpecs?.rawSpecs)` at line 230 — no new prop
+  needed, this task only changes what `NodeCard`'s `categories` memo reads).
+
+- [ ] **Step 1: Update the `categories` memo in `NodeCard`**
+
+In `client/src/home/WorkhorsePanel/index.jsx`, `NodeCard` currently (lines
+89-96) builds `categories` from `node.images` using the now-gone image-based
+`categorizeApp`/`isOpaqueRuntimeImage`. `NodeCard` doesn't currently receive
+`specsByName` as a prop — only `WorkhorsePanel` has it, passed to `NodeCard`
+as `specsByName={specsByName}` already (line 312). Change the memo to use
+that instead:
+
+```js
+  const categories = useMemo(() => {
+    const counts = {};
+    for (const name of node.containerAppNames || []) {
+      const cat = specsByName?.[name]?.category || 'other';
+      counts[cat] = (counts[cat] || 0) + 1;
+    }
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  }, [node.containerAppNames, specsByName]);
+```
+
+Remove the now-unused `categorizeApp, isOpaqueRuntimeImage` import (line 9) —
+`buildSpecIndex` (line 10) is the only one still needed from that pair of
+modules.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: PASS (no dedicated test file for this component today — matches
+the existing convention for `WorkhorsePanel`; verified visually in Task 7).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/home/WorkhorsePanel/index.jsx
+git commit -m "fix(workhorse): rebuild per-node Categories row from the name->spec join (#187)"
+```
+
+---
+
+### Task 6: Analytics Donor tab — "apps by category" panel
+
+**Files:**
+- Modify: `client/src/analytics/donorApps.js`
+- Modify: `client/src/analytics/donorApps.test.js`
+- Modify: `client/src/analytics/DonorTab/index.jsx`
+
+**Interfaces:**
+- Produces: `aggregateDonorAppsByCategory(nodesByIp, donorAddresses,
+  specIndex)` — signature gains a required third parameter. Every existing
+  caller (just `DonorTab`) is updated in this same task.
+
+- [ ] **Step 1: Update the failing tests first**
+
+Rewrite `client/src/analytics/donorApps.test.js` to use
+`containerAppNames` + a `specIndex` instead of `.images`:
+
+```js
+import { aggregateDonorAppsByCategory } from './donorApps';
+
+const specIndex = {
+  'folding1': { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
+  'wp1': { repotag: 'runonflux/wp-nginx:latest', category: 'web' },
+  'mc1': { repotag: 'itzg/minecraft-server:latest', category: 'gaming' },
+  'boinc1': { repotag: 'boinc/client:latest', category: 'computing' },
+  'watchtower': { repotag: 'containrrr/watchtower:latest', category: 'other' },
+};
+
+const nodesByIp = {
+  '1.2.3.4:16127': { containerAppNames: ['folding1', 'wp1'] },
+  '5.6.7.8:16127': { containerAppNames: ['mc1'] },
+  '9.9.9.9:16127': { containerAppNames: ['unrelated'] },
+};
+
+describe('aggregateDonorAppsByCategory', () => {
+  it('tallies one entry per running container, by category, across the donor\'s own nodes only', () => {
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127', '5.6.7.8:16127'], specIndex);
+
+    expect(totalApps).toBe(3);
+    const byCat = Object.fromEntries(categories.map((c) => [c.category, c.count]));
+    expect(byCat.computing).toBe(1);
+    expect(byCat.web).toBe(1);
+    expect(byCat.gaming).toBe(1);
+  });
+
+  it('sorts categories descending by count', () => {
+    const twoOnOneNode = {
+      '1.1.1.1:1': { containerAppNames: ['folding1', 'boinc1', 'mc1'] },
+    };
+    const { categories } = aggregateDonorAppsByCategory(twoOnOneNode, ['1.1.1.1:1'], specIndex);
+    expect(categories[0]).toEqual({ category: 'computing', count: 2 });
+    expect(categories[1]).toEqual({ category: 'gaming', count: 1 });
+  });
+
+  it('never counts an address that is not the donor\'s own', () => {
+    const { totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['1.2.3.4:16127'], specIndex);
+    expect(totalApps).toBe(2); // not 3 — 9.9.9.9's app is excluded
+  });
+
+  it('skips a donor address with no matching nodesByIp entry, rather than throwing', () => {
+    expect(() => aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0'], specIndex)).not.toThrow();
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['0.0.0.0:0'], specIndex);
+    expect(categories).toEqual([]);
+    expect(totalApps).toBe(0);
+  });
+
+  it('returns an empty result for no donor addresses or an empty/undefined lookup', () => {
+    expect(aggregateDonorAppsByCategory(nodesByIp, [], specIndex)).toEqual({ categories: [], totalApps: 0 });
+    expect(aggregateDonorAppsByCategory({}, ['1.2.3.4:16127'], specIndex)).toEqual({ categories: [], totalApps: 0 });
+    expect(aggregateDonorAppsByCategory(undefined, undefined, specIndex)).toEqual({ categories: [], totalApps: 0 });
+  });
+
+  it('excludes containrrr/watchtower from the tally by resolved repotag', () => {
+    const nodesByIpWithWatchtower = {
+      '1.2.3.4:16127': { containerAppNames: ['folding1', 'watchtower'] },
+    };
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIpWithWatchtower, ['1.2.3.4:16127'], specIndex);
+    expect(totalApps).toBe(1);
+    expect(categories).toEqual([{ category: 'computing', count: 1 }]);
+  });
+
+  it('normalizes the donor address before lookup (trims whitespace)', () => {
+    const cleanNodesByIp = { '1.2.3.4:16127': { containerAppNames: ['mc1'] } };
+    const { totalApps } = aggregateDonorAppsByCategory(cleanNodesByIp, [' 1.2.3.4:16127 '], specIndex);
+    expect(totalApps).toBe(1);
+  });
+
+  it('falls back to "other" for a running app whose spec is missing, without throwing', () => {
+    const { categories, totalApps } = aggregateDonorAppsByCategory(nodesByIp, ['9.9.9.9:16127'], specIndex);
+    expect(totalApps).toBe(1);
+    expect(categories).toEqual([{ category: 'other', count: 1 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern donorApps`
+Expected: FAIL — old implementation still reads `.images` and takes only two
+params.
+
+- [ ] **Step 3: Rewrite `aggregateDonorAppsByCategory`**
+
+Replace `client/src/analytics/donorApps.js`'s function body:
+
+```js
+import { addressOf } from 'networkNodes';
+
+/*
+ * Pure: tally the donor's own running apps by category, from the IP-keyed
+ * lookup fetch_fluxinfo_aggregate() carries as nodesByIp, joined against a
+ * name-keyed spec index (appSpecs.js's buildSpecIndex) for category —
+ * fluxinfo no longer reports a docker image (issue #187), so category can
+ * only be recovered by joining the running app's name to its
+ * globalappsspecifications repotag, same as runningAppsCategorized.js does
+ * network-wide. A running app whose spec can't be found (e.g. it expired
+ * between the two independent fetches) falls back to 'other' rather than
+ * being dropped from the tally.
+ *
+ * containrrr/watchtower is excluded from the tally by its resolved repotag:
+ * every Flux node runs it to auto-update its own containers, so it's
+ * infrastructure the node runs for itself, not something the donor deployed.
+ *
+ * Addresses are normalized via addressOf() before lookup, matching
+ * donorUtilization.js's own normalization.
+ */
+export function aggregateDonorAppsByCategory(nodesByIp, donorAddresses, specIndex) {
+  const perCategory = {};
+  let totalApps = 0;
+  const index = specIndex || {};
+
+  for (const rawAddr of donorAddresses || []) {
+    const node = nodesByIp?.[addressOf(rawAddr)];
+    if (!node) continue;
+
+    for (const name of node.containerAppNames || []) {
+      const spec = index[name];
+      const repotag = spec?.repotag || '';
+      if (repotag.toLowerCase().includes('containrrr/watchtower')) continue;
+
+      const cat = spec?.category || 'other';
+      perCategory[cat] = (perCategory[cat] || 0) + 1;
+      totalApps++;
+    }
+  }
+
+  const categories = Object.entries(perCategory)
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return { categories, totalApps };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern donorApps`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `specIndex` into `DonorTab`**
+
+In `client/src/analytics/DonorTab/index.jsx`, add the raw-specs import and
+build the index alongside the existing fetch. Change the import line:
+
+```js
+import { fetch_global_stats, fetch_total_network_utils, fetch_global_app_specs_raw } from 'apidata';
+import { buildSpecIndex } from 'appSpecs';
+```
+
+Find the existing block around the `fetch_total_network_utils` call (search
+for `aggregateDonorAppsByCategory` — currently reads
+`gstore.nodesByIp || {}` directly) and fetch specs alongside it:
+
+```js
+      const [gstore, rawSpecs] = await Promise.all([
+        fetch_total_network_utils(stage1),
+        fetch_global_app_specs_raw(),
+      ]);
+      if (cancelled) return;
+
+      const specIndex = buildSpecIndex(rawSpecs);
+      setAppCategories(aggregateDonorAppsByCategory(gstore.nodesByIp || {}, addresses, specIndex));
+```
+
+(Replacing the existing `const gstore = await fetch_total_network_utils(stage1);`
+line and the `setAppCategories(...)` line right after it — everything else
+in that `useEffect` is unchanged. `fetch_global_app_specs_raw` is
+sessionStorage-cached from Task 2, so this is not a second full network
+fetch once the Home page or Apps tab has already loaded once in the same
+session — and even cold, it's one extra ~request, not the ~726 KB fluxinfo
+payload the existing comment there was written to avoid duplicating.)
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/analytics/donorApps.js client/src/analytics/donorApps.test.js client/src/analytics/DonorTab/index.jsx
+git commit -m "fix(donor): restore apps-by-category via the name->spec join (#187)"
+```
+
+---
+
+### Task 7: Full verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: PASS, count is baseline (317) plus every test added in Tasks 1-6.
+
+- [ ] **Step 2: Production build**
+
+Run: `cd client && npx react-scripts build`
+Expected: exit 0, warnings limited to the same 4 pre-existing baseline files
+(Navbar/index.jsx, NodeGridTable/index.jsx, LayoutContext.jsx, WalletNodes/
+index.jsx) plus, if lint catches it, no new unused-import warnings from the
+removed `categorizeApp`/`isOpaqueRuntimeImage` imports in `apidata.js` and
+`WorkhorsePanel/index.jsx` (Tasks 4 and 5 already removed them — this step
+confirms nothing else was left dangling).
+
+- [ ] **Step 3: Manual spot-check via `run` (or `yarn start` + Chrome)**
+
+Check, against the real live APIs (no demo/mock mode):
+- `/home` — App Ecosystem panel shows real categories (not "unavailable"),
+  Top Hosted Apps shows a ranked list (not stuck spinning), header's Total
+  Running Apps / Wordpress / Streamr / Presearch counts are non-zero and
+  plausible, Workhorse showcase's Categories row is populated for the
+  current node.
+- `/nodes` — Apps tab: category chips, Repo column, and the GitHub-vs-Docker
+  icon all still populated (confirms the investigation's finding that this
+  page needed no code change).
+- `/analytics` → Apps tab: same as Home's App Ecosystem/Top Hosted panels.
+  → Donor tab (toggle `PREMIUM_TESTING_MODE` to `true` in
+  `client/public/runtime/app-content.js` for this check only, **revert to
+  `false` before committing**): "apps by category" panel populated for a
+  wallet with running apps.
+  → Network / Chain Activity tabs: unaffected, spot-check they still render.
+- `/live`: unaffected — confirm deploy/confirm/reward events still show a
+  repo tag in the details panel, proving this plan didn't disturb that path.
+
+- [ ] **Step 4: Update project memory**
+
+Update `fluxnode-next-steps.md` (or add a new dated session entry) noting
+issue #187 is fixed, which files now own the name→spec join, and that the
+Node page Apps tab / Live page needed no changes (so a future session
+doesn't re-investigate the same ground).


### PR DESCRIPTION
## Summary

Fixes #187: `stats.runonflux.io/fluxinfo` stopped returning a docker `Image` field on running-container entries, which broke several running-apps panels across the site.

**Root cause** (verified live, not just from the issue's screenshot): `apps.runningapps[]` entries now carry only `Names`/`State`/`Status`. That field was the only way this app used to recover a running app's docker image/repotag/category.

**What was actually broken:**
- Home: App Ecosystem panel (stuck "unavailable"), Top Hosted Apps (stuck on an **infinite spinner**, no error shown), header stat cells (Total Running Apps silently inflated; Presearch/Streamr/Wordpress counts silently 0), Workhorse showcase's Categories row
- Analytics: Apps tab (shares components with Home), Donor tab's apps-by-category panel

**What was *not* broken** (verified live before touching anything, contrary to the issue's suspicion):
- Node page's Apps tab — sources from each node's own `/apps/installedapps` + `globalappsspecifications`, neither of which changed
- Live page — its repo data comes from diffing `globalappsspecifications` snapshots, never from `fluxinfo`

**Fix:** join each running container's app name (still reported, recoverable from `flux<component>_<app>` container names) against `globalappsspecifications` (still has the real repotag) to recover category/repotag — the same pattern `AppsSection`/`WorkhorsePanel`'s per-app table already used. New module `client/src/runningAppsCategorized.js` does the join; `client/src/fluxinfo.js` now tallies by name instead of by image.

A subtlety worth calling out: a container's app name alone isn't enough to recover the correct image for a multi-component (compose) app, since different components can have different images. Running containers are resolved via their (app, component) pair against the spec's `compose[]` array — not just `compose[0]` — otherwise multi-component apps like WordPress (`wp`/`mysql`/`operator`) get triple-counted under whichever component happens to be listed first.

## Verification

- Full test suite: 359/359 passing (up from 317 baseline)
- Production build: exit 0, same 4 pre-existing warning files, no new ones
- Manual live walkthrough (`yarn start`, real production APIs) across `/home`, `/nodes`, `/analytics` (Apps + Donor tabs), `/live` — confirmed every affected panel now populates correctly, and confirmed Node page / Live page render unaffected

## Process

Built via `superpowers:subagent-driven-development`: 6 planned tasks (each implemented + reviewed independently), one supplementary fix (a join function no planned task named, caught via manual live verification — `networkNodes.js` was still forwarding a since-renamed field), a final whole-branch review that re-fetched live data and replayed the new algorithm to verify the accuracy claims directly (catching a multi-component miscount plus two smaller issues), and one scoped re-review of that fix. Full ledger of task reviews and rulings made along the way is in `docs/superpowers/plans/2026-09-09-fix-running-apps-categorization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
