### PR TITLE
fix: accuracy/reliability pass — Top Hosted Apps categories, issues #153 + #189

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -12,6 +12,7 @@ import {
   fetch_node_geolocation,
   buildWorkhorseNodes
 } from 'networkNodes';
+import { topInGroup } from 'main/Gamification/rankInGroup';
 
 import { FLUXNODE_INFO_API_MODE, FLUXNODE_INFO_API_URL } from 'app-buildinfo';
 
@@ -1078,18 +1079,32 @@ function _flagFromCountryCode(cc) {
   );
 }
 
-const GLOBAL_RANKINGS_CACHE_KEY = 'globalPerfRankings_v3';
+const GLOBAL_RANKINGS_CACHE_KEY = 'globalPerfRankings_v4';
 const GLOBAL_RANKINGS_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+const GLOBAL_RANKINGS_STALE_KEYS = ['globalPerfRankings_v3'];
+
+function _prune_stale_global_rankings_caches() {
+  for (const key of GLOBAL_RANKINGS_STALE_KEYS) {
+    try {
+      sessionStorage.removeItem(key);
+    } catch {}
+  }
+}
 
 /**
  * Fetches and joins node list (tier), benchmark data, and geolocation for all
- * ~8000 Flux nodes. Builds per-tier and per-country performance rankings.
- * Results are cached in sessionStorage for 10 minutes.
+ * ~8000 Flux nodes. Builds a flat nodeData array plus two small precomputed
+ * aggregates (tierWinners, countryTierCounts) — see issue #153: the old
+ * pre-sorted tierRankings/countryRankings shape duplicated every node 12+
+ * times and was the single biggest sessionStorage-quota offender. Results
+ * are cached in sessionStorage for 10 minutes.
  *
- * Returns: { tierRankings, countryRankings, nodeGeoMap, officialNodeCounts,
- * countryDominance, addressGeoMap } or null on failure.
+ * Returns: { nodeData, tierWinners, countryTierCounts, officialNodeCounts,
+ * countryDominance, nodeGeoMap, addressGeoMap } or null on failure.
  */
 export async function fetch_global_performance_rankings() {
+  _prune_stale_global_rankings_caches();
+
   // Return cached data if fresh
   try {
     const raw = sessionStorage.getItem(GLOBAL_RANKINGS_CACHE_KEY);
@@ -1202,57 +1217,36 @@ export async function fetch_global_performance_rankings() {
       });
     }
 
+    // Every consumer of this data (achievements.js's 6 dynamic functions,
+    // HomeOverview's TopDogsPanel, _extract_country_counts below) only
+    // ever needs ONE of: a specific wallet's own node's rank (computed
+    // on demand via rankInGroup, cheap since it's only ever a handful of
+    // nodes — see main/Gamification/rankInGroup.js), the single #1 node
+    // per tier/metric (tierWinners, precomputed here), or a country's
+    // node count (countryTierCounts, precomputed here). Nothing needs a
+    // pre-sorted rank list for the whole network — that used to cost 12+
+    // duplicated copies of every node (issue #153).
     const METRICS = ['eps', 'dws', 'down_speed', 'up_speed'];
     const TIERS = ['CUMULUS', 'NIMBUS', 'STRATUS'];
 
-    // Per-tier rankings
-    const tierRankings = {};
+    const tierWinners = {};
     for (const tier of TIERS) {
-      tierRankings[tier] = {};
+      tierWinners[tier] = {};
       const tierNodes = nodeData.filter((n) => n.tier === tier);
       for (const metric of METRICS) {
-        tierRankings[tier][metric] = [...tierNodes]
-          .sort((a, b) => (b[metric] || 0) - (a[metric] || 0))
-          .map((n, i) => ({ ip: n.ip, rank: i + 1, value: n[metric] }));
+        tierWinners[tier][metric] = topInGroup(tierNodes, metric);
       }
     }
 
-    // Per-country, per-tier rankings — nodes compete only within their own tier per country.
-    // Structure: countryRankings[cc].tiers[TIER].metrics[metric] = [{ip, rank, value}]
-    const countryRankings = {};
+    const countryTierCounts = {};
     for (const node of nodeData) {
       if (!node.geo?.countryCode) continue;
       const cc = node.geo.countryCode;
-      if (!countryRankings[cc]) {
-        countryRankings[cc] = {
-          country: node.geo.country,
-          countryCode: cc,
-          flag: node.geo.flag,
-          tiers: {},
-        };
-      }
-      const tier = node.tier;
-      if (!countryRankings[cc].tiers[tier]) {
-        countryRankings[cc].tiers[tier] = {
-          metrics: { eps: [], dws: [], down_speed: [], up_speed: [] },
-        };
-      }
-      for (const metric of METRICS) {
-        countryRankings[cc].tiers[tier].metrics[metric].push({ ip: node.ip, value: node[metric] || 0 });
-      }
-    }
-    // Sort and assign ranks within each country+tier+metric
-    for (const cc of Object.keys(countryRankings)) {
-      for (const tier of Object.keys(countryRankings[cc].tiers)) {
-        for (const metric of METRICS) {
-          countryRankings[cc].tiers[tier].metrics[metric]
-            .sort((a, b) => b.value - a.value)
-            .forEach((entry, i) => { entry.rank = i + 1; });
-        }
-      }
+      if (!countryTierCounts[cc]) countryTierCounts[cc] = { country: node.geo.country, tiers: {} };
+      countryTierCounts[cc].tiers[node.tier] = (countryTierCounts[cc].tiers[node.tier] || 0) + 1;
     }
 
-    const data = { tierRankings, countryRankings, nodeGeoMap, officialNodeCounts, countryDominance, addressGeoMap };
+    const data = { nodeData, tierWinners, countryTierCounts, officialNodeCounts, countryDominance, addressGeoMap, nodeGeoMap };
 
     try {
       sessionStorage.setItem(
@@ -1407,7 +1401,7 @@ export async function fetch_country_node_counts() {
     if (raw) {
       const cached = JSON.parse(raw);
       if (cached && Date.now() - cached.timestamp < GLOBAL_RANKINGS_CACHE_TTL) {
-        return _extract_country_counts(cached.data.countryRankings);
+        return _extract_country_counts(cached.data.countryTierCounts);
       }
     }
   } catch {}
@@ -1444,15 +1438,13 @@ export async function fetch_country_node_counts() {
   }
 }
 
-export function _extract_country_counts(countryRankings) {
-  if (!countryRankings) return [];
-  return Object.values(countryRankings)
-    .map(({ country, countryCode, tiers }) => ({
+export function _extract_country_counts(countryTierCounts) {
+  if (!countryTierCounts) return [];
+  return Object.entries(countryTierCounts)
+    .map(([countryCode, { country, tiers }]) => ({
       country,
       countryCode,
-      nodeCount: Object.values(tiers).reduce(
-        (sum, tier) => sum + (tier.metrics.eps?.length || 0), 0
-      ),
+      nodeCount: Object.values(tiers).reduce((sum, c) => sum + c, 0),
     }))
     .sort((a, b) => b.nodeCount - a.nodeCount);
 }

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -68,6 +68,8 @@ export function create_global_store() {
     presearchRunningApps: 0,
     uniqueWalletAddressesCount: 0,
     wordpressCount: 0,
+    enterpriseContainers: 0,
+    unresolvedContainers: 0,
     fluxBlockHeight: 0,
     daemon_version: 0,
     node_count: {
@@ -522,6 +524,8 @@ export async function fetch_global_stats(walletAddress = null) {
     store.streamrRunningApps = categorized.streamrRunningApps;
     store.presearchRunningApps = categorized.presearchRunningApps;
     store.wordpressCount = categorized.wordpressCount;
+    store.enterpriseContainers = categorized.enterpriseContainers;
+    store.unresolvedContainers = categorized.unresolvedContainers;
     store.topRunningApps = categorized.topRunningApps;
     store.runningCategoryMap = categorized.runningCategoryMap;
     store.runningCategoryTop = categorized.runningCategoryTop;

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1277,7 +1277,9 @@ export async function fetch_global_performance_rankings() {
         GLOBAL_RANKINGS_CACHE_KEY,
         JSON.stringify({ data, timestamp: Date.now() })
       );
-    } catch {}
+    } catch (e) {
+      console.warn('[GlobalRankings] Cache write failed:', e?.message);
+    }
 
     return data;
   } catch (e) {
@@ -1295,6 +1297,38 @@ const BLOCKS_PER_DAY = 2880; // 30 sec/block
 const RAW_APP_SPECS_CACHE_KEY = 'homeAppSpecsRaw_v1';
 const RAW_APP_SPECS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const RAW_APP_SPECS_STALE_KEYS = ['homeAppSpecs_v2']; // old key cached the full computed (height-dependent) result
+
+// Fields any downstream consumer actually reads off a raw spec (#153) — see
+// appSpecs.js's specResources()/buildSpecIndex(), appCategories.js's
+// categorizeAppSpec(), and live/apidata.js's diffDeployedForEvents(). This is
+// only what gets WRITTEN to sessionStorage; the in-memory return value below
+// (`json.data`) stays full/untrimmed for every caller. `cpu`/`ram`/`hdd` are
+// required for the LEGACY no-compose branch of specResources() (an app with
+// no `compose` array reads its resources straight off the top-level spec —
+// dropping them would silently show "0.00 cores/0GB/0GB" for those apps on a
+// warm cache read, the same class of bug this file's appSpecs.js comment
+// already describes fixing once for enterprise apps). `description` is read
+// by live/apidata.js's diffDeployedForEvents() for the Live page's deploy
+// event detail panel.
+const SPEC_CACHE_FIELDS = ['name', 'height', 'expire', 'instances', 'enterprise', 'owner', 'repotag', 'cpu', 'ram', 'hdd', 'description'];
+const COMPOSE_CACHE_FIELDS = ['name', 'repotag', 'cpu', 'ram', 'hdd'];
+
+function _trimSpecForCache(spec) {
+  const trimmed = {};
+  for (const f of SPEC_CACHE_FIELDS) {
+    if (spec[f] !== undefined) trimmed[f] = spec[f];
+  }
+  if (Array.isArray(spec.compose)) {
+    trimmed.compose = spec.compose.map((c) => {
+      const tc = {};
+      for (const f of COMPOSE_CACHE_FIELDS) {
+        if (c[f] !== undefined) tc[f] = c[f];
+      }
+      return tc;
+    });
+  }
+  return trimmed;
+}
 
 let _rawAppSpecsInFlight = null;
 
@@ -1343,10 +1377,13 @@ export async function fetch_global_app_specs_raw() {
       if (json.status === 'error' || !Array.isArray(json.data)) return [];
 
       try {
-        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: json.data, timestamp: Date.now() }));
-      } catch {}
+        const trimmedForCache = json.data.map(_trimSpecForCache);
+        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: trimmedForCache, timestamp: Date.now() }));
+      } catch (e) {
+        console.warn('[AppSpecs] Cache write failed:', e?.message, `(${JSON.stringify(json.data).length} bytes)`);
+      }
 
-      return json.data;
+      return json.data; // full, untrimmed — every in-memory caller keeps working exactly as before
     } catch (e) {
       console.warn('[AppSpecs] Failed to fetch:', e);
       return [];
@@ -1455,7 +1492,9 @@ export async function fetch_country_node_counts() {
     const data = Object.values(countryMap).sort((a, b) => b.nodeCount - a.nodeCount);
     try {
       sessionStorage.setItem(HOME_GEO_CACHE_KEY, JSON.stringify({ data, timestamp: Date.now() }));
-    } catch {}
+    } catch (e) {
+      console.warn('[Geo] Cache write failed:', e?.message);
+    }
     return data;
   } catch {
     return [];
@@ -1504,7 +1543,9 @@ export async function fetch_gpu_prices() {
     const data = { models, totalGPUs, totalComputers };
     try {
       sessionStorage.setItem(GPU_PRICES_CACHE_KEY, JSON.stringify({ data, timestamp: Date.now() }));
-    } catch {}
+    } catch (e) {
+      console.warn('[GPU] Cache write failed:', e?.message);
+    }
     return data;
   } catch {
     return null;

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1444,7 +1444,7 @@ export async function fetch_country_node_counts() {
   }
 }
 
-function _extract_country_counts(countryRankings) {
+export function _extract_country_counts(countryRankings) {
   if (!countryRankings) return [];
   return Object.values(countryRankings)
     .map(({ country, countryCode, tiers }) => ({

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1316,13 +1316,13 @@ const COMPOSE_CACHE_FIELDS = ['name', 'repotag', 'cpu', 'ram', 'hdd'];
 function _trimSpecForCache(spec) {
   const trimmed = {};
   for (const f of SPEC_CACHE_FIELDS) {
-    if (spec[f] !== undefined) trimmed[f] = spec[f];
+    if (spec?.[f] !== undefined) trimmed[f] = spec[f];
   }
-  if (Array.isArray(spec.compose)) {
+  if (Array.isArray(spec?.compose)) {
     trimmed.compose = spec.compose.map((c) => {
       const tc = {};
       for (const f of COMPOSE_CACHE_FIELDS) {
-        if (c[f] !== undefined) tc[f] = c[f];
+        if (c?.[f] !== undefined) tc[f] = c[f];
       }
       return tc;
     });
@@ -1376,11 +1376,16 @@ export async function fetch_global_app_specs_raw() {
       // whole Home page load down with it.
       if (json.status === 'error' || !Array.isArray(json.data)) return [];
 
+      const trimmedForCache = json.data.map(_trimSpecForCache);
       try {
-        const trimmedForCache = json.data.map(_trimSpecForCache);
-        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: trimmedForCache, timestamp: Date.now() }));
+        const payload = JSON.stringify({ data: trimmedForCache, timestamp: Date.now() });
+        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, payload);
       } catch (e) {
-        console.warn('[AppSpecs] Cache write failed:', e?.message, `(${JSON.stringify(json.data).length} bytes)`);
+        // Log the TRIMMED payload's size, not json.data's — trimmedForCache
+        // is what actually hit the quota, and can be several times smaller
+        // than the untrimmed array; logging the wrong number here would
+        // mislead exactly the debugging this warning exists for.
+        console.warn('[AppSpecs] Cache write failed:', e?.message, `(${JSON.stringify(trimmedForCache).length} bytes)`);
       }
 
       return json.data; // full, untrimmed — every in-memory caller keeps working exactly as before

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -413,37 +413,53 @@ export async function fetch_global_stats(walletAddress = null) {
   const store = create_global_store();
 
   const fetchCurrency = async () => {
-    const res = await fetch('https://explorer.runonflux.io/api/currency');
-    const json = await res.json();
-    store.flux_price_usd = json.data.rate;
+    try {
+      const res = await fetch('https://explorer.runonflux.io/api/currency');
+      const json = await res.json();
+      store.flux_price_usd = json.data.rate;
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   const fetchWallet = async () => {
-    if (walletAddress) {
-      const res = await fetch('https://explorer.runonflux.io/api/addr/' + walletAddress + '/?noTxList=1');
-      const json = await res.json();
-      const balance = json['balance'];
-      store.wallet_amount_flux = Math.round((balance + Number.EPSILON) * 100) / 100;
+    try {
+      if (walletAddress) {
+        const res = await fetch('https://explorer.runonflux.io/api/addr/' + walletAddress + '/?noTxList=1');
+        const json = await res.json();
+        const balance = json['balance'];
+        store.wallet_amount_flux = Math.round((balance + Number.EPSILON) * 100) / 100;
+      }
+    } catch (error) {
+      console.log('error', error);
     }
   };
 
   const fetchNode = async () => {
-    const res = await fetch('https://api.runonflux.io/daemon/getzelnodecount');
-    const json = await res.json();
-    const stats = json.data;
+    try {
+      const res = await fetch('https://api.runonflux.io/daemon/getzelnodecount');
+      const json = await res.json();
+      const stats = json.data;
 
-    store.node_count.cumulus = stats['cumulus-enabled'];
-    store.node_count.nimbus = stats['nimbus-enabled'];
-    store.node_count.stratus = stats['stratus-enabled'];
+      store.node_count.cumulus = stats['cumulus-enabled'];
+      store.node_count.nimbus = stats['nimbus-enabled'];
+      store.node_count.stratus = stats['stratus-enabled'];
 
-    store.node_count.total = stats['total'];
+      store.node_count.total = stats['total'];
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   const fetchBenchVer = async () => {
-    const res = await fetch('https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json');
-    if (res.status === 200) {
-      const json = await res.json();
-      store.fluxos_latest_version = fluxos_version_desc_parse(json['version']);
+    try {
+      const res = await fetch('https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json');
+      if (res.status === 200) {
+        const json = await res.json();
+        store.fluxos_latest_version = fluxos_version_desc_parse(json['version']);
+      }
+    } catch (error) {
+      console.log('error', error);
     }
   };
 
@@ -486,9 +502,13 @@ export async function fetch_global_stats(walletAddress = null) {
   };
 
   const fetchRichList = async () => {
-    const res = await fetch('https://explorer.runonflux.io/api/statistics/richest-addresses-list');
-    const json = await res.json();
-    store.in_rich_list = json.some((wAddress) => wAddress.address === walletAddress);
+    try {
+      const res = await fetch('https://explorer.runonflux.io/api/statistics/richest-addresses-list');
+      const json = await res.json();
+      store.in_rich_list = json.some((wAddress) => wAddress.address === walletAddress);
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   /*

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -273,23 +273,87 @@ describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
 });
 
 /*
- * Characterization test for _extract_country_counts (issue #153 prep).
- * Task 3 changes this function's entire input contract (from countryRankings
- * to a much smaller countryTierCounts shape) as part of the globalPerfRankings
- * redesign, and will REPLACE this test in place with an equivalent one against
- * the new shape — this is expected, not a conflict. This test is written
- * against the CURRENT shape regardless, since it proves today's nodeCount
- * arithmetic (sum of each tier's eps array length) before anything changes.
+ * _extract_country_counts (issue #153) — Task 3 changed this function's
+ * entire input contract from the old exploded countryRankings shape to the
+ * much smaller countryTierCounts shape. This test replaces (not adds to)
+ * Task 1's original version, keeping the exact same expected output.
  */
 describe('_extract_country_counts (characterization — current behavior)', () => {
-  it("counts nodes per country by summing each tier's eps array length", () => {
-    const countryRankings = {
-      US: { country: 'United States', countryCode: 'US', tiers: {
-        CUMULUS: { metrics: { eps: [{ ip: 'a' }, { ip: 'b' }] } },
-        STRATUS: { metrics: { eps: [{ ip: 'c' }] } },
-      } },
+  it("counts nodes per country by summing each tier's count", () => {
+    const countryTierCounts = {
+      US: { country: 'United States', tiers: { CUMULUS: 2, STRATUS: 1 } },
     };
-    const result = _extract_country_counts(countryRankings);
+    const result = _extract_country_counts(countryTierCounts);
     expect(result).toEqual([{ country: 'United States', countryCode: 'US', nodeCount: 3 }]);
+  });
+});
+
+/*
+ * fetch_global_performance_rankings (issue #153 redesign) — replaces the
+ * old pre-sorted, massively-duplicated tierRankings/countryRankings cache
+ * with a flat nodeData array plus two small precomputed aggregates
+ * (tierWinners, countryTierCounts). See Task 3 brief.
+ */
+describe('fetch_global_performance_rankings (redesigned shape)', () => {
+  const FLUX_NODES = { fluxNodes: [
+    { ip: '10.0.0.1:16127', tier: 'cumulus', payment_address: 't1a' },
+    { ip: '10.0.0.2:16127', tier: 'stratus', payment_address: 't1b' },
+  ] };
+  const BENCH_DATA = [
+    { benchmark: { bench: { ipaddress: '10.0.0.1:16127', eps: 100, ddwrite: 10, download_speed: 50, upload_speed: 20 } } },
+    { benchmark: { bench: { ipaddress: '10.0.0.2:16127', eps: 200, ddwrite: 20, download_speed: 60, upload_speed: 30 } } },
+  ];
+  const GEO_DATA = [
+    { geolocation: { ip: '10.0.0.1', country: 'United States', countryCode: 'US', continent: 'NA' } },
+    { geolocation: { ip: '10.0.0.2', country: 'Germany', countryCode: 'DE', continent: 'EU' } },
+  ];
+  const NODE_COUNT = { data: { 'cumulus-enabled': 1, 'nimbus-enabled': 0, 'stratus-enabled': 1, total: 2 } };
+
+  function mockFetchByUrl() {
+    global.fetch = jest.fn((url) => {
+      const u = typeof url === 'string' ? url : '';
+      if (u.includes('getFluxNodes')) return Promise.resolve({ json: async () => FLUX_NODES });
+      if (u.includes('projection=benchmark')) return Promise.resolve({ json: async () => ({ status: 'success', data: BENCH_DATA }) });
+      if (u.includes('projection=geolocation')) return Promise.resolve({ json: async () => ({ status: 'success', data: GEO_DATA }) });
+      if (u.includes('getzelnodecount')) return Promise.resolve({ json: async () => NODE_COUNT });
+      return Promise.reject(new Error(`unexpected fetch: ${u}`));
+    });
+  }
+
+  let fetch_global_performance_rankings;
+
+  beforeEach(() => {
+    jest.resetModules();
+    sessionStorage.clear();
+    mockFetchByUrl();
+    fetch_global_performance_rankings = require('./apidata').fetch_global_performance_rankings;
+  });
+
+  it('resolves nodeData as one entry per benchmarked node, no duplication', async () => {
+    const result = await fetch_global_performance_rankings();
+    expect(result.nodeData).toHaveLength(2);
+    expect(result.nodeData.find((n) => n.ip === '10.0.0.1')).toMatchObject({ tier: 'CUMULUS', eps: 100 });
+    expect(result.tierRankings).toBeUndefined();
+    expect(result.countryRankings).toBeUndefined();
+  });
+
+  it('tierWinners gives the single highest-value node per tier+metric', async () => {
+    const result = await fetch_global_performance_rankings();
+    // Only one node per tier in this fixture, so it trivially wins its own tier.
+    expect(result.tierWinners.CUMULUS.eps).toEqual({ ip: '10.0.0.1', value: 100 });
+    expect(result.tierWinners.STRATUS.eps).toEqual({ ip: '10.0.0.2', value: 200 });
+  });
+
+  it('countryTierCounts matches nodeData grouped by country+tier', async () => {
+    const result = await fetch_global_performance_rankings();
+    expect(result.countryTierCounts.US.tiers.CUMULUS).toBe(1);
+    expect(result.countryTierCounts.DE.tiers.STRATUS).toBe(1);
+  });
+
+  it('bumps the cache key to v4 and prunes the old v3 entry', async () => {
+    sessionStorage.setItem('globalPerfRankings_v3', JSON.stringify({ data: { stale: true }, timestamp: Date.now() }));
+    await fetch_global_performance_rankings();
+    expect(sessionStorage.getItem('globalPerfRankings_v3')).toBeNull();
+    expect(sessionStorage.getItem('globalPerfRankings_v4')).not.toBeNull();
   });
 });

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -332,6 +332,7 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
   }
 
   let fetch_global_performance_rankings;
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     jest.resetModules();
@@ -381,6 +382,10 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    // A direct `global.fetch = jest.fn()` assignment (as opposed to
+    // `jest.spyOn`) is never tracked by jest.restoreAllMocks() — it only
+    // restores spies. Restore the pre-suite reference explicitly so this
+    // describe block's mock can't leak into whatever runs after it.
+    global.fetch = originalFetch;
   });
 });

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -273,6 +273,154 @@ describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
   });
 });
 
+describe('fetch_global_app_specs_raw caches a trimmed payload (#153)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('strips fields no consumer reads before writing to sessionStorage, but returns the full spec to the caller', async () => {
+    const fullSpec = {
+      name: 'app1', height: 100, expire: 1000, instances: 3, enterprise: '', owner: 'zid1',
+      contacts: ['x'], description: 'long text', geolocation: ['a'], hash: 'abc', nodes: [], staticip: false, version: 8,
+      compose: [{ name: 'c1', repotag: 'img:latest', cpu: 1, ram: 512, hdd: 5, commands: [], containerData: '/x', containerPorts: [], domains: [''], environmentParameters: [], ports: [], repoauth: '', description: 'x' }],
+    };
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ status: 'success', data: [fullSpec] }) });
+
+    const result = await fetch_global_app_specs_raw();
+    expect(result[0].name).toBe('app1'); // in-memory return is untouched
+    expect(result[0]).toHaveProperty('contacts'); // and keeps every other field too
+    expect(result[0]).toHaveProperty('description');
+
+    const cached = JSON.parse(sessionStorage.getItem('homeAppSpecsRaw_v1')).data[0];
+    expect(cached).not.toHaveProperty('contacts');
+    expect(cached).not.toHaveProperty('geolocation');
+    expect(cached).not.toHaveProperty('hash');
+    expect(cached).not.toHaveProperty('nodes');
+    expect(cached).not.toHaveProperty('staticip');
+    expect(cached).not.toHaveProperty('version');
+    expect(cached.compose[0]).not.toHaveProperty('commands');
+    expect(cached.compose[0]).not.toHaveProperty('containerData');
+    expect(cached.compose[0]).not.toHaveProperty('domains');
+    expect(cached.compose[0]).not.toHaveProperty('description');
+    // fields every consumer needs stay present:
+    expect(cached).toMatchObject({ name: 'app1', height: 100, expire: 1000, instances: 3, enterprise: '', owner: 'zid1', description: 'long text' });
+    expect(cached.compose[0]).toMatchObject({ name: 'c1', repotag: 'img:latest', cpu: 1, ram: 512, hdd: 5 });
+  });
+
+  /*
+   * Regression test for the corrected allowlist (#153, task 8): specResources()
+   * (appSpecs.js) has a LEGACY branch for specs with no `compose` array at all
+   * — it reads spec.cpu/spec.ram/spec.hdd/spec.repotag straight off the
+   * top-level spec object. The original allowlist kept `repotag` but dropped
+   * `cpu`/`ram`/`hdd`, which would have made a warm-cache reload of a legacy
+   * no-compose app silently report "0.00 cores / 0GB RAM / 0GB storage"
+   * instead of its real figures. This proves a cache WRITE-then-READ round
+   * trip for exactly that shape still carries cpu/ram/hdd through.
+   */
+  it('keeps cpu/ram/hdd on a legacy no-compose spec through a cache write+read round trip', async () => {
+    const legacySpec = {
+      name: 'legacyApp', height: 200, instances: 1, owner: 'zid2',
+      repotag: 'legacy/image:1', cpu: 2, ram: 4096, hdd: 20,
+    };
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ status: 'success', data: [legacySpec] }) });
+
+    await fetch_global_app_specs_raw();
+
+    const cached = JSON.parse(sessionStorage.getItem('homeAppSpecsRaw_v1')).data[0];
+    // Not stripped: the legacy branch of specResources() needs these directly
+    // off the top-level spec (no `compose` array to fall back to).
+    expect(cached.cpu).toBe(2);
+    expect(cached.ram).toBe(4096);
+    expect(cached.hdd).toBe(20);
+    expect(cached.repotag).toBe('legacy/image:1');
+    expect(cached).not.toHaveProperty('compose');
+
+    // And a subsequent warm-cache read (within TTL) hands the trimmed-but-
+    // still-correct spec straight back out to callers.
+    const warmRead = await fetch_global_app_specs_raw();
+    expect(warmRead[0]).toMatchObject({ name: 'legacyApp', cpu: 2, ram: 4096, hdd: 20, repotag: 'legacy/image:1' });
+  });
+
+  it('logs loudly instead of swallowing a sessionStorage quota-exceeded error on write', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ status: 'success', data: [{ name: 'app1', height: 100 }] }) });
+
+    const result = await fetch_global_app_specs_raw();
+
+    expect(result).toEqual([{ name: 'app1', height: 100 }]); // the fetch itself still succeeds
+    expect(warn).toHaveBeenCalledWith('[AppSpecs] Cache write failed:', 'QuotaExceededError', expect.stringContaining('bytes'));
+  });
+});
+
+describe('sessionStorage cache-write failures are logged, not swallowed (#153)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetch_global_performance_rankings logs a [GlobalRankings] warning on a cache write failure', async () => {
+    jest.resetModules();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    global.fetch = jest.fn((url) => {
+      const u = typeof url === 'string' ? url : '';
+      if (u.includes('getFluxNodes')) return Promise.resolve({ json: async () => ({ fluxNodes: [] }) });
+      if (u.includes('projection=benchmark')) return Promise.resolve({ json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('projection=geolocation')) return Promise.resolve({ json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('getzelnodecount')) return Promise.resolve({ json: async () => ({ data: {} }) });
+      return Promise.reject(new Error(`unexpected fetch: ${u}`));
+    });
+
+    const { fetch_global_performance_rankings } = require('./apidata');
+    const result = await fetch_global_performance_rankings();
+
+    expect(result).not.toBeNull(); // the fetch/compute itself still succeeds
+    expect(warn).toHaveBeenCalledWith('[GlobalRankings] Cache write failed:', 'QuotaExceededError');
+  });
+
+  it('fetch_country_node_counts logs a [Geo] warning on a cache write failure', async () => {
+    jest.resetModules();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ status: 'success', data: [] }) });
+
+    const { fetch_country_node_counts } = require('./apidata');
+    const result = await fetch_country_node_counts();
+
+    expect(result).toEqual([]);
+    expect(warn).toHaveBeenCalledWith('[Geo] Cache write failed:', 'QuotaExceededError');
+  });
+
+  it('fetch_gpu_prices logs a [GPU] warning on a cache write failure', async () => {
+    jest.resetModules();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ([{ number_of_gpus: 2, number_of_computers: 1 }]),
+    });
+
+    const { fetch_gpu_prices } = require('./apidata');
+    const result = await fetch_gpu_prices();
+
+    expect(result).not.toBeNull();
+    expect(warn).toHaveBeenCalledWith('[GPU] Cache write failed:', 'QuotaExceededError');
+  });
+});
+
 /*
  * _extract_country_counts (issue #153) — Task 3 changed this function's
  * entire input contract from the old exploded countryRankings shape to the

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -7,6 +7,7 @@ import {
   wallet_health_full,
   fetch_global_app_specs,
   fetch_global_app_specs_raw,
+  _extract_country_counts,
 } from './apidata';
 
 import {
@@ -268,5 +269,27 @@ describe('fetch_global_app_specs_raw / fetch_global_app_specs', () => {
       expect(out.deployedToday).toHaveLength(1);
       expect(out.networkCategories).toHaveLength(1);
     });
+  });
+});
+
+/*
+ * Characterization test for _extract_country_counts (issue #153 prep).
+ * Task 3 changes this function's entire input contract (from countryRankings
+ * to a much smaller countryTierCounts shape) as part of the globalPerfRankings
+ * redesign, and will REPLACE this test in place with an equivalent one against
+ * the new shape — this is expected, not a conflict. This test is written
+ * against the CURRENT shape regardless, since it proves today's nodeCount
+ * arithmetic (sum of each tier's eps array length) before anything changes.
+ */
+describe('_extract_country_counts (characterization — current behavior)', () => {
+  it("counts nodes per country by summing each tier's eps array length", () => {
+    const countryRankings = {
+      US: { country: 'United States', countryCode: 'US', tiers: {
+        CUMULUS: { metrics: { eps: [{ ip: 'a' }, { ip: 'b' }] } },
+        STRATUS: { metrics: { eps: [{ ip: 'c' }] } },
+      } },
+    };
+    const result = _extract_country_counts(countryRankings);
+    expect(result).toEqual([{ country: 'United States', countryCode: 'US', nodeCount: 3 }]);
   });
 });

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -295,19 +295,30 @@ describe('_extract_country_counts (characterization — current behavior)', () =
  * (tierWinners, countryTierCounts). See Task 3 brief.
  */
 describe('fetch_global_performance_rankings (redesigned shape)', () => {
+  // 10.0.0.3 is a second CUMULUS node in the US (same tier+country as
+  // 10.0.0.1), deliberately given lower metric values than 10.0.0.1 across
+  // the board. This pins two things the original one-node-per-tier fixture
+  // could not: tierWinners.CUMULUS must still pick 10.0.0.1 (the higher
+  // value, not the last-seen or minimum entry), and countryTierCounts.US's
+  // CUMULUS count must become 2 (proving the accumulator adds rather than
+  // overwrites). NIMBUS has zero nodes in this fixture, pinning the null
+  // branch of tierWinners.
   const FLUX_NODES = { fluxNodes: [
     { ip: '10.0.0.1:16127', tier: 'cumulus', payment_address: 't1a' },
     { ip: '10.0.0.2:16127', tier: 'stratus', payment_address: 't1b' },
+    { ip: '10.0.0.3:16127', tier: 'cumulus', payment_address: 't1c' },
   ] };
   const BENCH_DATA = [
     { benchmark: { bench: { ipaddress: '10.0.0.1:16127', eps: 100, ddwrite: 10, download_speed: 50, upload_speed: 20 } } },
     { benchmark: { bench: { ipaddress: '10.0.0.2:16127', eps: 200, ddwrite: 20, download_speed: 60, upload_speed: 30 } } },
+    { benchmark: { bench: { ipaddress: '10.0.0.3:16127', eps: 60, ddwrite: 8, download_speed: 30, upload_speed: 15 } } },
   ];
   const GEO_DATA = [
     { geolocation: { ip: '10.0.0.1', country: 'United States', countryCode: 'US', continent: 'NA' } },
     { geolocation: { ip: '10.0.0.2', country: 'Germany', countryCode: 'DE', continent: 'EU' } },
+    { geolocation: { ip: '10.0.0.3', country: 'United States', countryCode: 'US', continent: 'NA' } },
   ];
-  const NODE_COUNT = { data: { 'cumulus-enabled': 1, 'nimbus-enabled': 0, 'stratus-enabled': 1, total: 2 } };
+  const NODE_COUNT = { data: { 'cumulus-enabled': 2, 'nimbus-enabled': 0, 'stratus-enabled': 1, total: 3 } };
 
   function mockFetchByUrl() {
     global.fetch = jest.fn((url) => {
@@ -331,7 +342,7 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
 
   it('resolves nodeData as one entry per benchmarked node, no duplication', async () => {
     const result = await fetch_global_performance_rankings();
-    expect(result.nodeData).toHaveLength(2);
+    expect(result.nodeData).toHaveLength(3);
     expect(result.nodeData.find((n) => n.ip === '10.0.0.1')).toMatchObject({ tier: 'CUMULUS', eps: 100 });
     expect(result.tierRankings).toBeUndefined();
     expect(result.countryRankings).toBeUndefined();
@@ -339,14 +350,22 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
 
   it('tierWinners gives the single highest-value node per tier+metric', async () => {
     const result = await fetch_global_performance_rankings();
-    // Only one node per tier in this fixture, so it trivially wins its own tier.
+    // Two CUMULUS nodes now (10.0.0.1 eps 100, 10.0.0.3 eps 60, added later
+    // in fixture order) — 10.0.0.1 must still win, proving this picks the
+    // highest value rather than the last-seen or minimum entry.
     expect(result.tierWinners.CUMULUS.eps).toEqual({ ip: '10.0.0.1', value: 100 });
+    // Only one node in STRATUS, so it trivially wins its own tier.
     expect(result.tierWinners.STRATUS.eps).toEqual({ ip: '10.0.0.2', value: 200 });
+    // NIMBUS has zero nodes in this fixture — the { ip, value } | null contract's
+    // null branch, which a single-winner-per-tier fixture would never exercise.
+    expect(result.tierWinners.NIMBUS.eps).toBeNull();
   });
 
   it('countryTierCounts matches nodeData grouped by country+tier', async () => {
     const result = await fetch_global_performance_rankings();
-    expect(result.countryTierCounts.US.tiers.CUMULUS).toBe(1);
+    // Two CUMULUS nodes in the US (10.0.0.1, 10.0.0.3) — proves the
+    // accumulator adds per node rather than overwriting with 1 each time.
+    expect(result.countryTierCounts.US.tiers.CUMULUS).toBe(2);
     expect(result.countryTierCounts.DE.tiers.STRATUS).toBe(1);
   });
 
@@ -355,5 +374,13 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
     await fetch_global_performance_rankings();
     expect(sessionStorage.getItem('globalPerfRankings_v3')).toBeNull();
     expect(sessionStorage.getItem('globalPerfRankings_v4')).not.toBeNull();
+    const cachedV4 = JSON.parse(sessionStorage.getItem('globalPerfRankings_v4'));
+    expect(cachedV4.data.nodeData).toHaveLength(3);
+    expect(cachedV4.data.tierRankings).toBeUndefined();
+    expect(cachedV4.data.countryRankings).toBeUndefined();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 });

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -8,6 +8,7 @@ import {
   fetch_global_app_specs,
   fetch_global_app_specs_raw,
   _extract_country_counts,
+  fetch_global_stats,
 } from './apidata';
 
 import {
@@ -387,5 +388,39 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
     // restores spies. Restore the pre-suite reference explicitly so this
     // describe block's mock can't leak into whatever runs after it.
     global.fetch = originalFetch;
+  });
+});
+
+describe('fetch_global_stats resilience (#189)', () => {
+  it('a single failing fetch (e.g. rate-limited currency endpoint) does not prevent other fields from populating', async () => {
+    global.fetch = jest.fn((url) => {
+      const u = typeof url === 'string' ? url : '';
+      if (u.includes('/api/currency')) return Promise.reject(new Error('429 rate limited'));
+      if (u.includes('/daemon/getzelnodecount')) return Promise.resolve({ ok: true, json: async () => ({ data: { 'cumulus-enabled': 10, 'nimbus-enabled': 5, 'stratus-enabled': 3, total: 18 } }) });
+      if (u.includes('/daemon/getinfo')) return Promise.resolve({ ok: true, json: async () => ({ data: { blocks: 999, version: 5.1 } }) });
+      if (u.includes('/api/addr/')) return Promise.resolve({ ok: true, json: async () => ({ balance: 1234.56 }) });
+      if (u.includes('/api/statistics/richest-addresses-list')) return Promise.resolve({ ok: true, json: async () => ([]) });
+      if (u.includes('package.json')) return Promise.resolve({ ok: true, status: 200, json: async () => ({ version: '1.2.3' }) });
+      if (u.includes('/apps/globalappsspecifications')) return Promise.resolve({ ok: true, json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('viewdeterministiczelnodelist')) return Promise.resolve({ ok: true, json: async () => ({ data: [] }) });
+      if (u.includes('benchmarkinfo.json')) return Promise.resolve({ ok: true, status: 200, json: async () => ({ version: '1.0.0' }) });
+      if (u.includes('projection=apps.resources')) return Promise.resolve({ ok: true, json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('projection=benchmark')) return Promise.resolve({ ok: true, json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('projection=geolocation')) return Promise.resolve({ ok: true, json: async () => ({ status: 'success', data: [] }) });
+      if (u.includes('projection=flux')) return Promise.resolve({ ok: true, json: async () => ({ status: 'error', data: [] }) });
+      if (u.includes('frontendData')) return Promise.resolve({ ok: true, json: async () => ({ latest_price: 0.25 }) });
+      // Default fallback for any other fetch
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    const store = await fetch_global_stats('t1Hs7jYsXmGXg2c3sW9Vk3nQp8pqRs4tU5vW6xYz7aA');
+    // The currency fetch failed, so flux_price_usd should remain at the default (0)
+    expect(store.flux_price_usd).toBe(0);
+    // But other fields should still be populated by successful fetches
+    expect(store.node_count.cumulus).toBe(10);
+    expect(store.node_count.nimbus).toBe(5);
+    expect(store.node_count.stratus).toBe(3);
+    expect(store.node_count.total).toBe(18);
+    expect(store.current_block_height).toBe(999);
+    expect(store.wallet_amount_flux).toBe(1234.56);
   });
 });

--- a/client/src/components/TopHostedApps/index.jsx
+++ b/client/src/components/TopHostedApps/index.jsx
@@ -30,6 +30,8 @@ export function TopHostedApps({ gstore }) {
   const images = gstore.topRunningApps || [];
   const isLoading = images.length === 0 && gstore.node_count.total > 0;
   const maxCount = images[0]?.nodeCount || 1;
+  const enterpriseContainers = gstore.enterpriseContainers || 0;
+  const unresolvedContainers = gstore.unresolvedContainers || 0;
 
   return (
     <div className="hov-panel hov-panel--top-apps">
@@ -55,6 +57,20 @@ export function TopHostedApps({ gstore }) {
           ))
         )}
       </div>
+      {images.length > 0 && (enterpriseContainers > 0 || unresolvedContainers > 0) && (
+        <div className="hov-top-apps-footnote">
+          {enterpriseContainers > 0 && (
+            <span title="Enterprise apps ship an encrypted spec — there is no image to rank.">
+              {fmtNum(enterpriseContainers)} Enterprise apps — image hidden by design
+            </span>
+          )}
+          {unresolvedContainers > 0 && (
+            <span title="Running, but no matching spec was found for this app.">
+              {fmtNum(unresolvedContainers)} unresolved
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/TopHostedApps/index.scss
+++ b/client/src/components/TopHostedApps/index.scss
@@ -230,6 +230,21 @@
   }
 }
 
+// ── Footnote (Enterprise / unresolved counts) ─────────────────────────────────
+// Muted/secondary text treatment, consistent with .hov-empty and
+// .hov-header-title elsewhere in this panel family.
+
+.hov-top-apps-footnote {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(128, 128, 128, 0.07);
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+}
+
 // ── Bottom row: fixed 10-row height panel ─────────────────────────────────────
 // (duplicated from home/HomeOverview/index.scss's shared bottom-row rule,
 // which also covers ExpiringTodayPanel/DeployedTodayPanel via .hov-list —

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -509,9 +509,9 @@ function MetricCard({ metric, winner, nodeGeoMap }) {
   );
 }
 
-function TierRow({ tier, tierRankings, nodeGeoMap }) {
+function TierRow({ tier, tierWinners, nodeGeoMap }) {
   const { label, color } = TIER_CONFIG[tier];
-  const rankings = tierRankings?.[tier];
+  const winners = tierWinners?.[tier];
   return (
     <div className="td-tier-row" style={{ borderLeftColor: color }}>
       <div className="td-tier-label-col">
@@ -520,7 +520,7 @@ function TierRow({ tier, tierRankings, nodeGeoMap }) {
       </div>
       <div className="td-metric-cards">
         {METRIC_CONFIG.map((m) => (
-          <MetricCard key={m.key} metric={m} winner={rankings?.[m.key]?.[0] ?? null} nodeGeoMap={nodeGeoMap} />
+          <MetricCard key={m.key} metric={m} winner={winners?.[m.key] ?? null} nodeGeoMap={nodeGeoMap} />
         ))}
       </div>
     </div>
@@ -533,13 +533,13 @@ function TopDogsPanel({ globalRankings }) {
       <Spinner size={20} />
     </div>
   );
-  const { tierRankings, nodeGeoMap } = globalRankings;
+  const { tierWinners, nodeGeoMap } = globalRankings;
   return (
     <div className="hov-panel hov-panel--top-dogs">
       <PanelHeader title="TOP DOGS" right={<FaTrophy size={14} className="td-header-icon" />} />
       <div className="td-body">
         {TIERS_ORDER.map((tier) => (
-          <TierRow key={tier} tier={tier} tierRankings={tierRankings} nodeGeoMap={nodeGeoMap} />
+          <TierRow key={tier} tier={tier} tierWinners={tierWinners} nodeGeoMap={nodeGeoMap} />
         ))}
       </div>
     </div>

--- a/client/src/live/apidata.js
+++ b/client/src/live/apidata.js
@@ -168,11 +168,24 @@ const BENCHMARK_METRICS = ['eps', 'dws', 'down_speed', 'up_speed'];
 export function lookupNodeInfo(ip, tier, { nodeGeoMap, nodeData } = {}) {
   const geo = ip ? nodeGeoMap?.[ip] : null;
 
-  const node = ip && tier ? (nodeData || []).find((n) => n.ip === ip && n.tier === tier) : null;
+  // A bare ip can legitimately match more than one nodeData entry: a host
+  // running several same-tier Flux nodes on different ports all collapse to
+  // one ip here (nodeData carries no port — buildConfirmationEvents strips
+  // it too, at the top of this file). The OLD per-metric sorted-array
+  // lookup independently found each metric's highest value among such
+  // duplicates (tierMetrics[metric].find() on an array already sorted
+  // descending for that metric); a plain single-entry .find() here would
+  // instead pick whichever duplicate happens to be first in nodeData's
+  // unsorted fetch order — the exact bug class rankInGroup had, live-
+  // verified elsewhere in this plan. Take the per-metric max across all
+  // matches to replicate the old composite-per-metric behavior exactly.
+  const matches = ip && tier ? (nodeData || []).filter((n) => n.ip === ip && n.tier === tier) : [];
   let benchmark = null;
-  if (node) {
+  if (matches.length > 0) {
     benchmark = {};
-    for (const metric of BENCHMARK_METRICS) benchmark[metric] = node[metric];
+    for (const metric of BENCHMARK_METRICS) {
+      benchmark[metric] = matches.reduce((best, n) => ((n[metric] || 0) > best ? n[metric] || 0 : best), 0);
+    }
   }
 
   return { country: geo?.country || null, countryCode: geo?.countryCode || null, benchmark };

--- a/client/src/live/apidata.js
+++ b/client/src/live/apidata.js
@@ -165,19 +165,14 @@ const BENCHMARK_METRICS = ['eps', 'dws', 'down_speed', 'up_speed'];
  * stats — that's exactly the reachability/proxy-mode fragility the coinbase-
  * based approach was built to get away from.
  */
-export function lookupNodeInfo(ip, tier, { nodeGeoMap, tierRankings } = {}) {
+export function lookupNodeInfo(ip, tier, { nodeGeoMap, nodeData } = {}) {
   const geo = ip ? nodeGeoMap?.[ip] : null;
 
-  const tierMetrics = tier ? tierRankings?.[tier] : null;
+  const node = ip && tier ? (nodeData || []).find((n) => n.ip === ip && n.tier === tier) : null;
   let benchmark = null;
-  if (ip && tierMetrics) {
-    for (const metric of BENCHMARK_METRICS) {
-      const entry = Array.isArray(tierMetrics[metric]) ? tierMetrics[metric].find((r) => r.ip === ip) : null;
-      if (entry) {
-        if (!benchmark) benchmark = {};
-        benchmark[metric] = entry.value;
-      }
-    }
+  if (node) {
+    benchmark = {};
+    for (const metric of BENCHMARK_METRICS) benchmark[metric] = node[metric];
   }
 
   return { country: geo?.country || null, countryCode: geo?.countryCode || null, benchmark };

--- a/client/src/live/apidata.test.js
+++ b/client/src/live/apidata.test.js
@@ -192,14 +192,9 @@ describe('buildConfirmationEvents', () => {
 describe('lookupNodeInfo', () => {
   const globalRankings = {
     nodeGeoMap: { '1.2.3.4': { country: 'Germany', countryCode: 'DE' } },
-    tierRankings: {
-      CUMULUS: {
-        eps: [{ ip: '1.2.3.4', rank: 3, value: 900 }, { ip: '5.6.7.8', rank: 1, value: 950 }],
-        dws: [{ ip: '1.2.3.4', rank: 2, value: 210 }],
-        down_speed: [{ ip: '1.2.3.4', rank: 1, value: 87.5 }],
-        up_speed: [{ ip: '1.2.3.4', rank: 4, value: 41.2 }],
-      },
-    },
+    nodeData: [
+      { ip: '1.2.3.4', tier: 'CUMULUS', eps: 900, dws: 210, down_speed: 87.5, up_speed: 41.2, geo: null },
+    ],
   };
 
   it('resolves country and real benchmark numbers for a known node', () => {

--- a/client/src/live/apidata.test.js
+++ b/client/src/live/apidata.test.js
@@ -232,6 +232,32 @@ describe('lookupNodeInfo', () => {
     const wrongTierInfo = lookupNodeInfo('1.2.3.4', 'NIMBUS', globalRankings);
     expect(wrongTierInfo.benchmark).toBeNull();
   });
+
+  it('takes the per-metric max across same-ip, same-tier duplicates (a host running several nodes on different ports)', () => {
+    // Live-verified 2026-09-09: buildConfirmationEvents strips the port off
+    // tx.ip, and nodeData carries no port either, so a host running several
+    // same-tier Flux nodes on different ports collapses to one ip here —
+    // exactly the shape that made rankInGroup's plain .find() pick an
+    // arbitrary duplicate instead of the real best one. The OLD per-metric
+    // sorted-array lookup found each metric's own highest value among such
+    // duplicates independently, so the correct composite benchmark object
+    // can genuinely mix values from different physical ports.
+    const sharedHost = {
+      nodeGeoMap: { '5.230.173.194': { country: 'Germany', countryCode: 'DE' } },
+      nodeData: [
+        { ip: '5.230.173.194', tier: 'CUMULUS', eps: 460.28, dws: 212.26, down_speed: 4296.66, up_speed: 798.48, geo: null },
+        { ip: '5.230.173.194', tier: 'CUMULUS', eps: 2143.16, dws: 236.6, down_speed: 3981.93, up_speed: 39.51, geo: null },
+        { ip: '5.230.173.194', tier: 'CUMULUS', eps: 265.64, dws: 817.72, down_speed: 50.51, up_speed: 39.93, geo: null },
+      ],
+    };
+    const info = lookupNodeInfo('5.230.173.194', 'CUMULUS', sharedHost);
+    expect(info.benchmark).toEqual({
+      eps: 2143.16, // the 2nd entry's eps is the highest of the three
+      dws: 817.72, // the 3rd entry's dws is the highest of the three
+      down_speed: 4296.66, // the 1st entry's down_speed is the highest of the three
+      up_speed: 798.48, // the 1st entry's up_speed is the highest of the three
+    });
+  });
 });
 
 describe('extractP2pTransfers', () => {

--- a/client/src/live/apidata.test.js
+++ b/client/src/live/apidata.test.js
@@ -194,6 +194,10 @@ describe('lookupNodeInfo', () => {
     nodeGeoMap: { '1.2.3.4': { country: 'Germany', countryCode: 'DE' } },
     nodeData: [
       { ip: '1.2.3.4', tier: 'CUMULUS', eps: 900, dws: 210, down_speed: 87.5, up_speed: 41.2, geo: null },
+      // Same ip, different tier — a node's ip is not globally unique across
+      // this array (an ip can theoretically reappear if reused/re-tiered),
+      // so the lookup must match on ip AND tier, not ip alone.
+      { ip: '1.2.3.4', tier: 'STRATUS', eps: 5, dws: 1, down_speed: 1, up_speed: 1, geo: null },
     ],
   };
 
@@ -219,6 +223,14 @@ describe('lookupNodeInfo', () => {
   it('handles a missing ip or tier gracefully', () => {
     expect(lookupNodeInfo(null, 'CUMULUS', globalRankings)).toEqual({ country: null, countryCode: null, benchmark: null });
     expect(lookupNodeInfo('1.2.3.4', null, globalRankings)).toEqual({ country: 'Germany', countryCode: 'DE', benchmark: null });
+  });
+
+  it('matches on ip AND tier, not ip alone, when the same ip appears under a different tier', () => {
+    const stratusInfo = lookupNodeInfo('1.2.3.4', 'STRATUS', globalRankings);
+    expect(stratusInfo.benchmark).toEqual({ eps: 5, dws: 1, down_speed: 1, up_speed: 1 });
+
+    const wrongTierInfo = lookupNodeInfo('1.2.3.4', 'NIMBUS', globalRankings);
+    expect(wrongTierInfo.benchmark).toBeNull();
   });
 });
 

--- a/client/src/main/Gamification/achievements.js
+++ b/client/src/main/Gamification/achievements.js
@@ -106,6 +106,17 @@ function _bestRankInTier(walletTierNodes, nodeData, tier, metricKey) {
 }
 
 // Find wallet's WORST global rank for (tier, metric) — inverse of _bestRankInTier
+//
+// Known, pre-existing limitation (not introduced by rankInGroup's
+// duplicate-ip fix, and correctly left as-is by it): when a wallet's
+// genuinely-worst node shares a bare host with a better one of its own
+// nodes, rankInGroup resolves that shared ip to the BEST entry, so the
+// worst one is invisible here too and the wallet may miss a Wooden Spoon
+// it technically deserves. The old pre-sorted-array lookup had the exact
+// same blind spot (sorting descending then finding the first match also
+// always favored the best duplicate), so preserving it is correct for
+// this migration's "no behavior change" mandate — fixing it would BE the
+// regression.
 function _worstRankInTier(walletTierNodes, nodeData, tier, metricKey) {
   const groupNodes = nodeData.filter((n) => n.tier === tier);
   let worst = null;

--- a/client/src/main/Gamification/achievements.js
+++ b/client/src/main/Gamification/achievements.js
@@ -155,7 +155,7 @@ function _bestRankInCountry(walletCountryNodes, metricRankings) {
  * Only generated for tiers where the wallet has nodes.
  * officialNodeCounts comes from getzelnodecount (same source as dashboard header).
  */
-function computeTierPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
+export function computeTierPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
   if (!tierRankings) return [];
   const results = [];
 
@@ -216,7 +216,7 @@ function computeTierPerformanceAchievements(walletNodes, tierRankings, officialN
  * Compute global per-country performance achievements.
  * ONLY generated for countries where the wallet has at least one node.
  */
-function computeCountryPerformanceAchievements(walletNodes, countryRankings, nodeGeoMap, enablePrivacyMode = false) {
+export function computeCountryPerformanceAchievements(walletNodes, countryRankings, nodeGeoMap, enablePrivacyMode = false) {
   if (!countryRankings || !nodeGeoMap) return [];
   const results = [];
 
@@ -292,7 +292,7 @@ function computeCountryPerformanceAchievements(walletNodes, countryRankings, nod
 // One set of 3 difficulty levels per tier — based on the wallet's WORST node
 // across any metric. Thresholds use metricRankings.length (benchmarked nodes).
 
-function computeTierWorstPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
+export function computeTierWorstPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
   if (!tierRankings) return [];
   const results = [];
 
@@ -391,7 +391,7 @@ function computeTierWorstPerformanceAchievements(walletNodes, tierRankings, offi
 // One per tier × metric — awarded when the wallet's worst node in that tier is
 // ranked dead last for that specific metric (more granular than Potato).
 
-function computeWoodenSpoonAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
+export function computeWoodenSpoonAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
   if (!tierRankings) return [];
   const results = [];
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
@@ -431,7 +431,7 @@ function computeWoodenSpoonAchievements(walletNodes, tierRankings, officialNodeC
 // One per tier × metric — awarded when the wallet's best node in that tier
 // ranks in the top 5% for that metric (stacks with medal achievements).
 
-function computeTryHardAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
+export function computeTryHardAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
   if (!tierRankings) return [];
   const results = [];
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
@@ -474,7 +474,7 @@ function computeTryHardAchievements(walletNodes, tierRankings, officialNodeCount
 // One per country where the wallet has nodes.
 // Earned when the wallet has more nodes in that country than any other single wallet.
 
-function computeDictatorAchievements(walletNodes, globalRankings) {
+export function computeDictatorAchievements(walletNodes, globalRankings) {
   if (!globalRankings?.countryDominance || !globalRankings?.nodeGeoMap) return [];
   const { countryDominance, nodeGeoMap } = globalRankings;
 

--- a/client/src/main/Gamification/achievements.js
+++ b/client/src/main/Gamification/achievements.js
@@ -6,6 +6,7 @@ import { TbBuildingSkyscraper, TbActivityHeartbeat, TbBrowser } from 'react-icon
 import { categorizeAppSpec } from './appCategories';
 import { fv_compare } from 'main/flux_version';
 import { hide_sensitive_number } from '../../utils';
+import { rankInGroup, topInGroup } from './rankInGroup';
 
 export const TIER = {
   BRONZE: 'bronze',
@@ -89,65 +90,51 @@ const MEDAL_RANKS = [
 const TIER_DISPLAY = { CUMULUS: 'Cumulus', NIMBUS: 'Nimbus', STRATUS: 'Stratus' };
 
 // Find wallet's best global rank for (tier, metric) across all wallet nodes in that tier
-function _bestRankInTier(walletTierNodes, metricRankings) {
-  let bestRank = null;
-  let bestIp = null;
-  let bestValue = 0;
-  let bestNodeDisplay = null;
-
+function _bestRankInTier(walletTierNodes, nodeData, tier, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier);
+  let best = null;
   for (const node of walletTierNodes) {
     const ip = node.ip_full?.host;
     if (!ip) continue;
-    const entry = metricRankings.find((r) => r.ip === ip);
-    if (!entry) continue;
-    if (bestRank === null || entry.rank < bestRank) {
-      bestRank = entry.rank;
-      bestIp = ip;
-      bestValue = entry.value;
-      bestNodeDisplay = node.ip_display;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (best === null || result.rank < best.bestRank) {
+      best = { bestRank: result.rank, bestIp: ip, bestValue: result.value, bestNodeDisplay: node.ip_display };
     }
   }
-  return { bestRank, bestIp, bestValue, bestNodeDisplay };
+  return best || { bestRank: null, bestIp: null, bestValue: 0, bestNodeDisplay: null };
 }
 
 // Find wallet's WORST global rank for (tier, metric) — inverse of _bestRankInTier
-function _worstRankInTier(walletTierNodes, metricRankings) {
-  let worstRank = null;
-  let worstValue = 0;
-  let worstNodeDisplay = null;
-
+function _worstRankInTier(walletTierNodes, nodeData, tier, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier);
+  let worst = null;
   for (const node of walletTierNodes) {
     const ip = node.ip_full?.host;
     if (!ip) continue;
-    const entry = metricRankings.find((r) => r.ip === ip);
-    if (!entry) continue;
-    if (worstRank === null || entry.rank > worstRank) {
-      worstRank = entry.rank;
-      worstValue = entry.value;
-      worstNodeDisplay = node.ip_display;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (worst === null || result.rank > worst.worstRank) {
+      worst = { worstRank: result.rank, worstValue: result.value, worstNodeDisplay: node.ip_display };
     }
   }
-  return { worstRank, worstValue, worstNodeDisplay };
+  return worst || { worstRank: null, worstValue: 0, worstNodeDisplay: null };
 }
 
 // Find wallet's best rank in a country for a metric
-function _bestRankInCountry(walletCountryNodes, metricRankings) {
-  let bestRank = null;
-  let bestValue = 0;
-  let bestNodeDisplay = null;
-
+function _bestRankInCountry(walletCountryNodes, nodeData, tier, countryCode, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === countryCode);
+  let best = null;
   for (const node of walletCountryNodes) {
     const ip = node.ip_full?.host;
     if (!ip) continue;
-    const entry = metricRankings.find((r) => r.ip === ip);
-    if (!entry) continue;
-    if (bestRank === null || entry.rank < bestRank) {
-      bestRank = entry.rank;
-      bestValue = entry.value;
-      bestNodeDisplay = node.ip_display;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (best === null || result.rank < best.bestRank) {
+      best = { bestRank: result.rank, bestValue: result.value, bestNodeDisplay: node.ip_display };
     }
   }
-  return { bestRank, bestValue, bestNodeDisplay };
+  return best || { bestRank: null, bestValue: 0, bestNodeDisplay: null };
 }
 
 /**
@@ -155,27 +142,26 @@ function _bestRankInCountry(walletCountryNodes, metricRankings) {
  * Only generated for tiers where the wallet has nodes.
  * officialNodeCounts comes from getzelnodecount (same source as dashboard header).
  */
-export function computeTierPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
-  if (!tierRankings) return [];
+export function computeTierPerformanceAchievements(walletNodes, nodeData, officialNodeCounts, enablePrivacyMode = false) {
+  if (!nodeData) return [];
   const results = [];
 
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
     const walletTierNodes = walletNodes.filter((n) => n.tier === tier);
     if (walletTierNodes.length === 0) continue;
-    const rankings = tierRankings[tier];
-    if (!rankings) continue;
+    const groupNodes = nodeData.filter((n) => n.tier === tier);
+    if (groupNodes.length === 0) continue;
 
     for (const metric of PERF_METRICS) {
-      const metricRankings = rankings[metric.key] || [];
-      if (metricRankings.length === 0) continue;
-
       // Use official enabled-node count from getzelnodecount to match dashboard header.
-      // Fall back to benchmark array length if unavailable.
-      const totalInTier = officialNodeCounts?.[tier] || metricRankings.length;
+      // Fall back to benchmarked node count if unavailable.
+      const totalInTier = officialNodeCounts?.[tier] || groupNodes.length;
 
       const { bestRank, bestValue, bestNodeDisplay } = _bestRankInTier(
         walletTierNodes,
-        metricRankings
+        nodeData,
+        tier,
+        metric.key
       );
 
       for (const { rank: medalRank, tier: medalTier } of MEDAL_RANKS) {
@@ -216,8 +202,8 @@ export function computeTierPerformanceAchievements(walletNodes, tierRankings, of
  * Compute global per-country performance achievements.
  * ONLY generated for countries where the wallet has at least one node.
  */
-export function computeCountryPerformanceAchievements(walletNodes, countryRankings, nodeGeoMap, enablePrivacyMode = false) {
-  if (!countryRankings || !nodeGeoMap) return [];
+export function computeCountryPerformanceAchievements(walletNodes, nodeData, nodeGeoMap, enablePrivacyMode = false) {
+  if (!nodeData || !nodeGeoMap) return [];
   const results = [];
 
   // Group wallet nodes by country AND tier — nodes only compete within their own tier per country
@@ -238,22 +224,22 @@ export function computeCountryPerformanceAchievements(walletNodes, countryRankin
   }
 
   for (const [, { cc, tier, nodes: walletCountryTierNodes }] of walletByCountryTier.entries()) {
-    const countryData = countryRankings[cc];
-    if (!countryData?.tiers) continue;
-    const tierData = countryData.tiers[tier];
-    if (!tierData) continue;
-
     const nodeTierLabel = TIER_DISPLAY[tier]; // e.g. 'Stratus'
-    const country = countryData.country;
+    // Display name for the country — nodeGeoMap is already a parameter here,
+    // so reuse it rather than threading in countryTierCounts as well.
+    const country = Object.values(nodeGeoMap).find((g) => g.countryCode === cc)?.country;
 
     for (const metric of PERF_METRICS) {
-      const metricRankings = tierData.metrics[metric.key] || [];
-      const totalInGroup = metricRankings.length;
+      const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === cc);
+      const totalInGroup = groupNodes.length;
       if (totalInGroup === 0) continue;
 
       const { bestRank, bestValue, bestNodeDisplay } = _bestRankInCountry(
         walletCountryTierNodes,
-        metricRankings
+        nodeData,
+        tier,
+        cc,
+        metric.key
       );
       if (bestRank === null) continue;
 
@@ -292,15 +278,15 @@ export function computeCountryPerformanceAchievements(walletNodes, countryRankin
 // One set of 3 difficulty levels per tier — based on the wallet's WORST node
 // across any metric. Thresholds use metricRankings.length (benchmarked nodes).
 
-export function computeTierWorstPerformanceAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
-  if (!tierRankings) return [];
+export function computeTierWorstPerformanceAchievements(walletNodes, nodeData, officialNodeCounts, enablePrivacyMode = false) {
+  if (!nodeData) return [];
   const results = [];
 
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
     const walletTierNodes = walletNodes.filter((n) => n.tier === tier);
     if (walletTierNodes.length === 0) continue;
-    const rankings = tierRankings[tier];
-    if (!rankings) continue;
+    const groupNodes = nodeData.filter((n) => n.tier === tier);
+    if (groupNodes.length === 0) continue;
 
     const tierLabel = TIER_DISPLAY[tier];
 
@@ -308,15 +294,13 @@ export function computeTierWorstPerformanceAchievements(walletNodes, tierRanking
     let worst = null; // { rank, metricLabel, metricTotal, nodeDisplay, value, unit }
 
     for (const metric of PERF_METRICS) {
-      const metricRankings = rankings[metric.key] || [];
-      if (metricRankings.length === 0) continue;
-      const { worstRank, worstValue, worstNodeDisplay } = _worstRankInTier(walletTierNodes, metricRankings);
+      const { worstRank, worstValue, worstNodeDisplay } = _worstRankInTier(walletTierNodes, nodeData, tier, metric.key);
       if (worstRank === null) continue;
       if (worst === null || worstRank > worst.rank) {
         worst = {
           rank: worstRank,
           metricLabel: metric.label,
-          metricTotal: metricRankings.length,
+          metricTotal: groupNodes.length,
           nodeDisplay: worstNodeDisplay,
           value: worstValue,
           unit: metric.unit,
@@ -391,22 +375,20 @@ export function computeTierWorstPerformanceAchievements(walletNodes, tierRanking
 // One per tier × metric — awarded when the wallet's worst node in that tier is
 // ranked dead last for that specific metric (more granular than Potato).
 
-export function computeWoodenSpoonAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
-  if (!tierRankings) return [];
+export function computeWoodenSpoonAchievements(walletNodes, nodeData, officialNodeCounts, enablePrivacyMode = false) {
+  if (!nodeData) return [];
   const results = [];
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
     const walletTierNodes = walletNodes.filter((n) => n.tier === tier);
     if (walletTierNodes.length === 0) continue;
-    const rankings = tierRankings[tier];
-    if (!rankings) continue;
+    const groupNodes = nodeData.filter((n) => n.tier === tier);
+    if (groupNodes.length === 0) continue;
     const tierLabel = TIER_DISPLAY[tier];
     for (const metric of PERF_METRICS) {
-      const metricRankings = rankings[metric.key] || [];
-      if (metricRankings.length === 0) continue;
-      const totalInTier = officialNodeCounts?.[tier] || metricRankings.length;
-      const { worstRank, worstValue, worstNodeDisplay } = _worstRankInTier(walletTierNodes, metricRankings);
+      const totalInTier = officialNodeCounts?.[tier] || groupNodes.length;
+      const { worstRank, worstValue, worstNodeDisplay } = _worstRankInTier(walletTierNodes, nodeData, tier, metric.key);
       if (worstRank === null) continue;
-      const earned = worstRank >= metricRankings.length;
+      const earned = worstRank >= groupNodes.length;
       const valueStr = worstValue > 0 ? worstValue.toFixed(2) + metric.unit : 'N/A';
       results.push({
         id: `wooden_spoon_${tier}_${metric.key}`,
@@ -419,7 +401,7 @@ export function computeWoodenSpoonAchievements(walletNodes, tierRankings, offici
         tier: TIER.GOLD,
         category: 'performance',
         earned,
-        progress: Math.max(0, Math.min(100, (worstRank / metricRankings.length) * 100)),
+        progress: Math.max(0, Math.min(100, (worstRank / groupNodes.length) * 100)),
         progressLabel: `Rank #${worstRank.toLocaleString()} of ${totalInTier.toLocaleString()} ${tierLabel} nodes · ${metric.label}`,
       });
     }
@@ -431,26 +413,24 @@ export function computeWoodenSpoonAchievements(walletNodes, tierRankings, offici
 // One per tier × metric — awarded when the wallet's best node in that tier
 // ranks in the top 5% for that metric (stacks with medal achievements).
 
-export function computeTryHardAchievements(walletNodes, tierRankings, officialNodeCounts, enablePrivacyMode = false) {
-  if (!tierRankings) return [];
+export function computeTryHardAchievements(walletNodes, nodeData, officialNodeCounts, enablePrivacyMode = false) {
+  if (!nodeData) return [];
   const results = [];
   for (const tier of ['CUMULUS', 'NIMBUS', 'STRATUS']) {
     const walletTierNodes = walletNodes.filter((n) => n.tier === tier);
     if (walletTierNodes.length === 0) continue;
-    const rankings = tierRankings[tier];
-    if (!rankings) continue;
+    const groupNodes = nodeData.filter((n) => n.tier === tier);
+    if (groupNodes.length === 0) continue;
     const tierLabel = TIER_DISPLAY[tier];
     for (const metric of PERF_METRICS) {
-      const metricRankings = rankings[metric.key] || [];
-      if (metricRankings.length === 0) continue;
-      const totalInTier = officialNodeCounts?.[tier] || metricRankings.length;
-      const topFivePctThreshold = Math.ceil(metricRankings.length * 0.05);
+      const totalInTier = officialNodeCounts?.[tier] || groupNodes.length;
+      const topFivePctThreshold = Math.ceil(groupNodes.length * 0.05);
       if (topFivePctThreshold < 1) continue; // safety guard for empty pools
-      const { bestRank, bestValue, bestNodeDisplay } = _bestRankInTier(walletTierNodes, metricRankings);
+      const { bestRank, bestValue, bestNodeDisplay } = _bestRankInTier(walletTierNodes, nodeData, tier, metric.key);
       if (bestRank === null) continue;
       const earned = bestRank <= topFivePctThreshold;
       const valueStr = bestValue > 0 ? bestValue.toFixed(2) + metric.unit : 'N/A';
-      const topPct = ((topFivePctThreshold / metricRankings.length) * 100).toFixed(0);
+      const topPct = ((topFivePctThreshold / groupNodes.length) * 100).toFixed(0);
       results.push({
         id: `try_hard_${tier}_${metric.key}`,
         name: `${tierLabel} ${metric.label} Try Hard`,
@@ -714,25 +694,25 @@ export function computeAchievements(gstore, walletNodes, walletPASummary, totalD
 
   const tierPerf = computeTierPerformanceAchievements(
     walletNodes,
-    globalRankings.tierRankings,
+    globalRankings.nodeData,
     globalRankings.officialNodeCounts,
     enablePrivacyMode
   );
   const countryPerf = computeCountryPerformanceAchievements(
     walletNodes,
-    globalRankings.countryRankings,
+    globalRankings.nodeData,
     globalRankings.nodeGeoMap,
     enablePrivacyMode
   );
   const worstTierPerf = computeTierWorstPerformanceAchievements(
     walletNodes,
-    globalRankings.tierRankings,
+    globalRankings.nodeData,
     globalRankings.officialNodeCounts,
     enablePrivacyMode
   );
   const dictator = computeDictatorAchievements(walletNodes, globalRankings);
-  const woodenSpoon = computeWoodenSpoonAchievements(walletNodes, globalRankings.tierRankings, globalRankings.officialNodeCounts, enablePrivacyMode);
-  const tryHard = computeTryHardAchievements(walletNodes, globalRankings.tierRankings, globalRankings.officialNodeCounts, enablePrivacyMode);
+  const woodenSpoon = computeWoodenSpoonAchievements(walletNodes, globalRankings.nodeData, globalRankings.officialNodeCounts, enablePrivacyMode);
+  const tryHard = computeTryHardAchievements(walletNodes, globalRankings.nodeData, globalRankings.officialNodeCounts, enablePrivacyMode);
 
   return [...staticAchievements, ...tierPerf, ...countryPerf, ...worstTierPerf, ...dictator, ...woodenSpoon, ...tryHard];
 }

--- a/client/src/main/Gamification/achievements.test.js
+++ b/client/src/main/Gamification/achievements.test.js
@@ -40,7 +40,7 @@ import {
 // eps values, index 0..18: node0 is the clear #1 (100), node1 ties node2 at
 // 50 (tie case — node1 appears first in this array, so under the current
 // stable-sort behavior node1 must rank ABOVE node2 on a tie), nodes 3..17
-// descend from 45 to 3, node18 is the clear last (1), node19 has NO
+// descend from 45 to 5, node18 is the clear last (1), node19 has NO
 // benchmark entry at all (simulates an offline/unbenchmarked node — must
 // be absent from tierRankings.CUMULUS.eps entirely, not present with a 0).
 function buildCumulusTierRankings() {
@@ -64,6 +64,15 @@ const CUMULUS_EPS_RANKINGS = buildCumulusTierRankings();
 
 // dws/down_speed/up_speed: reuse the same shape so tests can pick whichever
 // metric is convenient — only `eps` needs the carefully-tuned tie/edge values.
+//
+// NOTE: in the real data shape (apidata.js:1212-1217) all four per-tier metric
+// arrays (eps/dws/down_speed/up_speed) are always built from the same
+// `tierNodes` list, so they always share identical length/membership. This
+// fixture deliberately diverges — eps has 19 entries (CUMULUS_EPS_RANKINGS,
+// node19 omitted to model an unbenchmarked node) while dws/down_speed/up_speed
+// (built via FLAT_RANKINGS below) have 20 — purely to exercise that one
+// "unbenchmarked node" case. Don't read that divergence as a general
+// invariant of the real shape.
 const FLAT_RANKINGS = (n) =>
   Array.from({ length: 20 }, (_, i) => ({ ip: `10.0.0.${i}`, rank: i + 1, value: n - i }));
 
@@ -97,6 +106,11 @@ describe('computeTierPerformanceAchievements (characterization — current behav
     const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
     const medals = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
     expect(medals.every((m) => !m.earned)).toBe(true);
+    // progress (achievements.js:199-202): bestRank=11, totalInTier=20 (from
+    // OFFICIAL_NODE_COUNTS.CUMULUS) →
+    // (1 - (11-1)/20) * 100 = (1 - 0.5) * 100 = 50
+    const gold = medals.find((m) => m.id === 'global_CUMULUS_eps_gold');
+    expect(gold.progress).toBe(50);
   });
 
   it('breaks a tie the same way the current stable-sort ranking does — first-appearing node wins the better rank', () => {
@@ -119,10 +133,21 @@ describe('computeTierPerformanceAchievements (characterization — current behav
     // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
     expect(eps[0].description).toBe('No Cumulus nodes with benchmark data found');
   });
+
+  it('falls back to the benchmarked-array length when officialNodeCounts is missing (achievements.js:174)', () => {
+    // officialNodeCounts?.[tier] || metricRankings.length — omit officialNodeCounts
+    // entirely so totalInTier must come from CUMULUS_EPS_RANKINGS.length (19),
+    // NOT OFFICIAL_NODE_COUNTS.CUMULUS (20), proving the fallback branch ran.
+    const wallet = [walletNode('10.0.0.0')]; // eps rank 1
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, undefined);
+    const gold = results.find((r) => r.id === 'global_CUMULUS_eps_gold');
+    expect(gold.earned).toBe(true);
+    expect(gold.progressLabel).toBe('Global rank #1 of 19 Cumulus nodes');
+  });
 });
 
 describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievements (characterization)', () => {
-  it('awards Potato (dead last) only to the true last-ranked node, using the TRUE total, not a trimmed approximation', () => {
+  it('awards Potato (dead last) to the true last-ranked node — earned boundary checked against the benchmarked count (metricTotal), not the true/official count (only the display string uses that)', () => {
     // 10.0.0.18 is eps rank 19 of 19 benchmarked CUMULUS nodes (node19 is
     // deliberately unbenchmarked, so the eps array itself has 19 entries) —
     // the actual last position in the benchmark pool.
@@ -130,9 +155,15 @@ describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievemen
     const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
     const potato = worst.find((r) => r.id === 'slow_CUMULUS_potato');
     expect(potato.earned).toBe(true);
+    // progress (achievements.js:344): Math.min(100, rank / metricTotal * 100)
+    // = Math.min(100, 19 / 19 * 100) = 100
+    expect(potato.progress).toBe(100);
     const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
       .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
     expect(spoon.earned).toBe(true);
+    // progress (achievements.js:422): Math.max(0, Math.min(100, worstRank /
+    // metricRankings.length * 100)) = Math.min(100, 19 / 19 * 100) = 100
+    expect(spoon.progress).toBe(100);
     // CORRECTED vs brief: rank is #19 (of the 19-entry benchmark array), not
     // #20 — the display total (20) comes from officialNodeCounts and is a
     // separate number from the rank, which is computed against the 19-entry
@@ -148,6 +179,47 @@ describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievemen
       .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
     expect(spoon.earned).toBe(false);
   });
+
+  // ── Tortoise / Toaster levels (achievements.js:348-365) — the existing
+  // tests above only ever exercise the Potato (dead-last) level. rank/
+  // metricTotal for this fixture's eps pool: 10.0.0.16 -> rank 17,
+  // 10.0.0.17 -> rank 18, 10.0.0.18 -> rank 19, metricTotal = 19 (verified
+  // by hand and by re-running buildCumulusTierRankings' exact sort/map logic).
+  //
+  // Thresholds (achievements.js:350, :362): tortoise earned when
+  // rank > metricTotal * 0.90 = 17.1; toaster earned when
+  // rank > metricTotal * 0.75 = 14.25.
+  it('rank 18 of 19 (10.0.0.17): Tortoise is earned but Potato is not (18 > 17.1 but 18 < 19)', () => {
+    const wallet = [walletNode('10.0.0.17')];
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(true);
+  });
+
+  it('rank 17 of 19 (10.0.0.16): Toaster is earned but Tortoise is not (17 > 14.25 but 17 < 17.1)', () => {
+    const wallet = [walletNode('10.0.0.16')];
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(false);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_toaster').earned).toBe(true);
+
+    // pctFromBottom (achievements.js:333):
+    // ((metricTotal - rank + 1) / metricTotal * 100).toFixed(1)
+    // = ((19 - 17 + 1) / 19 * 100).toFixed(1) = (3 / 19 * 100).toFixed(1)
+    // = (15.789473...).toFixed(1) = '15.8'
+    // progressLabel (achievements.js:382):
+    // `Bottom ${pctFromBottom}% of ${displayTotal} ${tierLabel} nodes · ${metricLabel}`
+    // displayTotal = officialNodeCounts.CUMULUS.toLocaleString() = '20'
+    const toaster = worst.find((r) => r.id === 'slow_CUMULUS_toaster');
+    expect(toaster.progressLabel).toBe('Bottom 15.8% of 20 Cumulus nodes · EPS');
+  });
+
+  it('rank 1 of 19 (10.0.0.0): none of Potato/Tortoise/Toaster are earned — comfortably not near the bottom', () => {
+    const wallet = [walletNode('10.0.0.0')];
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(false);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_toaster').earned).toBe(false);
+  });
 });
 
 describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmarked = rank 1)', () => {
@@ -160,6 +232,13 @@ describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmar
       .find((r) => r.id === 'try_hard_CUMULUS_eps');
     expect(r1.earned).toBe(true);
     expect(r2.earned).toBe(false);
+    // progress (achievements.js:465): Math.max(0, Math.min(100,
+    //   (1 - (bestRank - 1) / Math.max(topFivePctThreshold, 1)) * 100))
+    // topFivePctThreshold = Math.ceil(19 * 0.05) = 1
+    // r1: bestRank=1 -> (1 - 0/1) * 100 = 100
+    // r2: bestRank=2 -> (1 - 1/1) * 100 = 0
+    expect(r1.progress).toBe(100);
+    expect(r2.progress).toBe(0);
   });
 
   it('with a larger pool (200 nodes), top 5% is rank 10 — reachable well beyond any small fixed top-N', () => {
@@ -213,7 +292,8 @@ describe('computeDictatorAchievements (characterization)', () => {
   };
 
   it('awards Dictator when the wallet node count meets or exceeds the leader count', () => {
-    const globalRankings = { countryDominance: { US: { leaderCount: 2 } }, nodeGeoMap };
+    // countryDominance[cc] shape per apidata.js:1179 is { leaderCount, country }.
+    const globalRankings = { countryDominance: { US: { leaderCount: 2, country: 'United States' } }, nodeGeoMap };
     const wallet = [walletNode('10.0.0.0'), walletNode('10.0.0.1')];
     const results = computeDictatorAchievements(wallet, globalRankings);
     const dictator = results.find((r) => r.id === 'dictator_US');
@@ -222,7 +302,8 @@ describe('computeDictatorAchievements (characterization)', () => {
   });
 
   it('does not award Dictator when the wallet node count is below the leader count', () => {
-    const globalRankings = { countryDominance: { US: { leaderCount: 3 } }, nodeGeoMap };
+    // countryDominance[cc] shape per apidata.js:1179 is { leaderCount, country }.
+    const globalRankings = { countryDominance: { US: { leaderCount: 3, country: 'United States' } }, nodeGeoMap };
     const wallet = [walletNode('10.0.0.0')];
     const results = computeDictatorAchievements(wallet, globalRankings);
     const dictator = results.find((r) => r.id === 'dictator_US');

--- a/client/src/main/Gamification/achievements.test.js
+++ b/client/src/main/Gamification/achievements.test.js
@@ -1,0 +1,231 @@
+import {
+  computeTierPerformanceAchievements,
+  computeCountryPerformanceAchievements,
+  computeTierWorstPerformanceAchievements,
+  computeWoodenSpoonAchievements,
+  computeTryHardAchievements,
+  computeDictatorAchievements,
+} from './achievements';
+
+/*
+ * Characterization tests for achievements.js's dynamic (network-ranking-based)
+ * achievement functions — established BEFORE the globalPerfRankings redesign
+ * (issue #153 / Tasks 2-5) so that redesign can be proven behavior-preserving
+ * instead of assumed to be. achievements.js had zero test coverage before this.
+ *
+ * IMPORTANT — fixture verification note:
+ * The task brief this file was derived from hand-computed a couple of expected
+ * values that do not match the CURRENT code when traced by hand (confirmed with
+ * a standalone Node script reproducing the exact sort/rank algorithm from
+ * apidata.js's fetch_global_performance_rankings). Both are corrected below,
+ * not silently — see the two comments marked "CORRECTED vs brief":
+ *
+ *  1. CUMULUS_EPS_RANKINGS has only 19 entries (node19 is deliberately
+ *     omitted to simulate an unbenchmarked node), so node18 (value=1, the
+ *     lowest value present) sorts to rank 19, not rank 20. The brief's dead-
+ *     last test comment/assertion assumed rank 20 of 20; the CURRENT code
+ *     computes rank 19 of 20 (rank from the 19-entry benchmark array, total
+ *     displayed from officialNodeCounts=20).
+ *  2. TIER_DISPLAY (in achievements.js) maps 'CUMULUS' -> 'Cumulus' (title
+ *     case), not 'CUMULUS' (upper case), for every tier label used in
+ *     user-facing strings (progressLabel/description). The brief's literal
+ *     string assertions used 'CUMULUS' verbatim; the CURRENT code renders
+ *     'Cumulus'. Corrected below to match the real rendered output.
+ */
+
+// A small CUMULUS tier: 20 nodes total, values chosen so every case below
+// (clear win, clear loss, exact tie, offline/unbenchmarked node, dead-last,
+// top-5%-boundary) is deliberately reachable.
+//
+// eps values, index 0..18: node0 is the clear #1 (100), node1 ties node2 at
+// 50 (tie case — node1 appears first in this array, so under the current
+// stable-sort behavior node1 must rank ABOVE node2 on a tie), nodes 3..17
+// descend from 45 to 3, node18 is the clear last (1), node19 has NO
+// benchmark entry at all (simulates an offline/unbenchmarked node — must
+// be absent from tierRankings.CUMULUS.eps entirely, not present with a 0).
+function buildCumulusTierRankings() {
+  const values = [100, 50, 50, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 7, 5, 1];
+  // node19 deliberately omitted — it exists in walletNodes but never appears here.
+  const sorted = values
+    .map((v, i) => ({ ip: `10.0.0.${i}`, value: v }))
+    .sort((a, b) => b.value - a.value); // stable: node1 (index1) stays before node2 (index2) on the tie
+  return sorted.map((n, i) => ({ ip: n.ip, rank: i + 1, value: n.value }));
+}
+
+const CUMULUS_EPS_RANKINGS = buildCumulusTierRankings();
+// Verified by hand and with a standalone Node script running the identical
+// sort/map logic (Array.prototype.sort is stable per spec since ES2019, and
+// this repo's benchmarked V8/Node confirms it): the resulting array has 19
+// entries (ranks 1..19). Index 1 (ip 10.0.0.1, value 50) lands at rank 2 and
+// index 2 (ip 10.0.0.2, value 50) lands at rank 3 — i.e. the first-appearing
+// node of a tie wins the better rank, exactly as the brief describes for the
+// tie case. Index 18 (ip 10.0.0.18, value 1) lands at rank 19 (dead last of
+// the 19-entry benchmarked pool), NOT rank 20 — see file-level comment above.
+
+// dws/down_speed/up_speed: reuse the same shape so tests can pick whichever
+// metric is convenient — only `eps` needs the carefully-tuned tie/edge values.
+const FLAT_RANKINGS = (n) =>
+  Array.from({ length: 20 }, (_, i) => ({ ip: `10.0.0.${i}`, rank: i + 1, value: n - i }));
+
+const TIER_RANKINGS = {
+  CUMULUS: {
+    eps: CUMULUS_EPS_RANKINGS,
+    dws: FLAT_RANKINGS(200),
+    down_speed: FLAT_RANKINGS(300),
+    up_speed: FLAT_RANKINGS(400),
+  },
+};
+
+const OFFICIAL_NODE_COUNTS = { CUMULUS: 20 };
+
+function walletNode(ip, tier = 'CUMULUS') {
+  return { ip_full: { host: ip }, ip_display: ip, tier };
+}
+
+describe('computeTierPerformanceAchievements (characterization — current behavior)', () => {
+  it('awards gold to the node ranked #1', () => {
+    const wallet = [walletNode('10.0.0.0')]; // eps=100, rank 1
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const gold = results.find((r) => r.id === 'global_CUMULUS_eps_gold');
+    expect(gold.earned).toBe(true);
+    // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
+    expect(gold.progressLabel).toBe('Global rank #1 of 20 Cumulus nodes');
+  });
+
+  it('does not award any medal to a node far from the top', () => {
+    const wallet = [walletNode('10.0.0.10')]; // eps=24, rank 11
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const medals = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
+    expect(medals.every((m) => !m.earned)).toBe(true);
+  });
+
+  it('breaks a tie the same way the current stable-sort ranking does — first-appearing node wins the better rank', () => {
+    // node at array index 1 (ip 10.0.0.1, eps=50) must rank ABOVE node at index 2 (10.0.0.2, eps=50)
+    const walletA = [walletNode('10.0.0.1')];
+    const walletB = [walletNode('10.0.0.2')];
+    const resultsA = computeTierPerformanceAchievements(walletA, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const resultsB = computeTierPerformanceAchievements(walletB, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const silverA = resultsA.find((r) => r.id === 'global_CUMULUS_eps_silver');
+    const silverB = resultsB.find((r) => r.id === 'global_CUMULUS_eps_silver');
+    expect(silverA.earned).toBe(true);  // rank 2
+    expect(silverB.earned).toBe(false); // rank 3, not silver
+  });
+
+  it('omits a node with no benchmark entry from the rankings entirely (not present, not rank 0)', () => {
+    const wallet = [walletNode('10.0.0.19')]; // never appears in CUMULUS_EPS_RANKINGS
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const eps = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
+    expect(eps.every((m) => !m.earned)).toBe(true);
+    // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
+    expect(eps[0].description).toBe('No Cumulus nodes with benchmark data found');
+  });
+});
+
+describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievements (characterization)', () => {
+  it('awards Potato (dead last) only to the true last-ranked node, using the TRUE total, not a trimmed approximation', () => {
+    // 10.0.0.18 is eps rank 19 of 19 benchmarked CUMULUS nodes (node19 is
+    // deliberately unbenchmarked, so the eps array itself has 19 entries) —
+    // the actual last position in the benchmark pool.
+    const wallet = [walletNode('10.0.0.18')];
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const potato = worst.find((r) => r.id === 'slow_CUMULUS_potato');
+    expect(potato.earned).toBe(true);
+    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
+    expect(spoon.earned).toBe(true);
+    // CORRECTED vs brief: rank is #19 (of the 19-entry benchmark array), not
+    // #20 — the display total (20) comes from officialNodeCounts and is a
+    // separate number from the rank, which is computed against the 19-entry
+    // eps array. Tier label is 'Cumulus' (title case), not 'CUMULUS'.
+    expect(spoon.progressLabel).toBe('Rank #19 of 20 Cumulus nodes · EPS');
+  });
+
+  it('does not award Potato/Wooden Spoon to a node one place off last', () => {
+    const wallet = [walletNode('10.0.0.17')]; // eps rank 18 of 19 — not dead last
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
+    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
+    expect(spoon.earned).toBe(false);
+  });
+});
+
+describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmarked = rank 1)', () => {
+  it('Math.ceil(19 * 0.05) = 1, so only rank 1 qualifies for this fixture\'s benchmarked pool', () => {
+    const walletRank1 = [walletNode('10.0.0.0')];
+    const walletRank2 = [walletNode('10.0.0.1')];
+    const r1 = computeTryHardAchievements(walletRank1, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    const r2 = computeTryHardAchievements(walletRank2, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    expect(r1.earned).toBe(true);
+    expect(r2.earned).toBe(false);
+  });
+
+  it('with a larger pool (200 nodes), top 5% is rank 10 — reachable well beyond any small fixed top-N', () => {
+    const bigRankings = {
+      CUMULUS: { eps: Array.from({ length: 200 }, (_, i) => ({ ip: `10.0.1.${i}`, rank: i + 1, value: 200 - i })) },
+    };
+    const officialCounts = { CUMULUS: 200 };
+    const walletRank10 = [walletNode('10.0.1.9')]; // rank 10
+    const walletRank11 = [walletNode('10.0.1.10')]; // rank 11
+    const r10 = computeTryHardAchievements(walletRank10, bigRankings, officialCounts)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    const r11 = computeTryHardAchievements(walletRank11, bigRankings, officialCounts)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    expect(r10.earned).toBe(true);
+    expect(r11.earned).toBe(false);
+  });
+});
+
+describe('computeCountryPerformanceAchievements (characterization)', () => {
+  const countryRankings = {
+    US: {
+      country: 'United States',
+      tiers: {
+        CUMULUS: { metrics: { eps: [
+          { ip: '10.0.0.0', rank: 1, value: 100 },
+          { ip: '10.0.0.1', rank: 2, value: 50 },
+          { ip: '10.0.0.2', rank: 3, value: 10 },
+        ] } },
+      },
+    },
+  };
+  const nodeGeoMap = { '10.0.0.0': { countryCode: 'US' }, '10.0.0.1': { countryCode: 'US' }, '10.0.0.2': { countryCode: 'US' } };
+
+  it('awards a country medal using the country-scoped total (3), not the network total', () => {
+    const wallet = [walletNode('10.0.0.0')];
+    const results = computeCountryPerformanceAchievements(wallet, countryRankings, nodeGeoMap);
+    const gold = results.find((r) => r.id === 'country_US_CUMULUS_eps_gold');
+    expect(gold.earned).toBe(true);
+    // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
+    expect(gold.description).toContain('among all 3 Cumulus nodes in United States');
+  });
+});
+
+describe('computeDictatorAchievements (characterization)', () => {
+  // Not covered by explicit test code in the brief, but the task requires
+  // coverage for all 6 dynamic ranking functions — this one ranks a wallet's
+  // node count in a country against the country's current leader count.
+  const nodeGeoMap = {
+    '10.0.0.0': { countryCode: 'US', country: 'United States' },
+    '10.0.0.1': { countryCode: 'US', country: 'United States' },
+  };
+
+  it('awards Dictator when the wallet node count meets or exceeds the leader count', () => {
+    const globalRankings = { countryDominance: { US: { leaderCount: 2 } }, nodeGeoMap };
+    const wallet = [walletNode('10.0.0.0'), walletNode('10.0.0.1')];
+    const results = computeDictatorAchievements(wallet, globalRankings);
+    const dictator = results.find((r) => r.id === 'dictator_US');
+    expect(dictator.earned).toBe(true);
+    expect(dictator.progressLabel).toBe('2 / 2 nodes in United States');
+  });
+
+  it('does not award Dictator when the wallet node count is below the leader count', () => {
+    const globalRankings = { countryDominance: { US: { leaderCount: 3 } }, nodeGeoMap };
+    const wallet = [walletNode('10.0.0.0')];
+    const results = computeDictatorAchievements(wallet, globalRankings);
+    const dictator = results.find((r) => r.id === 'dictator_US');
+    expect(dictator.earned).toBe(false);
+  });
+});

--- a/client/src/main/Gamification/achievements.test.js
+++ b/client/src/main/Gamification/achievements.test.js
@@ -20,70 +20,83 @@ import {
  * apidata.js's fetch_global_performance_rankings). Both are corrected below,
  * not silently — see the two comments marked "CORRECTED vs brief":
  *
- *  1. CUMULUS_EPS_RANKINGS has only 19 entries (node19 is deliberately
+ *  1. The CUMULUS nodeData fixture has only 19 entries (node19 is deliberately
  *     omitted to simulate an unbenchmarked node), so node18 (value=1, the
- *     lowest value present) sorts to rank 19, not rank 20. The brief's dead-
+ *     lowest value present) ranks 19, not rank 20. The brief's dead-
  *     last test comment/assertion assumed rank 20 of 20; the CURRENT code
- *     computes rank 19 of 20 (rank from the 19-entry benchmark array, total
+ *     computes rank 19 of 20 (rank from the 19-node benchmarked pool, total
  *     displayed from officialNodeCounts=20).
  *  2. TIER_DISPLAY (in achievements.js) maps 'CUMULUS' -> 'Cumulus' (title
  *     case), not 'CUMULUS' (upper case), for every tier label used in
  *     user-facing strings (progressLabel/description). The brief's literal
  *     string assertions used 'CUMULUS' verbatim; the CURRENT code renders
  *     'Cumulus'. Corrected below to match the real rendered output.
+ *
+ * ── TASK 4 FIXTURE-SHAPE MIGRATION ─────────────────────────────────────────
+ * Task 4 (issue #153) moved achievements.js's ranking functions from
+ * consuming pre-sorted per-metric arrays (`tierRankings`/`countryRankings`)
+ * to a flat `nodeData` array (`{ip, tier, eps, dws, down_speed, up_speed,
+ * geo}`, one entry per benchmarked node) ranked on demand via
+ * rankInGroup()/topInGroup() (Task 2). This file's FIXTURE SETUP below was
+ * reshaped accordingly — every expected value in every `expect(...)` call
+ * is UNCHANGED from before this migration; only the shape of the input data
+ * that produces those values changed.
+ *
+ * Reshaping note: the old fixture built 4 SEPARATE per-metric arrays for
+ * the CUMULUS tier (eps had 19 entries — node19 omitted to model an
+ * unbenchmarked node — while dws/down_speed/up_speed had 20, via
+ * FLAT_RANKINGS). A flat nodeData array can't represent "this node is
+ * benchmarked for dws but not eps" (one entry per node, not per metric) —
+ * so node19 is simply omitted from nodeData entirely (unbenchmarked for
+ * every metric). No existing test asserted anything about node19's
+ * dws/down_speed/up_speed standing, so this is a safe, behavior-preserving
+ * collapse: CUMULUS_NODE_DATA below has exactly 19 entries, and every
+ * tier-level total (`groupNodes.length` in achievements.js) that used to
+ * come from a metric-specific array's `.length` now comes from this same
+ * 19-node pool for every metric alike, which is what the old fixture's eps
+ * arithmetic already assumed for every rank/percentage computed below.
  */
 
-// A small CUMULUS tier: 20 nodes total, values chosen so every case below
-// (clear win, clear loss, exact tie, offline/unbenchmarked node, dead-last,
-// top-5%-boundary) is deliberately reachable.
+// A small CUMULUS tier: 19 benchmarked nodes (node19 deliberately omitted
+// entirely, to model an unbenchmarked/offline node — see migration note
+// above), values chosen so every case below (clear win, clear loss, exact
+// tie, offline/unbenchmarked node, dead-last, top-5%-boundary) is
+// deliberately reachable.
 //
 // eps values, index 0..18: node0 is the clear #1 (100), node1 ties node2 at
-// 50 (tie case — node1 appears first in this array, so under the current
-// stable-sort behavior node1 must rank ABOVE node2 on a tie), nodes 3..17
-// descend from 45 to 5, node18 is the clear last (1), node19 has NO
-// benchmark entry at all (simulates an offline/unbenchmarked node — must
-// be absent from tierRankings.CUMULUS.eps entirely, not present with a 0).
-function buildCumulusTierRankings() {
-  const values = [100, 50, 50, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 7, 5, 1];
-  // node19 deliberately omitted — it exists in walletNodes but never appears here.
-  const sorted = values
-    .map((v, i) => ({ ip: `10.0.0.${i}`, value: v }))
-    .sort((a, b) => b.value - a.value); // stable: node1 (index1) stays before node2 (index2) on the tie
-  return sorted.map((n, i) => ({ ip: n.ip, rank: i + 1, value: n.value }));
-}
-
-const CUMULUS_EPS_RANKINGS = buildCumulusTierRankings();
-// Verified by hand and with a standalone Node script running the identical
-// sort/map logic (Array.prototype.sort is stable per spec since ES2019, and
-// this repo's benchmarked V8/Node confirms it): the resulting array has 19
-// entries (ranks 1..19). Index 1 (ip 10.0.0.1, value 50) lands at rank 2 and
-// index 2 (ip 10.0.0.2, value 50) lands at rank 3 — i.e. the first-appearing
-// node of a tie wins the better rank, exactly as the brief describes for the
-// tie case. Index 18 (ip 10.0.0.18, value 1) lands at rank 19 (dead last of
-// the 19-entry benchmarked pool), NOT rank 20 — see file-level comment above.
-
-// dws/down_speed/up_speed: reuse the same shape so tests can pick whichever
-// metric is convenient — only `eps` needs the carefully-tuned tie/edge values.
+// 50 (tie case — node1 appears first in this array, so under rankInGroup's
+// stable-sort-equivalent tie-break node1 must rank ABOVE node2 on a tie),
+// nodes 3..17 descend from 45 to 5, node18 is the clear last (1). The array
+// is already in non-increasing eps order (matching the OLD fixture's
+// post-sort order exactly, since sorting an already-sorted array changes
+// nothing), so building nodeData directly in this index order reproduces
+// identical ranks to the old buildCumulusTierRankings()/sort step —
+// rankInGroup's tie-break is array-index-based, same as the old stable sort.
 //
-// NOTE: in the real data shape (apidata.js:1212-1217) all four per-tier metric
-// arrays (eps/dws/down_speed/up_speed) are always built from the same
-// `tierNodes` list, so they always share identical length/membership. This
-// fixture deliberately diverges — eps has 19 entries (CUMULUS_EPS_RANKINGS,
-// node19 omitted to model an unbenchmarked node) while dws/down_speed/up_speed
-// (built via FLAT_RANKINGS below) have 20 — purely to exercise that one
-// "unbenchmarked node" case. Don't read that divergence as a general
-// invariant of the real shape.
-const FLAT_RANKINGS = (n) =>
-  Array.from({ length: 20 }, (_, i) => ({ ip: `10.0.0.${i}`, rank: i + 1, value: n - i }));
+// dws/down_speed/up_speed reuse the old FLAT_RANKINGS(n) shape's per-index
+// formula (n - i) truncated to these same 19 nodes — no test asserts on
+// their values directly, they just need to exist so every metric in
+// PERF_METRICS has real numbers to rank.
+const CUMULUS_EPS_VALUES = [100, 50, 50, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 7, 5, 1];
 
-const TIER_RANKINGS = {
-  CUMULUS: {
-    eps: CUMULUS_EPS_RANKINGS,
-    dws: FLAT_RANKINGS(200),
-    down_speed: FLAT_RANKINGS(300),
-    up_speed: FLAT_RANKINGS(400),
-  },
-};
+const CUMULUS_NODE_DATA = CUMULUS_EPS_VALUES.map((eps, i) => ({
+  ip: `10.0.0.${i}`,
+  tier: 'CUMULUS',
+  eps,
+  dws: 200 - i,
+  down_speed: 300 - i,
+  up_speed: 400 - i,
+  geo: null,
+}));
+// Verified by hand: eps rank for node i (0-indexed) = 1 + count of nodes with
+// strictly greater eps, plus (for a tie) count of earlier-indexed nodes with
+// an equal eps. node0 (100) -> rank 1. node1 (50, tie w/ node2, earlier index)
+// -> rank 2. node2 (50, tie w/ node1, later index) -> rank 3. nodes 3..18
+// have unique descending values -> rank = index + 1 (ranks 4..19). node18
+// (value=1) lands at rank 19 (dead last of the 19-node benchmarked pool),
+// NOT rank 20 — see file-level comment above. node19 has no entry at all —
+// rankInGroup returns null for it, matching the old .find()-returns-
+// undefined "not present, not rank 0" behavior.
 
 const OFFICIAL_NODE_COUNTS = { CUMULUS: 20 };
 
@@ -94,7 +107,7 @@ function walletNode(ip, tier = 'CUMULUS') {
 describe('computeTierPerformanceAchievements (characterization — current behavior)', () => {
   it('awards gold to the node ranked #1', () => {
     const wallet = [walletNode('10.0.0.0')]; // eps=100, rank 1
-    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const results = computeTierPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     const gold = results.find((r) => r.id === 'global_CUMULUS_eps_gold');
     expect(gold.earned).toBe(true);
     // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
@@ -103,10 +116,10 @@ describe('computeTierPerformanceAchievements (characterization — current behav
 
   it('does not award any medal to a node far from the top', () => {
     const wallet = [walletNode('10.0.0.10')]; // eps=24, rank 11
-    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const results = computeTierPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     const medals = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
     expect(medals.every((m) => !m.earned)).toBe(true);
-    // progress (achievements.js:199-202): bestRank=11, totalInTier=20 (from
+    // progress (achievements.js:185-188): bestRank=11, totalInTier=20 (from
     // OFFICIAL_NODE_COUNTS.CUMULUS) →
     // (1 - (11-1)/20) * 100 = (1 - 0.5) * 100 = 50
     const gold = medals.find((m) => m.id === 'global_CUMULUS_eps_gold');
@@ -117,8 +130,8 @@ describe('computeTierPerformanceAchievements (characterization — current behav
     // node at array index 1 (ip 10.0.0.1, eps=50) must rank ABOVE node at index 2 (10.0.0.2, eps=50)
     const walletA = [walletNode('10.0.0.1')];
     const walletB = [walletNode('10.0.0.2')];
-    const resultsA = computeTierPerformanceAchievements(walletA, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
-    const resultsB = computeTierPerformanceAchievements(walletB, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const resultsA = computeTierPerformanceAchievements(walletA, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
+    const resultsB = computeTierPerformanceAchievements(walletB, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     const silverA = resultsA.find((r) => r.id === 'global_CUMULUS_eps_silver');
     const silverB = resultsB.find((r) => r.id === 'global_CUMULUS_eps_silver');
     expect(silverA.earned).toBe(true);  // rank 2
@@ -126,20 +139,20 @@ describe('computeTierPerformanceAchievements (characterization — current behav
   });
 
   it('omits a node with no benchmark entry from the rankings entirely (not present, not rank 0)', () => {
-    const wallet = [walletNode('10.0.0.19')]; // never appears in CUMULUS_EPS_RANKINGS
-    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const wallet = [walletNode('10.0.0.19')]; // never appears in CUMULUS_NODE_DATA
+    const results = computeTierPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     const eps = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
     expect(eps.every((m) => !m.earned)).toBe(true);
     // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
     expect(eps[0].description).toBe('No Cumulus nodes with benchmark data found');
   });
 
-  it('falls back to the benchmarked-array length when officialNodeCounts is missing (achievements.js:174)', () => {
-    // officialNodeCounts?.[tier] || metricRankings.length — omit officialNodeCounts
-    // entirely so totalInTier must come from CUMULUS_EPS_RANKINGS.length (19),
+  it('falls back to the benchmarked-node count when officialNodeCounts is missing (achievements.js:158)', () => {
+    // officialNodeCounts?.[tier] || groupNodes.length — omit officialNodeCounts
+    // entirely so totalInTier must come from CUMULUS_NODE_DATA.length (19),
     // NOT OFFICIAL_NODE_COUNTS.CUMULUS (20), proving the fallback branch ran.
     const wallet = [walletNode('10.0.0.0')]; // eps rank 1
-    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, undefined);
+    const results = computeTierPerformanceAchievements(wallet, CUMULUS_NODE_DATA, undefined);
     const gold = results.find((r) => r.id === 'global_CUMULUS_eps_gold');
     expect(gold.earned).toBe(true);
     expect(gold.progressLabel).toBe('Global rank #1 of 19 Cumulus nodes');
@@ -149,64 +162,64 @@ describe('computeTierPerformanceAchievements (characterization — current behav
 describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievements (characterization)', () => {
   it('awards Potato (dead last) to the true last-ranked node — earned boundary checked against the benchmarked count (metricTotal), not the true/official count (only the display string uses that)', () => {
     // 10.0.0.18 is eps rank 19 of 19 benchmarked CUMULUS nodes (node19 is
-    // deliberately unbenchmarked, so the eps array itself has 19 entries) —
+    // deliberately unbenchmarked, so nodeData itself has 19 CUMULUS entries) —
     // the actual last position in the benchmark pool.
     const wallet = [walletNode('10.0.0.18')];
-    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const worst = computeTierWorstPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     const potato = worst.find((r) => r.id === 'slow_CUMULUS_potato');
     expect(potato.earned).toBe(true);
-    // progress (achievements.js:344): Math.min(100, rank / metricTotal * 100)
+    // progress (achievements.js:328): Math.min(100, rank / metricTotal * 100)
     // = Math.min(100, 19 / 19 * 100) = 100
     expect(potato.progress).toBe(100);
-    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+    const spoon = computeWoodenSpoonAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS)
       .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
     expect(spoon.earned).toBe(true);
-    // progress (achievements.js:422): Math.max(0, Math.min(100, worstRank /
-    // metricRankings.length * 100)) = Math.min(100, 19 / 19 * 100) = 100
+    // progress (achievements.js:404): Math.max(0, Math.min(100, worstRank /
+    // groupNodes.length * 100)) = Math.min(100, 19 / 19 * 100) = 100
     expect(spoon.progress).toBe(100);
-    // CORRECTED vs brief: rank is #19 (of the 19-entry benchmark array), not
+    // CORRECTED vs brief: rank is #19 (of the 19-node benchmark pool), not
     // #20 — the display total (20) comes from officialNodeCounts and is a
-    // separate number from the rank, which is computed against the 19-entry
-    // eps array. Tier label is 'Cumulus' (title case), not 'CUMULUS'.
+    // separate number from the rank, which is computed against the 19-node
+    // nodeData pool. Tier label is 'Cumulus' (title case), not 'CUMULUS'.
     expect(spoon.progressLabel).toBe('Rank #19 of 20 Cumulus nodes · EPS');
   });
 
   it('does not award Potato/Wooden Spoon to a node one place off last', () => {
     const wallet = [walletNode('10.0.0.17')]; // eps rank 18 of 19 — not dead last
-    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const worst = computeTierWorstPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
-    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+    const spoon = computeWoodenSpoonAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS)
       .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
     expect(spoon.earned).toBe(false);
   });
 
-  // ── Tortoise / Toaster levels (achievements.js:348-365) — the existing
+  // ── Tortoise / Toaster levels (achievements.js:332-349) — the existing
   // tests above only ever exercise the Potato (dead-last) level. rank/
   // metricTotal for this fixture's eps pool: 10.0.0.16 -> rank 17,
   // 10.0.0.17 -> rank 18, 10.0.0.18 -> rank 19, metricTotal = 19 (verified
-  // by hand and by re-running buildCumulusTierRankings' exact sort/map logic).
+  // by hand against CUMULUS_NODE_DATA's ranking above).
   //
-  // Thresholds (achievements.js:350, :362): tortoise earned when
+  // Thresholds (achievements.js:334, :344): tortoise earned when
   // rank > metricTotal * 0.90 = 17.1; toaster earned when
   // rank > metricTotal * 0.75 = 14.25.
   it('rank 18 of 19 (10.0.0.17): Tortoise is earned but Potato is not (18 > 17.1 but 18 < 19)', () => {
     const wallet = [walletNode('10.0.0.17')];
-    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const worst = computeTierWorstPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(true);
   });
 
   it('rank 17 of 19 (10.0.0.16): Toaster is earned but Tortoise is not (17 > 14.25 but 17 < 17.1)', () => {
     const wallet = [walletNode('10.0.0.16')];
-    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const worst = computeTierWorstPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(false);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_toaster').earned).toBe(true);
 
-    // pctFromBottom (achievements.js:333):
+    // pctFromBottom (achievements.js:317):
     // ((metricTotal - rank + 1) / metricTotal * 100).toFixed(1)
     // = ((19 - 17 + 1) / 19 * 100).toFixed(1) = (3 / 19 * 100).toFixed(1)
     // = (15.789473...).toFixed(1) = '15.8'
-    // progressLabel (achievements.js:382):
+    // progressLabel (achievements.js:366):
     // `Bottom ${pctFromBottom}% of ${displayTotal} ${tierLabel} nodes · ${metricLabel}`
     // displayTotal = officialNodeCounts.CUMULUS.toLocaleString() = '20'
     const toaster = worst.find((r) => r.id === 'slow_CUMULUS_toaster');
@@ -215,7 +228,7 @@ describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievemen
 
   it('rank 1 of 19 (10.0.0.0): none of Potato/Tortoise/Toaster are earned — comfortably not near the bottom', () => {
     const wallet = [walletNode('10.0.0.0')];
-    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const worst = computeTierWorstPerformanceAchievements(wallet, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_tortoise').earned).toBe(false);
     expect(worst.find((r) => r.id === 'slow_CUMULUS_toaster').earned).toBe(false);
@@ -226,13 +239,13 @@ describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmar
   it('Math.ceil(19 * 0.05) = 1, so only rank 1 qualifies for this fixture\'s benchmarked pool', () => {
     const walletRank1 = [walletNode('10.0.0.0')];
     const walletRank2 = [walletNode('10.0.0.1')];
-    const r1 = computeTryHardAchievements(walletRank1, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+    const r1 = computeTryHardAchievements(walletRank1, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS)
       .find((r) => r.id === 'try_hard_CUMULUS_eps');
-    const r2 = computeTryHardAchievements(walletRank2, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+    const r2 = computeTryHardAchievements(walletRank2, CUMULUS_NODE_DATA, OFFICIAL_NODE_COUNTS)
       .find((r) => r.id === 'try_hard_CUMULUS_eps');
     expect(r1.earned).toBe(true);
     expect(r2.earned).toBe(false);
-    // progress (achievements.js:465): Math.max(0, Math.min(100,
+    // progress (achievements.js:445): Math.max(0, Math.min(100,
     //   (1 - (bestRank - 1) / Math.max(topFivePctThreshold, 1)) * 100))
     // topFivePctThreshold = Math.ceil(19 * 0.05) = 1
     // r1: bestRank=1 -> (1 - 0/1) * 100 = 100
@@ -242,15 +255,17 @@ describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmar
   });
 
   it('with a larger pool (200 nodes), top 5% is rank 10 — reachable well beyond any small fixed top-N', () => {
-    const bigRankings = {
-      CUMULUS: { eps: Array.from({ length: 200 }, (_, i) => ({ ip: `10.0.1.${i}`, rank: i + 1, value: 200 - i })) },
-    };
+    const bigNodeData = Array.from({ length: 200 }, (_, i) => ({
+      ip: `10.0.1.${i}`,
+      tier: 'CUMULUS',
+      eps: 200 - i,
+    }));
     const officialCounts = { CUMULUS: 200 };
     const walletRank10 = [walletNode('10.0.1.9')]; // rank 10
     const walletRank11 = [walletNode('10.0.1.10')]; // rank 11
-    const r10 = computeTryHardAchievements(walletRank10, bigRankings, officialCounts)
+    const r10 = computeTryHardAchievements(walletRank10, bigNodeData, officialCounts)
       .find((r) => r.id === 'try_hard_CUMULUS_eps');
-    const r11 = computeTryHardAchievements(walletRank11, bigRankings, officialCounts)
+    const r11 = computeTryHardAchievements(walletRank11, bigNodeData, officialCounts)
       .find((r) => r.id === 'try_hard_CUMULUS_eps');
     expect(r10.earned).toBe(true);
     expect(r11.earned).toBe(false);
@@ -258,23 +273,28 @@ describe('computeTryHardAchievements (characterization — top-5%-of-19-benchmar
 });
 
 describe('computeCountryPerformanceAchievements (characterization)', () => {
-  const countryRankings = {
-    US: {
-      country: 'United States',
-      tiers: {
-        CUMULUS: { metrics: { eps: [
-          { ip: '10.0.0.0', rank: 1, value: 100 },
-          { ip: '10.0.0.1', rank: 2, value: 50 },
-          { ip: '10.0.0.2', rank: 3, value: 10 },
-        ] } },
-      },
-    },
+  // Reshaped from the old countryRankings-shaped fixture into flat nodeData:
+  // 3 CUMULUS nodes, all geo-tagged US, eps 100/50/10 (ranks 1/2/3).
+  const countryNodeData = [
+    { ip: '10.0.0.0', tier: 'CUMULUS', eps: 100, geo: { countryCode: 'US' } },
+    { ip: '10.0.0.1', tier: 'CUMULUS', eps: 50, geo: { countryCode: 'US' } },
+    { ip: '10.0.0.2', tier: 'CUMULUS', eps: 10, geo: { countryCode: 'US' } },
+  ];
+  // nodeGeoMap must carry `.country` (display name) too — achievements.js's
+  // computeCountryPerformanceAchievements looks up the country's display
+  // name via Object.values(nodeGeoMap).find(g => g.countryCode === cc)?.country
+  // (chosen over threading in countryTierCounts as an extra parameter, since
+  // nodeGeoMap is already part of this function's signature — keeps the
+  // parameter list the same size it was before this migration).
+  const nodeGeoMap = {
+    '10.0.0.0': { countryCode: 'US', country: 'United States' },
+    '10.0.0.1': { countryCode: 'US', country: 'United States' },
+    '10.0.0.2': { countryCode: 'US', country: 'United States' },
   };
-  const nodeGeoMap = { '10.0.0.0': { countryCode: 'US' }, '10.0.0.1': { countryCode: 'US' }, '10.0.0.2': { countryCode: 'US' } };
 
   it('awards a country medal using the country-scoped total (3), not the network total', () => {
     const wallet = [walletNode('10.0.0.0')];
-    const results = computeCountryPerformanceAchievements(wallet, countryRankings, nodeGeoMap);
+    const results = computeCountryPerformanceAchievements(wallet, countryNodeData, nodeGeoMap);
     const gold = results.find((r) => r.id === 'country_US_CUMULUS_eps_gold');
     expect(gold.earned).toBe(true);
     // CORRECTED vs brief: TIER_DISPLAY.CUMULUS = 'Cumulus' (title case), not 'CUMULUS'.
@@ -286,6 +306,9 @@ describe('computeDictatorAchievements (characterization)', () => {
   // Not covered by explicit test code in the brief, but the task requires
   // coverage for all 6 dynamic ranking functions — this one ranks a wallet's
   // node count in a country against the country's current leader count.
+  // computeDictatorAchievements is UNCHANGED by Task 4 (it never used
+  // tierRankings/countryRankings, only countryDominance/nodeGeoMap, both
+  // untouched by Task 3) — no fixture reshaping needed here.
   const nodeGeoMap = {
     '10.0.0.0': { countryCode: 'US', country: 'United States' },
     '10.0.0.1': { countryCode: 'US', country: 'United States' },

--- a/client/src/main/Gamification/rankInGroup.js
+++ b/client/src/main/Gamification/rankInGroup.js
@@ -33,12 +33,16 @@
  * behavior exactly, and is a no-op when an ip has only one entry.
  */
 export function rankInGroup(groupNodes, targetIp, metricKey) {
+  // Ascending iteration + strict `>` already gives earliest-index-wins for
+  // ties among the target ip's own duplicates: once targetIndex is set,
+  // only a later i can be examined, so an equal-value duplicate can never
+  // displace it — no separate "earlier index" clause is needed here.
   let targetIndex = -1;
-  let targetValue = -Infinity;
+  let targetValue = 0;
   for (let i = 0; i < groupNodes.length; i++) {
     if (groupNodes[i].ip !== targetIp) continue;
     const v = groupNodes[i][metricKey] || 0;
-    if (targetIndex === -1 || v > targetValue || (v === targetValue && i < targetIndex)) {
+    if (targetIndex === -1 || v > targetValue) {
       targetIndex = i;
       targetValue = v;
     }

--- a/client/src/main/Gamification/rankInGroup.js
+++ b/client/src/main/Gamification/rankInGroup.js
@@ -19,11 +19,31 @@
  * Returns null if targetIp isn't in groupNodes at all (offline/
  * unbenchmarked node) — every caller already treats "not found" as "skip",
  * matching the old .find()-returns-undefined behavior.
+ *
+ * A bare IP can legitimately appear more than once in groupNodes: a single
+ * host running several Flux nodes on different ports all collapse to one
+ * key here, since nodeData carries no port (confirmed live 2026-09-09 —
+ * one wallet owning 8 CUMULUS nodes on one host, EPS ranging 265-2143
+ * across them). The OLD pre-sorted-array lookup sorted descending by value
+ * BEFORE any .find()-by-ip, so a duplicate ip always incidentally resolved
+ * to its highest-value entry. A naive first-match scan here would instead
+ * land on whatever happens to be first in nodeData's unsorted fetch order
+ * — silently downgrading a wallet's real best node to an arbitrary worse
+ * one. Scanning for the best (not first) matching entry restores the old
+ * behavior exactly, and is a no-op when an ip has only one entry.
  */
 export function rankInGroup(groupNodes, targetIp, metricKey) {
-  const targetIndex = groupNodes.findIndex((n) => n.ip === targetIp);
+  let targetIndex = -1;
+  let targetValue = -Infinity;
+  for (let i = 0; i < groupNodes.length; i++) {
+    if (groupNodes[i].ip !== targetIp) continue;
+    const v = groupNodes[i][metricKey] || 0;
+    if (targetIndex === -1 || v > targetValue || (v === targetValue && i < targetIndex)) {
+      targetIndex = i;
+      targetValue = v;
+    }
+  }
   if (targetIndex === -1) return null;
-  const targetValue = groupNodes[targetIndex][metricKey] || 0;
 
   let rank = 1;
   for (let i = 0; i < groupNodes.length; i++) {

--- a/client/src/main/Gamification/rankInGroup.js
+++ b/client/src/main/Gamification/rankInGroup.js
@@ -1,0 +1,51 @@
+/**
+ * Rank of one specific node within a group, by one metric — the on-demand
+ * replacement for looking a node up in a pre-sorted array (issue #153:
+ * pre-sorting and caching the ENTIRE network for every metric/tier/country
+ * combination was the single biggest sessionStorage cost, and no consumer
+ * ever needed any node's rank except a searched wallet's own — see
+ * docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md).
+ *
+ * Cheap specifically because it only ever runs for the handful of nodes a
+ * searched wallet owns, never for the whole network.
+ *
+ * Tie-break matches the OLD pre-sort exactly: Array.sort is stable in this
+ * engine, so among equal values the one appearing earlier in `groupNodes`
+ * always got the better (lower) rank. rank = 1 + (strictly greater) +
+ * (equal AND earlier in the array). Getting this wrong flips medal
+ * outcomes on tied values — the one behavior change this redesign must
+ * never introduce.
+ *
+ * Returns null if targetIp isn't in groupNodes at all (offline/
+ * unbenchmarked node) — every caller already treats "not found" as "skip",
+ * matching the old .find()-returns-undefined behavior.
+ */
+export function rankInGroup(groupNodes, targetIp, metricKey) {
+  const targetIndex = groupNodes.findIndex((n) => n.ip === targetIp);
+  if (targetIndex === -1) return null;
+  const targetValue = groupNodes[targetIndex][metricKey] || 0;
+
+  let rank = 1;
+  for (let i = 0; i < groupNodes.length; i++) {
+    if (i === targetIndex) continue;
+    const v = groupNodes[i][metricKey] || 0;
+    if (v > targetValue || (v === targetValue && i < targetIndex)) rank++;
+  }
+  return { rank, value: targetValue, total: groupNodes.length };
+}
+
+/**
+ * The single highest-value node in a group for one metric — replaces
+ * indexing [0] on a pre-sorted array (HomeOverview's "Top Dogs" panel).
+ * Tie-break: whichever node appears earlier in groupNodes wins, matching
+ * the old rank-1 assignment under a stable sort.
+ */
+export function topInGroup(groupNodes, metricKey) {
+  if (groupNodes.length === 0) return null;
+  let best = null;
+  for (const n of groupNodes) {
+    const v = n[metricKey] || 0;
+    if (best === null || v > best.value) best = { ip: n.ip, value: v };
+  }
+  return best;
+}

--- a/client/src/main/Gamification/rankInGroup.test.js
+++ b/client/src/main/Gamification/rankInGroup.test.js
@@ -1,0 +1,53 @@
+import { rankInGroup, topInGroup } from './rankInGroup';
+
+describe('rankInGroup', () => {
+  const nodes = [
+    { ip: 'a', eps: 50 }, // index 0
+    { ip: 'b', eps: 50 }, // index 1 — tied with a, appears later
+    { ip: 'c', eps: 100 }, // index 2 — highest
+    { ip: 'd', eps: 10 },  // index 3 — lowest
+  ];
+
+  it('ranks the clear highest as #1', () => {
+    expect(rankInGroup(nodes, 'c', 'eps')).toEqual({ rank: 1, value: 100, total: 4 });
+  });
+
+  it('ranks the clear lowest as last', () => {
+    expect(rankInGroup(nodes, 'd', 'eps')).toEqual({ rank: 4, value: 10, total: 4 });
+  });
+
+  it('breaks a tie in favor of whichever node appears earlier in the array (matches JS stable-sort behavior)', () => {
+    expect(rankInGroup(nodes, 'a', 'eps')).toEqual({ rank: 2, value: 50, total: 4 });
+    expect(rankInGroup(nodes, 'b', 'eps')).toEqual({ rank: 3, value: 50, total: 4 });
+  });
+
+  it('returns null for an ip not present in the group', () => {
+    expect(rankInGroup(nodes, 'not-here', 'eps')).toBeNull();
+  });
+
+  it('returns total:1, rank:1 for a single-node group', () => {
+    expect(rankInGroup([{ ip: 'only', eps: 5 }], 'only', 'eps')).toEqual({ rank: 1, value: 5, total: 1 });
+  });
+
+  it('treats a missing metric value as 0', () => {
+    const withMissing = [{ ip: 'x' }, { ip: 'y', eps: 5 }];
+    expect(rankInGroup(withMissing, 'x', 'eps')).toEqual({ rank: 2, value: 0, total: 2 });
+  });
+});
+
+describe('topInGroup', () => {
+  const nodes = [{ ip: 'a', eps: 50 }, { ip: 'b', eps: 100 }, { ip: 'c', eps: 10 }];
+
+  it('returns the highest-value node as {ip, value}', () => {
+    expect(topInGroup(nodes, 'eps')).toEqual({ ip: 'b', value: 100 });
+  });
+
+  it('returns null for an empty group', () => {
+    expect(topInGroup([], 'eps')).toBeNull();
+  });
+
+  it('breaks a tie in favor of whichever node appears earlier (matches the old rank-1 behavior)', () => {
+    const tied = [{ ip: 'first', eps: 100 }, { ip: 'second', eps: 100 }];
+    expect(topInGroup(tied, 'eps')).toEqual({ ip: 'first', value: 100 });
+  });
+});

--- a/client/src/main/Gamification/rankInGroup.test.js
+++ b/client/src/main/Gamification/rankInGroup.test.js
@@ -33,6 +33,43 @@ describe('rankInGroup', () => {
     const withMissing = [{ ip: 'x' }, { ip: 'y', eps: 5 }];
     expect(rankInGroup(withMissing, 'x', 'eps')).toEqual({ rank: 2, value: 0, total: 2 });
   });
+
+  // A single bare IP can legitimately appear more than once: one host
+  // running several Flux nodes on different ports all collapse to one
+  // nodeData key, since nodeData carries no port. Live-verified 2026-09-09
+  // (one wallet, 8 CUMULUS nodes sharing a host, EPS ranging 265-2143) —
+  // without this, a plain first-match scan silently downgraded a real #1
+  // node to an arbitrary, much worse one, flipping a Gold medal to nothing.
+  describe('a target ip with multiple entries in the group (one host, several ports)', () => {
+    it('resolves to the BEST (highest-value) entry, not whichever comes first in the array', () => {
+      const dup = [
+        { ip: 'shared', eps: 10 }, // index 0 — first occurrence, but not the best
+        { ip: 'other', eps: 500 }, // index 1
+        { ip: 'shared', eps: 900 }, // index 2 — the wallet's actual best node at this host
+        { ip: 'shared', eps: 300 }, // index 3 — a third port, mid value
+      ];
+      expect(rankInGroup(dup, 'shared', 'eps')).toEqual({ rank: 1, value: 900, total: 4 });
+    });
+
+    it('ranks the best duplicate correctly against the rest of the group, including its own lower-value siblings', () => {
+      const dup = [
+        { ip: 'shared', eps: 50 }, // a low-value duplicate — must not inflate the rank
+        { ip: 'top', eps: 999 }, // genuinely outranks the best 'shared' entry
+        { ip: 'shared', eps: 800 }, // the best 'shared' entry
+        { ip: 'mid', eps: 700 }, // below the best 'shared' entry
+      ];
+      expect(rankInGroup(dup, 'shared', 'eps')).toEqual({ rank: 2, value: 800, total: 4 });
+    });
+
+    it('breaks a tie among the target ip\'s own duplicates the same way as any other tie: earliest index wins', () => {
+      const dup = [
+        { ip: 'shared', eps: 500 }, // index 0 — earliest of the tied max
+        { ip: 'shared', eps: 500 }, // index 1 — tied with index 0
+        { ip: 'other', eps: 500 }, // index 2 — also tied, different ip
+      ];
+      expect(rankInGroup(dup, 'shared', 'eps')).toEqual({ rank: 1, value: 500, total: 3 });
+    });
+  });
 });
 
 describe('topInGroup', () => {

--- a/client/src/runningAppsCategorized.js
+++ b/client/src/runningAppsCategorized.js
@@ -76,11 +76,23 @@ export function categorizeRunningApps(aggregate, specIndex) {
   // Image-level tallies, resolved per component (see the note above).
   const repoCounts = {}; // repotag -> count, for topRunningApps (unresolved names excluded)
   let wordpressCount = 0;
+  // A container can fail to resolve a repotag for two different reasons, and
+  // conflating them under a silent `continue` under-counts the network
+  // without telling the viewer why: an Enterprise app's spec exists but its
+  // compose is encrypted by design (nothing to rank, not an error), while a
+  // container with no spec found at all is genuinely unresolved/unknown.
+  let enterpriseContainers = 0;
+  let unresolvedContainers = 0;
 
   for (const [key, count] of Object.entries(componentCounts)) {
     const { name, component } = splitComponentCountKey(key);
-    const repotag = repotagForComponent(index[name], component);
-    if (!repotag) continue;
+    const spec = index[name];
+    const repotag = repotagForComponent(spec, component);
+    if (!repotag) {
+      if (spec?.category === 'enterprise') enterpriseContainers += count;
+      else unresolvedContainers += count;
+      continue;
+    }
 
     repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
     if (repotag.split(':')[0] === WORDPRESS_REPO_BASE) {
@@ -124,6 +136,8 @@ export function categorizeRunningApps(aggregate, specIndex) {
     wordpressCount,
     streamrRunningApps: streamrNodes,
     presearchRunningApps: presearchNodes,
-    totalRunningApps
+    totalRunningApps,
+    enterpriseContainers,
+    unresolvedContainers
   };
 }

--- a/client/src/runningAppsCategorized.test.js
+++ b/client/src/runningAppsCategorized.test.js
@@ -1,4 +1,5 @@
 import { categorizeRunningApps } from './runningAppsCategorized';
+import { componentCountKey } from 'fluxinfo';
 
 const specIndex = {
   FoldingAtRunOnFlux1: { repotag: 'yurinnick/folding-at-home:latest', category: 'computing' },
@@ -83,6 +84,29 @@ describe('categorizeRunningApps', () => {
   it('does not throw when nodesByIp or specIndex is missing entirely', () => {
     expect(() => categorizeRunningApps({ nameCounts: { a: 1 } }, undefined)).not.toThrow();
     expect(() => categorizeRunningApps({}, {})).not.toThrow();
+  });
+
+  it('reports enterpriseContainers separately from the ranking, for apps whose spec is Enterprise (repotag deliberately hidden)', () => {
+    const aggregate = {
+      nameCounts: { entApp: 2 },
+      componentCounts: { [componentCountKey('entApp', null)]: 2 },
+      nodesByIp: {},
+    };
+    const specIndex = { entApp: { category: 'enterprise', repotag: '', compose: null } };
+    const { enterpriseContainers, unresolvedContainers } = categorizeRunningApps(aggregate, specIndex);
+    expect(enterpriseContainers).toBe(2);
+    expect(unresolvedContainers).toBe(0);
+  });
+
+  it('reports unresolvedContainers separately, for apps with no spec found at all', () => {
+    const aggregate = {
+      nameCounts: { ghostApp: 1 },
+      componentCounts: { [componentCountKey('ghostApp', null)]: 1 },
+      nodesByIp: {},
+    };
+    const { enterpriseContainers, unresolvedContainers } = categorizeRunningApps(aggregate, {});
+    expect(enterpriseContainers).toBe(0);
+    expect(unresolvedContainers).toBe(1);
   });
 });
 

--- a/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
+++ b/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
@@ -42,10 +42,14 @@ the same architecture the spec approved, not a design change.
 - `client/src/` only — no Rust API changes anywhere in this plan.
 - No new npm dependency.
 - Test with `cd client && CI=true npx react-scripts test --watchAll=false`,
-  build with `npx react-scripts build`. Baseline going into this plan:
-  **359 tests, build exit 0, exactly 4 pre-existing baseline warning files**
-  (`Navbar/index.jsx`, `NodeGridTable/index.jsx`, `LayoutContext.jsx`,
-  `WalletNodes/index.jsx`). Anything beyond those four is new work.
+  build with `npx react-scripts build`. Baseline going into this plan
+  (verified fresh in this worktree, post-#187-and-Live-Session-D-merge):
+  **367 tests, 23 suites, build exit 0, exactly 4 pre-existing baseline
+  warning files** (`Navbar/index.jsx`, `NodeGridTable/index.jsx`,
+  `LayoutContext.jsx`, `WalletNodes/index.jsx`). Anything beyond those four
+  is new work. (An earlier draft of this plan cited 359 — that number
+  predates both prior branches being merged together onto `main`; 367 is
+  the real current baseline.)
 - Part C.3 (Tasks 3-6) must not change any achievement's earned/not-earned
   outcome, progress percentage, or displayed description text for any
   input that was valid before this plan. Task 1's characterization tests

--- a/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
+++ b/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
@@ -1,0 +1,1353 @@
+# Accuracy & Reliability Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three issues surfaced by one investigation: Top Hosted Apps
+silently hides ~23% of the network (Enterprise apps) with no indication;
+GitHub #189 — one unguarded fetch zeros the entire Home page on a rate
+limit; GitHub #153 — sessionStorage sits at ~85% of quota, dominated by a
+2.9MB cache (`globalPerfRankings_v3`) that pre-sorts the *entire* network
+for every metric/tier/country combination when every real consumer only
+ever needs a searched wallet's own handful of nodes ranked against that
+data, plus a few small aggregate counts.
+
+**Architecture:** Parts A, B, C.1, C.2 are small, independent, low-risk
+changes to existing functions. Part C.3 (Tasks 3-6 below) replaces
+`fetch_global_performance_rankings`'s pre-exploded `tierRankings`/
+`countryRankings` (12+ duplicated copies of the network) with one
+un-duplicated per-node array (`nodeData`) plus small precomputed
+aggregates, and a new on-demand ranking helper that computes a specific
+node's rank by comparison only when actually needed (i.e. only for a
+searched wallet's own nodes — never for the whole network). Every consumer
+(`achievements.js`'s 6 dynamic achievement functions, `_extract_country_counts`,
+`HomeOverview`'s `TopDogsPanel`) is migrated to the new shape. Task 1
+establishes verified ground-truth behavior via characterization tests
+*before* anything is touched, specifically because `achievements.js` has
+zero existing test coverage today and this is the highest-risk part of
+this plan.
+
+**Tech Stack:** React 18, plain JS. No new npm dependency.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md`
+— read it in full; it contains the live-measured numbers, the full
+per-consumer requirements table for Part C.3, and the reasoning for why a
+naive top-N trim was rejected. This plan's Task 3 refines two of the
+spec's field names (`tierWinners` instead of overloading `tierRankings`'s
+shape; a precomputed `countryTierCounts` instead of a separate
+`totalInCountryTier`) — both are implementation-level clarifications of
+the same architecture the spec approved, not a design change.
+
+## Global Constraints
+
+- `client/src/` only — no Rust API changes anywhere in this plan.
+- No new npm dependency.
+- Test with `cd client && CI=true npx react-scripts test --watchAll=false`,
+  build with `npx react-scripts build`. Baseline going into this plan:
+  **359 tests, build exit 0, exactly 4 pre-existing baseline warning files**
+  (`Navbar/index.jsx`, `NodeGridTable/index.jsx`, `LayoutContext.jsx`,
+  `WalletNodes/index.jsx`). Anything beyond those four is new work.
+- Part C.3 (Tasks 3-6) must not change any achievement's earned/not-earned
+  outcome, progress percentage, or displayed description text for any
+  input that was valid before this plan. Task 1's characterization tests
+  are the enforcement mechanism for this — they must still pass, unmodified,
+  after Tasks 3-6 land.
+- Cache key `globalPerfRankings_v3` → `v4` (Task 3) — old key added to the
+  existing stale-key prune list, matching this repo's established
+  versioning convention (see `RAW_APP_SPECS_STALE_KEYS` in `apidata.js` for
+  the pattern to follow).
+
+---
+
+## File Structure
+
+- Create: `client/src/main/Gamification/rankInGroup.js` — the new pure
+  on-demand ranking helper (Task 2).
+- Create: `client/src/main/Gamification/rankInGroup.test.js`
+- Create: `client/src/main/Gamification/achievements.test.js` — the
+  characterization tests (Task 1), extended in Task 4.
+- Modify: `client/src/apidata.js` — `fetch_global_performance_rankings`
+  (Task 3), `fetch_global_stats`'s 5 unguarded fetchers (Task 7),
+  `fetch_global_app_specs_raw`'s cache write (Task 8), `_extract_country_counts`
+  (Task 3).
+- Modify: `client/src/main/Gamification/achievements.js` — the 6 dynamic
+  achievement functions (Task 4).
+- Modify: `client/src/home/HomeOverview/index.jsx` — `TopDogsPanel`/
+  `TierRow`/`MetricCard` (Task 5).
+- Modify: `client/src/runningAppsCategorized.js`,
+  `client/src/runningAppsCategorized.test.js`,
+  `client/src/components/TopHostedApps/index.jsx` (Task 6).
+- Modify: `client/src/apidata.test.js` (Tasks 3, 7, 8).
+
+---
+
+### Task 1: Characterization tests for `achievements.js`'s dynamic functions (against CURRENT code — do not touch the implementation)
+
+**Files:**
+- Create: `client/src/main/Gamification/achievements.test.js`
+
+**Interfaces:**
+- Consumes: `computeAchievements` and the module's exported/testable
+  surface as it exists **right now, unmodified**. If a function you need to
+  test isn't exported, add `export` to it in this task (a pure visibility
+  change, not a behavior change) rather than testing it indirectly through
+  `computeAchievements` alone — you want direct, precise assertions on
+  `computeTierPerformanceAchievements`, `computeCountryPerformanceAchievements`,
+  `computeTierWorstPerformanceAchievements`, `computeWoodenSpoonAchievements`,
+  `computeTryHardAchievements`, and `computeDictatorAchievements` (already
+  fine, doesn't touch rankings), plus `apidata.js`'s `_extract_country_counts`
+  (add `export` there too if needed).
+- Produces: a fixture set and expected-output assertions that Task 4 must
+  keep passing unmodified.
+
+This is the most important task in this plan — read it carefully and do
+not rush it. `achievements.js` has never had a test before. These tests
+are what makes "did we break anything" a verified fact instead of a hope.
+
+- [ ] **Step 1: Build one shared fixture set covering every edge case that matters**
+
+Add to the new test file:
+
+```js
+import {
+  computeTierPerformanceAchievements,
+  computeCountryPerformanceAchievements,
+  computeTierWorstPerformanceAchievements,
+  computeWoodenSpoonAchievements,
+  computeTryHardAchievements,
+} from './achievements';
+
+// A small CUMULUS tier: 20 nodes total, values chosen so every case below
+// (clear win, clear loss, exact tie, offline/unbenchmarked node, dead-last,
+// top-5%-boundary) is deliberately reachable.
+//
+// eps values, index 0..19: node0 is the clear #1 (100), node1 ties node2 at
+// 50 (tie case — node1 appears first in this array, so under the current
+// stable-sort behavior node1 must rank ABOVE node2 on a tie), nodes 3..17
+// descend from 45 to 3, node18 is the clear last (1), node19 has NO
+// benchmark entry at all (simulates an offline/unbenchmarked node — must
+// be absent from tierRankings.CUMULUS.eps entirely, not present with a 0).
+function buildCumulusTierRankings() {
+  const values = [100, 50, 50, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 7, 5, 1];
+  // node19 deliberately omitted — it exists in walletNodes but never appears here.
+  const sorted = values
+    .map((v, i) => ({ ip: `10.0.0.${i}`, value: v }))
+    .sort((a, b) => b.value - a.value); // stable: node1 (index1) stays before node2 (index2) on the tie
+  return sorted.map((n, i) => ({ ip: n.ip, rank: i + 1, value: n.value }));
+}
+
+const CUMULUS_EPS_RANKINGS = buildCumulusTierRankings();
+// dws/down_speed/up_speed: reuse the same shape so tests can pick whichever
+// metric is convenient — only `eps` needs the carefully-tuned tie/edge values.
+const FLAT_RANKINGS = (n) =>
+  Array.from({ length: 20 }, (_, i) => ({ ip: `10.0.0.${i}`, rank: i + 1, value: n - i }));
+
+const TIER_RANKINGS = {
+  CUMULUS: {
+    eps: CUMULUS_EPS_RANKINGS,
+    dws: FLAT_RANKINGS(200),
+    down_speed: FLAT_RANKINGS(300),
+    up_speed: FLAT_RANKINGS(400),
+  },
+};
+
+const OFFICIAL_NODE_COUNTS = { CUMULUS: 20 };
+
+function walletNode(ip, tier = 'CUMULUS') {
+  return { ip_full: { host: ip }, ip_display: ip, tier };
+}
+```
+
+Confirm (by hand, against the current `_bestRankInTier`/`.sort()` logic in
+`apidata.js`'s `fetch_global_performance_rankings`) that `CUMULUS_EPS_RANKINGS`
+really does put the index-1 node (value 50) at rank 2 and the index-2 node
+(also value 50) at rank 3 — i.e. verify the fixture models the CURRENT
+stable-sort tie behavior correctly before writing assertions against it.
+This is the single most important thing to get right in this task.
+
+- [ ] **Step 2: Medal achievements — clear win, clear loss, exact tie**
+
+```js
+describe('computeTierPerformanceAchievements (characterization — current behavior)', () => {
+  it('awards gold to the node ranked #1', () => {
+    const wallet = [walletNode('10.0.0.0')]; // eps=100, rank 1
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const gold = results.find((r) => r.id === 'global_CUMULUS_eps_gold');
+    expect(gold.earned).toBe(true);
+    expect(gold.progressLabel).toBe('Global rank #1 of 20 CUMULUS nodes');
+  });
+
+  it('does not award any medal to a node far from the top', () => {
+    const wallet = [walletNode('10.0.0.10')]; // eps=24, rank 11
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const medals = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
+    expect(medals.every((m) => !m.earned)).toBe(true);
+  });
+
+  it('breaks a tie the same way the current stable-sort ranking does — first-appearing node wins the better rank', () => {
+    // node at array index 1 (ip 10.0.0.1, eps=50) must rank ABOVE node at index 2 (10.0.0.2, eps=50)
+    const walletA = [walletNode('10.0.0.1')];
+    const walletB = [walletNode('10.0.0.2')];
+    const resultsA = computeTierPerformanceAchievements(walletA, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const resultsB = computeTierPerformanceAchievements(walletB, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const silverA = resultsA.find((r) => r.id === 'global_CUMULUS_eps_silver');
+    const silverB = resultsB.find((r) => r.id === 'global_CUMULUS_eps_silver');
+    expect(silverA.earned).toBe(true);  // rank 2
+    expect(silverB.earned).toBe(false); // rank 3, not silver
+  });
+
+  it('omits a node with no benchmark entry from the rankings entirely (not present, not rank 0)', () => {
+    const wallet = [walletNode('10.0.0.19')]; // never appears in CUMULUS_EPS_RANKINGS
+    const results = computeTierPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const eps = results.filter((r) => r.id.startsWith('global_CUMULUS_eps_'));
+    expect(eps.every((m) => !m.earned)).toBe(true);
+    expect(eps[0].description).toBe('No CUMULUS nodes with benchmark data found');
+  });
+});
+```
+
+- [ ] **Step 3: Worst-performance ("Potato"/"Tortoise"/"Toaster") and Wooden Spoon — dead-last boundary**
+
+```js
+describe('computeTierWorstPerformanceAchievements / computeWoodenSpoonAchievements (characterization)', () => {
+  it('awards Potato (dead last) only to the true last-ranked node, using the TRUE total, not a trimmed approximation', () => {
+    // 10.0.0.18 is eps rank 20 of 20 — the actual last position.
+    const wallet = [walletNode('10.0.0.18')];
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    const potato = worst.find((r) => r.id === 'slow_CUMULUS_potato');
+    expect(potato.earned).toBe(true);
+    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
+    expect(spoon.earned).toBe(true);
+    expect(spoon.progressLabel).toBe('Rank #20 of 20 CUMULUS nodes · EPS');
+  });
+
+  it('does not award Potato/Wooden Spoon to a node one place off last', () => {
+    const wallet = [walletNode('10.0.0.17')]; // rank 19 of 20 — not dead last
+    const worst = computeTierWorstPerformanceAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS);
+    expect(worst.find((r) => r.id === 'slow_CUMULUS_potato').earned).toBe(false);
+    const spoon = computeWoodenSpoonAchievements(wallet, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'wooden_spoon_CUMULUS_eps');
+    expect(spoon.earned).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 4: Try Hard (top 5%) — the case that needs the TRUE total, not top-N**
+
+```js
+describe('computeTryHardAchievements (characterization — top-5%-of-20 = rank 1)', () => {
+  it('Math.ceil(20 * 0.05) = 1, so only rank 1 qualifies for a 20-node pool', () => {
+    const walletRank1 = [walletNode('10.0.0.0')];
+    const walletRank2 = [walletNode('10.0.0.1')];
+    const r1 = computeTryHardAchievements(walletRank1, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    const r2 = computeTryHardAchievements(walletRank2, TIER_RANKINGS, OFFICIAL_NODE_COUNTS)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    expect(r1.earned).toBe(true);
+    expect(r2.earned).toBe(false);
+  });
+
+  it('with a larger pool (200 nodes), top 5% is rank 10 — reachable well beyond any small fixed top-N', () => {
+    const bigRankings = {
+      CUMULUS: { eps: Array.from({ length: 200 }, (_, i) => ({ ip: `10.0.1.${i}`, rank: i + 1, value: 200 - i })) },
+    };
+    const officialCounts = { CUMULUS: 200 };
+    const walletRank10 = [walletNode('10.0.1.9')]; // rank 10
+    const walletRank11 = [walletNode('10.0.1.10')]; // rank 11
+    const r10 = computeTryHardAchievements(walletRank10, bigRankings, officialCounts)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    const r11 = computeTryHardAchievements(walletRank11, bigRankings, officialCounts)
+      .find((r) => r.id === 'try_hard_CUMULUS_eps');
+    expect(r10.earned).toBe(true);
+    expect(r11.earned).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5: Country performance achievements**
+
+```js
+describe('computeCountryPerformanceAchievements (characterization)', () => {
+  const countryRankings = {
+    US: {
+      country: 'United States',
+      tiers: {
+        CUMULUS: { metrics: { eps: [
+          { ip: '10.0.0.0', rank: 1, value: 100 },
+          { ip: '10.0.0.1', rank: 2, value: 50 },
+          { ip: '10.0.0.2', rank: 3, value: 10 },
+        ] } },
+      },
+    },
+  };
+  const nodeGeoMap = { '10.0.0.0': { countryCode: 'US' }, '10.0.0.1': { countryCode: 'US' }, '10.0.0.2': { countryCode: 'US' } };
+
+  it('awards a country medal using the country-scoped total (3), not the network total', () => {
+    const wallet = [walletNode('10.0.0.0')];
+    const results = computeCountryPerformanceAchievements(wallet, countryRankings, nodeGeoMap);
+    const gold = results.find((r) => r.id === 'country_US_CUMULUS_eps_gold');
+    expect(gold.earned).toBe(true);
+    expect(gold.description).toContain('among all 3 CUMULUS nodes in United States');
+  });
+});
+```
+
+- [ ] **Step 6: `_extract_country_counts` (in `apidata.js`)**
+
+```js
+// In a new or existing client/src/apidata.test.js describe block:
+import { _extract_country_counts } from './apidata'; // export it if not already
+
+describe('_extract_country_counts (characterization — current behavior)', () => {
+  it('counts nodes per country by summing each tier\'s eps array length', () => {
+    const countryRankings = {
+      US: { country: 'United States', countryCode: 'US', tiers: {
+        CUMULUS: { metrics: { eps: [{ ip: 'a' }, { ip: 'b' }] } },
+        STRATUS: { metrics: { eps: [{ ip: 'c' }] } },
+      } },
+    };
+    const result = _extract_country_counts(countryRankings);
+    expect(result).toEqual([{ country: 'United States', countryCode: 'US', nodeCount: 3 }]);
+  });
+});
+```
+
+- [ ] **Step 7: Run and confirm every test passes against the CURRENT, unmodified code**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern "achievements|apidata.test"`
+Expected: all new tests PASS. If any fails, your fixture's hand-computed
+expectation is wrong, not the code — re-derive it by tracing the actual
+current algorithm, do not adjust the production code to make a test pass
+in this task.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add client/src/main/Gamification/achievements.test.js client/src/apidata.js client/src/apidata.test.js
+git commit -m "test(achievements): characterization tests for dynamic ranking achievements
+
+Establishes verified ground-truth behavior before the globalPerfRankings
+redesign (issue #153) — achievements.js had zero test coverage before this."
+```
+
+---
+
+### Task 2: `rankInGroup` / `topInGroup` — the new on-demand ranking helper
+
+**Files:**
+- Create: `client/src/main/Gamification/rankInGroup.js`
+- Create: `client/src/main/Gamification/rankInGroup.test.js`
+
+**Interfaces:**
+- Produces: `rankInGroup(groupNodes, targetIp, metricKey)` →
+  `{rank, value, total} | null`; `topInGroup(groupNodes, metricKey)` →
+  `{ip, value} | null`. `groupNodes` is any array of objects with `.ip` and
+  a numeric field named `metricKey` (e.g. `{ip, eps, dws, down_speed, up_speed}`
+  — the shape Task 3's `nodeData` will use). Consumed by Task 4
+  (`achievements.js`) and Task 5 (`HomeOverview.jsx`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import { rankInGroup, topInGroup } from './rankInGroup';
+
+describe('rankInGroup', () => {
+  const nodes = [
+    { ip: 'a', eps: 50 }, // index 0
+    { ip: 'b', eps: 50 }, // index 1 — tied with a, appears later
+    { ip: 'c', eps: 100 }, // index 2 — highest
+    { ip: 'd', eps: 10 },  // index 3 — lowest
+  ];
+
+  it('ranks the clear highest as #1', () => {
+    expect(rankInGroup(nodes, 'c', 'eps')).toEqual({ rank: 1, value: 100, total: 4 });
+  });
+
+  it('ranks the clear lowest as last', () => {
+    expect(rankInGroup(nodes, 'd', 'eps')).toEqual({ rank: 4, value: 10, total: 4 });
+  });
+
+  it('breaks a tie in favor of whichever node appears earlier in the array (matches JS stable-sort behavior)', () => {
+    expect(rankInGroup(nodes, 'a', 'eps')).toEqual({ rank: 2, value: 50, total: 4 });
+    expect(rankInGroup(nodes, 'b', 'eps')).toEqual({ rank: 3, value: 50, total: 4 });
+  });
+
+  it('returns null for an ip not present in the group', () => {
+    expect(rankInGroup(nodes, 'not-here', 'eps')).toBeNull();
+  });
+
+  it('returns total:1, rank:1 for a single-node group', () => {
+    expect(rankInGroup([{ ip: 'only', eps: 5 }], 'only', 'eps')).toEqual({ rank: 1, value: 5, total: 1 });
+  });
+
+  it('treats a missing metric value as 0', () => {
+    const withMissing = [{ ip: 'x' }, { ip: 'y', eps: 5 }];
+    expect(rankInGroup(withMissing, 'x', 'eps')).toEqual({ rank: 2, value: 0, total: 2 });
+  });
+});
+
+describe('topInGroup', () => {
+  const nodes = [{ ip: 'a', eps: 50 }, { ip: 'b', eps: 100 }, { ip: 'c', eps: 10 }];
+
+  it('returns the highest-value node as {ip, value}', () => {
+    expect(topInGroup(nodes, 'eps')).toEqual({ ip: 'b', value: 100 });
+  });
+
+  it('returns null for an empty group', () => {
+    expect(topInGroup([], 'eps')).toBeNull();
+  });
+
+  it('breaks a tie in favor of whichever node appears earlier (matches the old rank-1 behavior)', () => {
+    const tied = [{ ip: 'first', eps: 100 }, { ip: 'second', eps: 100 }];
+    expect(topInGroup(tied, 'eps')).toEqual({ ip: 'first', value: 100 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern rankInGroup`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```js
+/**
+ * Rank of one specific node within a group, by one metric — the on-demand
+ * replacement for looking a node up in a pre-sorted array (issue #153:
+ * pre-sorting and caching the ENTIRE network for every metric/tier/country
+ * combination was the single biggest sessionStorage cost, and no consumer
+ * ever needed any node's rank except a searched wallet's own — see
+ * docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md).
+ *
+ * Cheap specifically because it only ever runs for the handful of nodes a
+ * searched wallet owns, never for the whole network.
+ *
+ * Tie-break matches the OLD pre-sort exactly: Array.sort is stable in this
+ * engine, so among equal values the one appearing earlier in `groupNodes`
+ * always got the better (lower) rank. rank = 1 + (strictly greater) +
+ * (equal AND earlier in the array). Getting this wrong flips medal
+ * outcomes on tied values — the one behavior change this redesign must
+ * never introduce.
+ *
+ * Returns null if targetIp isn't in groupNodes at all (offline/
+ * unbenchmarked node) — every caller already treats "not found" as "skip",
+ * matching the old .find()-returns-undefined behavior.
+ */
+export function rankInGroup(groupNodes, targetIp, metricKey) {
+  const targetIndex = groupNodes.findIndex((n) => n.ip === targetIp);
+  if (targetIndex === -1) return null;
+  const targetValue = groupNodes[targetIndex][metricKey] || 0;
+
+  let rank = 1;
+  for (let i = 0; i < groupNodes.length; i++) {
+    if (i === targetIndex) continue;
+    const v = groupNodes[i][metricKey] || 0;
+    if (v > targetValue || (v === targetValue && i < targetIndex)) rank++;
+  }
+  return { rank, value: targetValue, total: groupNodes.length };
+}
+
+/**
+ * The single highest-value node in a group for one metric — replaces
+ * indexing [0] on a pre-sorted array (HomeOverview's "Top Dogs" panel).
+ * Tie-break: whichever node appears earlier in groupNodes wins, matching
+ * the old rank-1 assignment under a stable sort.
+ */
+export function topInGroup(groupNodes, metricKey) {
+  if (groupNodes.length === 0) return null;
+  let best = null;
+  for (const n of groupNodes) {
+    const v = n[metricKey] || 0;
+    if (best === null || v > best.value) best = { ip: n.ip, value: v };
+  }
+  return best;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern rankInGroup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/main/Gamification/rankInGroup.js client/src/main/Gamification/rankInGroup.test.js
+git commit -m "feat(gamification): add on-demand rankInGroup/topInGroup helpers (#153)"
+```
+
+---
+
+### Task 3: Redesign `fetch_global_performance_rankings` — `nodeData` instead of exploded rankings
+
+**Files:**
+- Modify: `client/src/apidata.js` (`fetch_global_performance_rankings`,
+  `GLOBAL_RANKINGS_CACHE_KEY`, `GLOBAL_RANKINGS_STALE_KEYS` if none exists
+  yet — add one, matching `RAW_APP_SPECS_STALE_KEYS`'s pattern, so old
+  `globalPerfRankings_v3` entries get pruned), `_extract_country_counts`
+- Modify: `client/src/apidata.test.js`
+
+**Interfaces:**
+- Produces: `fetch_global_performance_rankings()` now resolves to
+  `{ nodeData, tierWinners, countryTierCounts, officialNodeCounts,
+  countryDominance, nodeGeoMap, addressGeoMap }` — **`tierRankings` and
+  `countryRankings` are REMOVED** from this object. `nodeData` is
+  `Array<{ip, tier, eps, dws, down_speed, up_speed, geo}>` — one entry per
+  benchmarked node, no duplication. `tierWinners` is
+  `{[tier]: {[metric]: {ip, value} | null}}` (via `topInGroup`, computed
+  once here rather than per-render). `countryTierCounts` is
+  `{[countryCode]: {country, tiers: {[tier]: count}}}`.
+- Consumed by: Task 4 (`achievements.js`), Task 5 (`HomeOverview.jsx`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`fetch_node_benchmarks`/`fetch_node_geolocation` (from `networkNodes.js`)
+are module-level singletons built by a `_shared()` factory with their own
+60-second in-memory result cache — **that cache persists across tests in
+the same file** unless you reset the module registry between tests. Use
+`jest.resetModules()` + fresh `require()` per test (no existing precedent
+in this codebase for this exact pattern, but it's the standard fix, and
+it's the only way to avoid one test's mocked benchmark data leaking into
+the next). Mock `global.fetch` itself (routed by URL substring), not the
+imported functions — that way `fetch_node_benchmarks`/`fetch_node_geolocation`'s
+real internal logic still runs.
+
+Add to `apidata.test.js`:
+
+```js
+describe('fetch_global_performance_rankings (redesigned shape)', () => {
+  const FLUX_NODES = { fluxNodes: [
+    { ip: '10.0.0.1:16127', tier: 'cumulus', payment_address: 't1a' },
+    { ip: '10.0.0.2:16127', tier: 'stratus', payment_address: 't1b' },
+  ] };
+  const BENCH_DATA = [
+    { benchmark: { bench: { ipaddress: '10.0.0.1:16127', eps: 100, ddwrite: 10, download_speed: 50, upload_speed: 20 } } },
+    { benchmark: { bench: { ipaddress: '10.0.0.2:16127', eps: 200, ddwrite: 20, download_speed: 60, upload_speed: 30 } } },
+  ];
+  const GEO_DATA = [
+    { geolocation: { ip: '10.0.0.1', country: 'United States', countryCode: 'US', continent: 'NA' } },
+    { geolocation: { ip: '10.0.0.2', country: 'Germany', countryCode: 'DE', continent: 'EU' } },
+  ];
+  const NODE_COUNT = { data: { 'cumulus-enabled': 1, 'nimbus-enabled': 0, 'stratus-enabled': 1, total: 2 } };
+
+  function mockFetchByUrl() {
+    global.fetch = jest.fn((url) => {
+      const u = typeof url === 'string' ? url : '';
+      if (u.includes('getFluxNodes')) return Promise.resolve({ json: async () => FLUX_NODES });
+      if (u.includes('projection=benchmark')) return Promise.resolve({ json: async () => ({ status: 'success', data: BENCH_DATA }) });
+      if (u.includes('projection=geolocation')) return Promise.resolve({ json: async () => ({ status: 'success', data: GEO_DATA }) });
+      if (u.includes('getzelnodecount')) return Promise.resolve({ json: async () => NODE_COUNT });
+      return Promise.reject(new Error(`unexpected fetch: ${u}`));
+    });
+  }
+
+  let fetch_global_performance_rankings;
+
+  beforeEach(() => {
+    jest.resetModules();
+    sessionStorage.clear();
+    mockFetchByUrl();
+    fetch_global_performance_rankings = require('./apidata').fetch_global_performance_rankings;
+  });
+
+  it('resolves nodeData as one entry per benchmarked node, no duplication', async () => {
+    const result = await fetch_global_performance_rankings();
+    expect(result.nodeData).toHaveLength(2);
+    expect(result.nodeData.find((n) => n.ip === '10.0.0.1')).toMatchObject({ tier: 'CUMULUS', eps: 100 });
+    expect(result.tierRankings).toBeUndefined();
+    expect(result.countryRankings).toBeUndefined();
+  });
+
+  it('tierWinners gives the single highest-value node per tier+metric', async () => {
+    const result = await fetch_global_performance_rankings();
+    // Only one node per tier in this fixture, so it trivially wins its own tier.
+    expect(result.tierWinners.CUMULUS.eps).toEqual({ ip: '10.0.0.1', value: 100 });
+    expect(result.tierWinners.STRATUS.eps).toEqual({ ip: '10.0.0.2', value: 200 });
+  });
+
+  it('countryTierCounts matches nodeData grouped by country+tier', async () => {
+    const result = await fetch_global_performance_rankings();
+    expect(result.countryTierCounts.US.tiers.CUMULUS).toBe(1);
+    expect(result.countryTierCounts.DE.tiers.STRATUS).toBe(1);
+  });
+
+  it('bumps the cache key to v4 and prunes the old v3 entry', async () => {
+    sessionStorage.setItem('globalPerfRankings_v3', JSON.stringify({ data: { stale: true }, timestamp: Date.now() }));
+    await fetch_global_performance_rankings();
+    expect(sessionStorage.getItem('globalPerfRankings_v3')).toBeNull();
+    expect(sessionStorage.getItem('globalPerfRankings_v4')).not.toBeNull();
+  });
+});
+```
+
+Note: `nodeData` entries use the bare host (`10.0.0.1`), not
+`host:port` — confirm this against the CURRENT code's existing
+`host = (bench.ipaddress || '').split(':')[0]` line (unchanged by this
+task) before trusting the fixture above; adjust the assertions if the real
+behavior differs from this description.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern apidata.test`
+
+- [ ] **Step 3: Implement**
+
+In `apidata.js`, replace the tail of `fetch_global_performance_rankings`
+(currently: the `tierRankings`/`countryRankings` construction block, from
+`const METRICS = [...]` through `const data = { tierRankings, countryRankings, ... }`)
+with:
+
+```js
+    // Every consumer of this data (achievements.js's 6 dynamic functions,
+    // HomeOverview's TopDogsPanel, _extract_country_counts below) only
+    // ever needs ONE of: a specific wallet's own node's rank (computed
+    // on demand via rankInGroup, cheap since it's only ever a handful of
+    // nodes — see main/Gamification/rankInGroup.js), the single #1 node
+    // per tier/metric (tierWinners, precomputed here), or a country's
+    // node count (countryTierCounts, precomputed here). Nothing needs a
+    // pre-sorted rank list for the whole network — that used to cost 12+
+    // duplicated copies of every node (issue #153).
+    const METRICS = ['eps', 'dws', 'down_speed', 'up_speed'];
+    const TIERS = ['CUMULUS', 'NIMBUS', 'STRATUS'];
+
+    const tierWinners = {};
+    for (const tier of TIERS) {
+      tierWinners[tier] = {};
+      const tierNodes = nodeData.filter((n) => n.tier === tier);
+      for (const metric of METRICS) {
+        tierWinners[tier][metric] = topInGroup(tierNodes, metric);
+      }
+    }
+
+    const countryTierCounts = {};
+    for (const node of nodeData) {
+      if (!node.geo?.countryCode) continue;
+      const cc = node.geo.countryCode;
+      if (!countryTierCounts[cc]) countryTierCounts[cc] = { country: node.geo.country, tiers: {} };
+      countryTierCounts[cc].tiers[node.tier] = (countryTierCounts[cc].tiers[node.tier] || 0) + 1;
+    }
+
+    const data = { nodeData, tierWinners, countryTierCounts, officialNodeCounts, countryDominance, addressGeoMap, nodeGeoMap };
+```
+
+(`nodeData` is already built above this point in the existing function —
+unchanged. Delete the old `tierRankings`/`countryRankings` construction
+blocks entirely, including their now-unused `nodeData.push({..., geo: nodeGeoMap[host] || null})`
+— wait, `nodeData` itself must be KEPT and still needs `.geo` on each
+entry, since `tierWinners`/`countryTierCounts` above both read it, and
+Task 4 needs it too. Only the `tierRankings`/`countryRankings` explosion
+blocks are removed, not `nodeData` itself.)
+
+Add the import: `import { topInGroup } from 'main/Gamification/rankInGroup';`
+at the top of `apidata.js`.
+
+Update the cache key section:
+
+```js
+const GLOBAL_RANKINGS_CACHE_KEY = 'globalPerfRankings_v4';
+const GLOBAL_RANKINGS_STALE_KEYS = ['globalPerfRankings_v3'];
+```
+
+and add the prune step (matching `_prune_stale_app_spec_caches`'s pattern
+in the same file) at the top of `fetch_global_performance_rankings`,
+before its cache-read block.
+
+Update `_extract_country_counts` to read the new shape directly:
+
+```js
+export function _extract_country_counts(countryTierCounts) {
+  if (!countryTierCounts) return [];
+  return Object.entries(countryTierCounts)
+    .map(([countryCode, { country, tiers }]) => ({
+      country,
+      countryCode,
+      nodeCount: Object.values(tiers).reduce((sum, c) => sum + c, 0),
+    }))
+    .sort((a, b) => b.nodeCount - a.nodeCount);
+}
+```
+
+(Export it if it wasn't already — Task 1's Step 6 test needs this.) Update
+its one call site (`fetch_country_node_counts`, same file) to pass
+`cached.data.countryTierCounts` instead of `cached.data.countryRankings`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern apidata.test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/apidata.js client/src/apidata.test.js
+git commit -m "refactor(apidata): globalPerfRankings caches nodeData instead of pre-sorted network (#153)"
+```
+
+---
+
+### Task 4: Migrate `achievements.js`'s dynamic functions to on-demand ranking
+
+**Files:**
+- Modify: `client/src/main/Gamification/achievements.js`
+
+**Interfaces:**
+- Consumes: `rankInGroup`/`topInGroup` (Task 2), `globalRankings.nodeData`
+  (Task 3, replaces `globalRankings.tierRankings`/`.countryRankings`).
+- Must not change: any field on the objects `computeAchievements` returns,
+  for any input Task 1's characterization tests cover. Task 1's tests are
+  the acceptance criterion for this task — they must pass unmodified
+  against this task's code.
+
+- [ ] **Step 1: Rewrite `_bestRankInTier`/`_worstRankInTier`/`_bestRankInCountry` to filter `nodeData` and call `rankInGroup`**
+
+```js
+import { rankInGroup, topInGroup } from './rankInGroup';
+
+// Find wallet's best global rank for (tier, metric) across all wallet nodes in that tier
+function _bestRankInTier(walletTierNodes, nodeData, tier, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier);
+  let best = null;
+  for (const node of walletTierNodes) {
+    const ip = node.ip_full?.host;
+    if (!ip) continue;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (best === null || result.rank < best.bestRank) {
+      best = { bestRank: result.rank, bestIp: ip, bestValue: result.value, bestNodeDisplay: node.ip_display };
+    }
+  }
+  return best || { bestRank: null, bestIp: null, bestValue: 0, bestNodeDisplay: null };
+}
+
+// Find wallet's WORST global rank for (tier, metric) — inverse of _bestRankInTier
+function _worstRankInTier(walletTierNodes, nodeData, tier, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier);
+  let worst = null;
+  for (const node of walletTierNodes) {
+    const ip = node.ip_full?.host;
+    if (!ip) continue;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (worst === null || result.rank > worst.worstRank) {
+      worst = { worstRank: result.rank, worstValue: result.value, worstNodeDisplay: node.ip_display };
+    }
+  }
+  return worst || { worstRank: null, worstValue: 0, worstNodeDisplay: null };
+}
+
+// Find wallet's best rank in a country for a metric
+function _bestRankInCountry(walletCountryNodes, nodeData, tier, countryCode, metricKey) {
+  const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === countryCode);
+  let best = null;
+  for (const node of walletCountryNodes) {
+    const ip = node.ip_full?.host;
+    if (!ip) continue;
+    const result = rankInGroup(groupNodes, ip, metricKey);
+    if (!result) continue;
+    if (best === null || result.rank < best.bestRank) {
+      best = { bestRank: result.rank, bestValue: result.value, bestNodeDisplay: node.ip_display };
+    }
+  }
+  return best || { bestRank: null, bestValue: 0, bestNodeDisplay: null };
+}
+```
+
+Note the signature change: these three helpers now take `nodeData` (the
+full array) plus `tier`/`countryCode` to filter by, instead of a
+pre-filtered `metricRankings` array — because filtering now happens inside
+the helper (once per call), not once at the top of the caller as
+`tierRankings[tier][metric]`. Update every call site in Step 2 accordingly.
+
+- [ ] **Step 2: Update the 5 functions that call these helpers**
+
+In `computeTierPerformanceAchievements`, `computeTierWorstPerformanceAchievements`,
+`computeWoodenSpoonAchievements`, `computeTryHardAchievements`: replace the
+parameter `tierRankings` with `nodeData` throughout, remove the
+`const rankings = tierRankings[tier]; if (!rankings) continue;` lines
+(no longer needed — `nodeData.filter` on an unknown tier just yields `[]`,
+which the total-size guards below already handle), and replace
+`const metricRankings = rankings[metric.key] || [];` /
+`metricRankings.length` with a single filter-once-per-tier:
+
+```js
+    const groupNodes = nodeData.filter((n) => n.tier === tier);
+    if (groupNodes.length === 0) continue;
+```
+
+then each metric loop calls `_bestRankInTier(walletTierNodes, nodeData, tier, metric.key)`
+(or `_worstRankInTier`) instead of the old `_bestRankInTier(walletTierNodes, metricRankings)`,
+and replaces every remaining `metricRankings.length` with `groupNodes.length`
+(same value — `groupNodes` is exactly what the old `metricRankings` array
+would have had `.length` of, since it's the same tier's node set, just not
+exploded per-metric).
+
+In `computeCountryPerformanceAchievements`: replace the `countryRankings`
+parameter with `nodeData`. Remove the `const countryData = countryRankings[cc];`/
+`tierData` lookups. Inside the metric loop, replace
+`const metricRankings = tierData.metrics[metric.key] || []; const totalInGroup = metricRankings.length;`
+with:
+
+```js
+      const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === cc);
+      const totalInGroup = groupNodes.length;
+      if (totalInGroup === 0) continue;
+```
+
+and call `_bestRankInCountry(walletCountryTierNodes, nodeData, tier, cc, metric.key)`.
+`country` (the display name) is no longer available from `countryRankings[cc].country`
+— get it from `nodeGeoMap` instead (any node in `walletCountryTierNodes` has
+`.ip_full.host` you can look up, or thread `countryTierCounts` in for the
+name — check what's simplest given what's already in scope at this call
+site; `computeCountryPerformanceAchievements` is called with `nodeGeoMap`
+already, per its own signature, so `Object.values(nodeGeoMap).find(g => g.countryCode === cc)?.country`
+is one option, or read it directly off `globalRankings.countryTierCounts[cc].country` — prefer
+whichever keeps the function's existing parameter list smallest).
+
+- [ ] **Step 3: Update `computeAchievements`'s call sites at the bottom of the file**
+
+```js
+  const tierPerf = computeTierPerformanceAchievements(
+    walletNodes,
+    globalRankings.nodeData,
+    globalRankings.officialNodeCounts,
+    enablePrivacyMode
+  );
+  const countryPerf = computeCountryPerformanceAchievements(
+    walletNodes,
+    globalRankings.nodeData,
+    globalRankings.nodeGeoMap,
+    enablePrivacyMode
+  );
+  const worstTierPerf = computeTierWorstPerformanceAchievements(
+    walletNodes,
+    globalRankings.nodeData,
+    globalRankings.officialNodeCounts,
+    enablePrivacyMode
+  );
+  const dictator = computeDictatorAchievements(walletNodes, globalRankings);
+  const woodenSpoon = computeWoodenSpoonAchievements(walletNodes, globalRankings.nodeData, globalRankings.officialNodeCounts, enablePrivacyMode);
+  const tryHard = computeTryHardAchievements(walletNodes, globalRankings.nodeData, globalRankings.officialNodeCounts, enablePrivacyMode);
+```
+
+(`computeDictatorAchievements` is unchanged — it never used
+`tierRankings`/`countryRankings`, only `countryDominance`/`nodeGeoMap`,
+both untouched by Task 3.)
+
+- [ ] **Step 4: Run Task 1's characterization tests — they must still pass, unmodified**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern achievements`
+Expected: every test from Task 1 passes. If one fails, the bug is in this
+task's migration, not in Task 1's fixture — re-check the rank-computation
+logic against `rankInGroup`'s tie-break rule before touching the test file.
+Do not edit Task 1's tests to make them pass.
+
+You will need to update Task 1's fixture SETUP (the `TIER_RANKINGS` /
+`countryRankings` shaped objects it builds) to instead build `nodeData`-
+shaped fixtures, since the function signatures changed in this task — but
+the *expected values* in every `expect(...)` call must stay exactly what
+Task 1 established. This is a mechanical fixture-shape update, not a
+license to change what's being asserted.
+
+- [ ] **Step 5: Run the full suite + build**
+
+```
+cd client && CI=true npx react-scripts test --watchAll=false
+npx react-scripts build
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/main/Gamification/achievements.js client/src/main/Gamification/achievements.test.js
+git commit -m "refactor(achievements): rank via nodeData + rankInGroup instead of pre-sorted arrays (#153)"
+```
+
+---
+
+### Task 5: Migrate `HomeOverview`'s `TopDogsPanel` to `tierWinners`
+
+**Files:**
+- Modify: `client/src/home/HomeOverview/index.jsx`
+
+**Interfaces:**
+- Consumes: `globalRankings.tierWinners` (Task 3) instead of
+  `globalRankings.tierRankings`.
+
+- [ ] **Step 1: Update `TierRow`/`TopDogsPanel`**
+
+```jsx
+function TierRow({ tier, tierWinners, nodeGeoMap }) {
+  const { label, color } = TIER_CONFIG[tier];
+  const winners = tierWinners?.[tier];
+  return (
+    <div className="td-tier-row" style={{ borderLeftColor: color }}>
+      <div className="td-tier-label-col">
+        <span className="td-tier-dot" style={{ background: color }} />
+        <span className="td-tier-name" style={{ color }}>{label}</span>
+      </div>
+      <div className="td-metric-cards">
+        {METRIC_CONFIG.map((m) => (
+          <MetricCard key={m.key} metric={m} winner={winners?.[m.key] ?? null} nodeGeoMap={nodeGeoMap} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TopDogsPanel({ globalRankings }) {
+  if (!globalRankings) return (
+    <div className="hov-panel hov-panel-center hov-panel--top-dogs">
+      <Spinner size={20} />
+    </div>
+  );
+  const { tierWinners, nodeGeoMap } = globalRankings;
+  return (
+    <div className="hov-panel hov-panel--top-dogs">
+      <PanelHeader title="TOP DOGS" right={<FaTrophy size={14} className="td-header-icon" />} />
+      <div className="td-body">
+        {TIERS_ORDER.map((tier) => (
+          <TierRow key={tier} tier={tier} tierWinners={tierWinners} nodeGeoMap={nodeGeoMap} />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+(`MetricCard` itself is unchanged — it already destructures `{ip, value}`
+off `winner`, which is exactly `topInGroup`'s return shape.)
+
+- [ ] **Step 2: Manual QA**
+
+Via `yarn start`, load `/home`, confirm the "Top Dogs" panel still shows a
+plausible #1 node per tier/metric (compare against `main` before this
+plan if in doubt).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/home/HomeOverview/index.jsx
+git commit -m "fix(home): TopDogsPanel reads tierWinners instead of pre-sorted tierRankings (#153)"
+```
+
+---
+
+### Task 6: Part A — Top Hosted Apps: Enterprise vs. Unknown
+
+**Files:**
+- Modify: `client/src/runningAppsCategorized.js`
+- Modify: `client/src/runningAppsCategorized.test.js`
+- Modify: `client/src/components/TopHostedApps/index.jsx`
+
+**Interfaces:**
+- Produces: `categorizeRunningApps`'s return value gains
+  `enterpriseContainers: number` and `unresolvedContainers: number`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `runningAppsCategorized.test.js` (import `componentCountKey` from
+`'fluxinfo'` -- the same helper `fluxinfo.js`'s own aggregate uses to build
+these keys, so the fixture matches the real key format exactly instead of
+hand-building the separator string):
+
+```js
+import { componentCountKey } from 'fluxinfo';
+
+it('reports enterpriseContainers separately from the ranking, for apps whose spec is Enterprise (repotag deliberately hidden)', () => {
+  const aggregate = {
+    nameCounts: { entApp: 2 },
+    componentCounts: { [componentCountKey('entApp', null)]: 2 },
+    nodesByIp: {},
+  };
+  const specIndex = { entApp: { category: 'enterprise', repotag: '', compose: null } };
+  const { enterpriseContainers, unresolvedContainers } = categorizeRunningApps(aggregate, specIndex);
+  expect(enterpriseContainers).toBe(2);
+  expect(unresolvedContainers).toBe(0);
+});
+
+it('reports unresolvedContainers separately, for apps with no spec found at all', () => {
+  const aggregate = {
+    nameCounts: { ghostApp: 1 },
+    componentCounts: { [componentCountKey('ghostApp', null)]: 1 },
+    nodesByIp: {},
+  };
+  const { enterpriseContainers, unresolvedContainers } = categorizeRunningApps(aggregate, {});
+  expect(enterpriseContainers).toBe(0);
+  expect(unresolvedContainers).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern runningAppsCategorized`
+
+- [ ] **Step 3: Implement**
+
+In `categorizeRunningApps`, in the `componentCounts` loop (where
+`repoCounts`/`wordpressCount` are built), track the two new counters
+alongside the existing `if (!repotag) continue;` skip:
+
+```js
+  let enterpriseContainers = 0;
+  let unresolvedContainers = 0;
+
+  for (const [key, count] of Object.entries(componentCounts)) {
+    const { name, component } = splitComponentCountKey(key);
+    const spec = index[name];
+    const repotag = repotagForComponent(spec, component);
+    if (!repotag) {
+      if (spec?.category === 'enterprise') enterpriseContainers += count;
+      else unresolvedContainers += count;
+      continue;
+    }
+
+    repoCounts[repotag] = (repoCounts[repotag] || 0) + count;
+    if (repotag.split(':')[0] === WORDPRESS_REPO_BASE) {
+      wordpressCount += count;
+    }
+  }
+```
+
+Add both new fields to the function's return object.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false --testPathPattern runningAppsCategorized`
+
+- [ ] **Step 5: `TopHostedApps` — render the two counts**
+
+In `client/src/components/TopHostedApps/index.jsx`, read
+`gstore.enterpriseContainers`/`gstore.unresolvedContainers` (these need to
+be threaded onto `store` in `apidata.js`'s `fetchTotalDeployedApps` too —
+check the existing pattern for `wordpressCount` et al. right above the
+`categorizeRunningApps` call and add the same assignment for these two new
+fields). Render below the ranked list, only when non-zero:
+
+```jsx
+{images.length > 0 && (enterpriseContainers > 0 || unresolvedContainers > 0) && (
+  <div className="hov-top-apps-footnote">
+    {enterpriseContainers > 0 && (
+      <span title="Enterprise apps ship an encrypted spec — there is no image to rank.">
+        {fmtNum(enterpriseContainers)} Enterprise apps — image hidden by design
+      </span>
+    )}
+    {unresolvedContainers > 0 && (
+      <span title="Running, but no matching spec was found for this app.">
+        {fmtNum(unresolvedContainers)} unresolved
+      </span>
+    )}
+  </div>
+)}
+```
+
+Match the existing file's class-naming/style convention rather than
+inventing a new one — check `index.scss` in the same directory for the
+established pattern (e.g. `hov-` prefix, muted text color) before adding
+this rule.
+
+- [ ] **Step 6: Run the full suite + build**
+
+```
+cd client && CI=true npx react-scripts test --watchAll=false
+npx react-scripts build
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/runningAppsCategorized.js client/src/runningAppsCategorized.test.js client/src/components/TopHostedApps/index.jsx client/src/apidata.js
+git commit -m "feat(home): distinguish Enterprise apps from genuinely unresolved ones in Top Hosted Apps"
+```
+
+---
+
+### Task 7: Part B — issue #189, guard the 5 unguarded fetchers
+
+**Files:**
+- Modify: `client/src/apidata.js`
+
+**Interfaces:** none new — purely additive error handling, no signature
+changes.
+
+- [ ] **Step 1: Wrap each of the 5 functions**
+
+In `fetch_global_stats`, wrap `fetchCurrency`, `fetchWallet`, `fetchNode`,
+`fetchBenchVer`, `fetchRichList` each in try/catch, matching
+`fetchDaemonInfo`'s exact style (`console.log('error', error)` on catch,
+otherwise unchanged):
+
+```js
+  const fetchCurrency = async () => {
+    try {
+      const res = await fetch('https://explorer.runonflux.io/api/currency');
+      const json = await res.json();
+      store.flux_price_usd = json.data.rate;
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+
+  const fetchWallet = async () => {
+    try {
+      if (walletAddress) {
+        const res = await fetch('https://explorer.runonflux.io/api/addr/' + walletAddress + '/?noTxList=1');
+        const json = await res.json();
+        const balance = json['balance'];
+        store.wallet_amount_flux = Math.round((balance + Number.EPSILON) * 100) / 100;
+      }
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+
+  const fetchNode = async () => {
+    try {
+      const res = await fetch('https://api.runonflux.io/daemon/getzelnodecount');
+      const json = await res.json();
+      const stats = json.data;
+
+      store.node_count.cumulus = stats['cumulus-enabled'];
+      store.node_count.nimbus = stats['nimbus-enabled'];
+      store.node_count.stratus = stats['stratus-enabled'];
+
+      store.node_count.total = stats['total'];
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+
+  const fetchBenchVer = async () => {
+    try {
+      const res = await fetch('https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json');
+      if (res.status === 200) {
+        const json = await res.json();
+        store.fluxos_latest_version = fluxos_version_desc_parse(json['version']);
+      }
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+```
+
+(`fetchRichList` already has the try/catch — added in the design/spec pass
+and confirmed still present. Verify it's there; if a merge conflict or
+earlier revert removed it, restore it in this same style.)
+
+- [ ] **Step 2: Add regression tests proving one failure no longer blocks the rest**
+
+Add to `apidata.test.js`:
+
+```js
+describe('fetch_global_stats resilience (#189)', () => {
+  it('a single failing fetch (e.g. rate-limited currency endpoint) does not prevent other fields from populating', async () => {
+    global.fetch = jest.fn((url) => {
+      if (url.includes('/api/currency')) return Promise.reject(new Error('429 rate limited'));
+      // ...mock every other endpoint fetch_global_stats calls with a minimal valid response,
+      // matching whatever mocking pattern this test file already uses elsewhere for
+      // fetch_global_stats (read the file for the existing convention before writing this)
+      return Promise.resolve({ ok: true, json: async () => ({ data: {} }) });
+    });
+    const store = await fetch_global_stats();
+    expect(store.flux_price_usd).toBe(0); // failed fetch leaves the zeroed default — does not throw
+    // assert at least one OTHER field that a real mocked response would have populated
+  });
+});
+```
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/apidata.js client/src/apidata.test.js
+git commit -m "fix(home): guard fetchCurrency/fetchWallet/fetchNode/fetchBenchVer/fetchRichList (#189)
+
+One rate-limited or failed endpoint no longer zeros the entire Home page —
+matches the try/catch pattern fetchDaemonInfo already used one function
+above these in the same Promise.all."
+```
+
+---
+
+### Task 8: Part C.1 + C.2 — spec field-stripping and loud quota-failure logging
+
+**Files:**
+- Modify: `client/src/apidata.js` (`fetch_global_app_specs_raw`, every
+  `sessionStorage.setItem` call site in this file)
+- Modify: `client/src/apidata.test.js`
+
+**Interfaces:** `fetch_global_app_specs_raw()`'s return value (in-memory,
+to callers) is UNCHANGED — every field every consumer reads today stays
+present. Only what gets written to `sessionStorage` is trimmed.
+
+- [ ] **Step 1: Write the failing test for field-stripping**
+
+```js
+describe('fetch_global_app_specs_raw caches a trimmed payload (#153)', () => {
+  it('strips fields no consumer reads before writing to sessionStorage, but returns the full spec to the caller', async () => {
+    const fullSpec = {
+      name: 'app1', height: 100, expire: 1000, instances: 3, enterprise: '', owner: 'zid1',
+      contacts: ['x'], description: 'long text', geolocation: ['a'], hash: 'abc', nodes: [], staticip: false, version: 8,
+      compose: [{ name: 'c1', repotag: 'img:latest', cpu: 1, ram: 512, hdd: 5, commands: [], containerData: '/x', containerPorts: [], domains: [''], environmentParameters: [], ports: [], repoauth: '', description: 'x' }],
+    };
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ status: 'success', data: [fullSpec] }) });
+
+    const result = await fetch_global_app_specs_raw();
+    expect(result[0].name).toBe('app1'); // in-memory return is untouched
+
+    const cached = JSON.parse(sessionStorage.getItem('homeAppSpecsRaw_v1')).data[0];
+    expect(cached).not.toHaveProperty('contacts');
+    expect(cached).not.toHaveProperty('description');
+    expect(cached).not.toHaveProperty('geolocation');
+    expect(cached).not.toHaveProperty('hash');
+    expect(cached).not.toHaveProperty('nodes');
+    expect(cached).not.toHaveProperty('staticip');
+    expect(cached).not.toHaveProperty('version');
+    expect(cached.compose[0]).not.toHaveProperty('commands');
+    expect(cached.compose[0]).not.toHaveProperty('containerData');
+    expect(cached.compose[0]).not.toHaveProperty('domains');
+    // fields every consumer needs stay present:
+    expect(cached).toMatchObject({ name: 'app1', height: 100, expire: 1000, instances: 3, enterprise: '', owner: 'zid1' });
+    expect(cached.compose[0]).toMatchObject({ name: 'c1', repotag: 'img:latest', cpu: 1, ram: 512, hdd: 5 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement**
+
+In `fetch_global_app_specs_raw`, add a trim function and apply it only on
+the write path (the `return json.data;` for in-memory callers stays the
+full untrimmed data):
+
+```js
+const SPEC_CACHE_FIELDS = ['name', 'height', 'expire', 'instances', 'enterprise', 'owner', 'repotag'];
+const COMPOSE_CACHE_FIELDS = ['name', 'repotag', 'cpu', 'ram', 'hdd'];
+
+function _trimSpecForCache(spec) {
+  const trimmed = {};
+  for (const f of SPEC_CACHE_FIELDS) {
+    if (spec[f] !== undefined) trimmed[f] = spec[f];
+  }
+  if (Array.isArray(spec.compose)) {
+    trimmed.compose = spec.compose.map((c) => {
+      const tc = {};
+      for (const f of COMPOSE_CACHE_FIELDS) {
+        if (c[f] !== undefined) tc[f] = c[f];
+      }
+      return tc;
+    });
+  }
+  return trimmed;
+}
+```
+
+Update the `sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, ...)` call:
+
+```js
+      try {
+        const trimmedForCache = json.data.map(_trimSpecForCache);
+        sessionStorage.setItem(RAW_APP_SPECS_CACHE_KEY, JSON.stringify({ data: trimmedForCache, timestamp: Date.now() }));
+      } catch (e) {
+        console.warn('[AppSpecs] Cache write failed:', e?.message, `(${JSON.stringify(json.data).length} bytes)`);
+      }
+
+      return json.data; // full, untrimmed — every in-memory caller keeps working exactly as before
+```
+
+Note: this means a WARM cache read (`cached.data`) now returns
+ALREADY-TRIMMED specs, not full ones — re-verify every consumer of
+`fetch_global_app_specs_raw()`'s return value only reads the allowlisted
+fields (this was already verified during the design/spec phase — see the
+spec doc's Part C.1 table — but confirm once more against the actual
+current code before shipping, since code may have drifted since the spec
+was written).
+
+- [ ] **Step 4: Loud failure on every remaining `sessionStorage.setItem` in this file**
+
+Grep `apidata.js` for every `catch {}` immediately following a
+`sessionStorage.setItem` call (there are several — `GLOBAL_RANKINGS_CACHE_KEY`,
+`GPU_PRICES_CACHE_KEY`, `HOME_GEO_CACHE_KEY`, plus the one just touched
+above). Replace each bare `catch {}` with:
+
+```js
+      } catch (e) {
+        console.warn('[<ModuleName>] Cache write failed:', e?.message);
+      }
+```
+
+using a label matching that section's existing console-log prefix
+convention (e.g. `[GlobalRankings]`, `[GPU]`, `[Geo]` — check what's
+already used nearby in each section for consistency).
+
+- [ ] **Step 5: Run to verify pass, then the full suite**
+
+```
+cd client && CI=true npx react-scripts test --watchAll=false
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/apidata.js client/src/apidata.test.js
+git commit -m "fix(apidata): trim cached spec fields, log cache-write failures instead of swallowing them (#153)"
+```
+
+---
+
+### Task 9: Final verification sweep
+
+**Files:** none expected (verification-only).
+
+- [ ] **Step 1: Full test suite**
+
+Run: `cd client && CI=true npx react-scripts test --watchAll=false`
+Expected: baseline (359) plus every test added across Tasks 1-8, all
+passing, 0 failures.
+
+- [ ] **Step 2: Production build**
+
+Run: `cd client && npx react-scripts build`
+Expected: exit 0, warnings limited to the same 4 pre-existing baseline
+files, no new ones.
+
+- [ ] **Step 3: Manual sessionStorage measurement (issue #153's actual acceptance criterion)**
+
+Via `yarn start` against real data: load `/home`, search a wallet with
+several nodes (to populate the Gamification tab), then in the browser
+console:
+
+```js
+Object.keys(sessionStorage).map(k => ({ key: k, kb: Math.round(sessionStorage.getItem(k).length / 1024) }))
+```
+
+Confirm total usage is well under ~50% of the ~5,120KB quota (issue
+#153's stated target), and specifically confirm `globalPerfRankings_v4`
+and `homeAppSpecsRaw_v1` are both meaningfully smaller than the pre-plan
+measurements recorded in the spec doc (2,912KB and ~1,520KB respectively).
+
+- [ ] **Step 4: Manual Gamification comparison (the "don't break calculations" check)**
+
+Search the SAME wallet on this branch and on `main`, screenshot the
+Gamification tab's achievement list on both, and confirm every earned/
+not-earned status, progress bar, and description number matches exactly.
+This is a live-data confirmation on top of Task 1/4's unit-test proof —
+both matter, neither replaces the other.
+
+- [ ] **Step 5: Manual Top Hosted Apps / regression check**
+
+Confirm the Enterprise/Unknown footnote renders correctly on `/home` and
+`/analytics`'s Apps tab (shared component). Spot-check `/nodes` and `/live`
+are visually/functionally unaffected (this plan never touches either).
+
+- [ ] **Step 6: `git diff --stat main`**
+
+Confirm only `client/src/` files plus this plan doc and its spec changed —
+no unrelated files.

--- a/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
+++ b/docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md
@@ -298,6 +298,14 @@ describe('computeCountryPerformanceAchievements (characterization)', () => {
 
 - [ ] **Step 6: `_extract_country_counts` (in `apidata.js`)**
 
+Note: Task 3 changes this function's entire input contract (from
+`countryRankings` to a much smaller `countryTierCounts` shape) as part of
+the `globalPerfRankings` redesign, and will REPLACE this test in place with
+an equivalent one against the new shape — this is expected, not a
+conflict; write the characterization test below against the CURRENT shape
+regardless, since it's what proves today's `nodeCount` arithmetic
+(sum of each tier's array length) before anything changes.
+
 ```js
 // In a new or existing client/src/apidata.test.js describe block:
 import { _extract_country_counts } from './apidata'; // export it if not already
@@ -672,9 +680,32 @@ export function _extract_country_counts(countryTierCounts) {
 }
 ```
 
-(Export it if it wasn't already — Task 1's Step 6 test needs this.) Update
-its one call site (`fetch_country_node_counts`, same file) to pass
+(Export it if it wasn't already.) Update its one call site
+(`fetch_country_node_counts`, same file) to pass
 `cached.data.countryTierCounts` instead of `cached.data.countryRankings`.
+
+**This changes `_extract_country_counts`'s entire input contract, not just
+an internal detail** — Task 1's Step 6 test for this function was written
+against the OLD `countryRankings` shape (`{tiers: {CUMULUS: {metrics: {eps: [...]}}}}`)
+and will now fail, the same way Task 4 has to update Task 1's achievements
+fixtures. Update that one test (in `apidata.test.js`) to build a
+`countryTierCounts`-shaped fixture instead, while keeping the exact same
+expected output:
+
+```js
+describe('_extract_country_counts (characterization — current behavior)', () => {
+  it('counts nodes per country by summing each tier\'s count', () => {
+    const countryTierCounts = {
+      US: { country: 'United States', tiers: { CUMULUS: 2, STRATUS: 1 } },
+    };
+    const result = _extract_country_counts(countryTierCounts);
+    expect(result).toEqual([{ country: 'United States', countryCode: 'US', nodeCount: 3 }]);
+  });
+});
+```
+
+(This replaces, not adds to, Task 1's original version of this test — one
+test for this function, updated in place, matching its new real contract.)
 
 - [ ] **Step 4: Run to verify pass**
 

--- a/docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md
+++ b/docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md
@@ -1,0 +1,279 @@
+# Accuracy & Reliability Fixes — Design Spec
+
+**Date:** 2026-09-09
+**Status:** Approved for implementation
+
+## Overview
+
+Three independent fixes, bundled as one piece of work because they were all
+surfaced by the same investigation (a user report about Home page data
+accuracy, followed by live-data verification):
+
+- **Part A** — Top Hosted Apps silently excludes ~23% of the network
+  (Enterprise apps) from its ranking with no indication anything is missing.
+- **Part B** — GitHub issue #189: an unguarded fetch anywhere in
+  `fetch_global_stats`'s `Promise.all` zeros out the entire Home page on a
+  single rate-limited/failed endpoint.
+- **Part C** — GitHub issue #153: sessionStorage sits at ~85% of quota on a
+  normal load; cache writes fail silently past that point. The single
+  biggest contributor (`globalPerfRankings_v3`, 2.9MB) is deeply coupled to
+  the Gamification achievements system and needs an actual redesign, not a
+  trim — covered in detail below since it's the architecturally significant
+  part of this spec.
+
+All three are changes to code that already exists in this repo (`client/src/`
+only). No new subsystems, no new external dependencies, no changes to the
+Rust API.
+
+## Part A — Top Hosted Apps: distinguish Enterprise from genuinely Unknown
+
+### Current behavior
+
+`runningAppsCategorized.js`'s `categorizeRunningApps` builds `topRunningApps`
+by resolving each running container's repotag via `repotagForComponent` and
+skipping (`if (!repotag) continue`) any container whose spec can't produce
+one. Live-measured: **1,708 of 7,257 containers (23.5%)** are skipped this
+way — **1,695 (23.4%)** because the app's spec is Enterprise (compose
+encrypted, no repotag by design) and **13 (0.2%)** because no spec could be
+found for that app name at all (expired/renamed between the two independent
+fetches). Both classes of container still count correctly everywhere else
+(`totalRunningApps`, the "Enterprise" category bucket in `runningCategoryMap`)
+— they only vanish from this one ranked list, with nothing telling the
+viewer that ~23% of the network isn't represented.
+
+### Fix
+
+`categorizeRunningApps` gains two new fields on its return value, computed
+in the same `componentCounts` loop that already builds `repoCounts`/
+`topRunningApps` (no new data source, no new fetch):
+
+- `enterpriseContainers` — count of containers whose resolved spec has
+  `enterprise` set (and therefore no repotag).
+- `unresolvedContainers` — count of containers whose app name has no
+  matching spec at all.
+
+`TopHostedApps` renders two small labeled lines below the ranked list, only
+when non-zero: something like "1,695 Enterprise apps — image hidden by
+design" and "13 unresolved". This is purely additive to the existing
+component; the ranked list itself is unchanged.
+
+## Part B — Issue #189: unguarded fetches crash the whole page
+
+### Confirmed root cause
+
+`client/src/apidata.js`'s `fetch_global_stats` runs `fetchCurrency`,
+`fetchWallet`, `fetchNode`, `fetchBenchVer`, and `fetchRichList` inside one
+`Promise.all` alongside already-guarded fetchers (`fetchDaemonInfo`,
+`fetchTotalDeployedApps`, `fetchUniqueWalletAddresses`). None of the five
+named functions has a try/catch. Any one of them throwing (a rate limit, a
+CORS block, a transient network failure) rejects the whole `Promise.all`,
+and every field on `store` — including all the running-apps data most of
+this investigation started with — stays at its zero default. Issue #189's
+own screenshot shows exactly this: a 429 on `fetchCurrency`'s endpoint,
+followed by an uncaught `TypeError: Failed to fetch`, followed by "Top
+Hosted Apps: No data available" alongside every other Home stat reading
+zero.
+
+### Audit of the rest of the codebase (already verified, not guesswork)
+
+- `client/src/live/apidata.js`'s three fetchers (`fetch_recent_blocks`,
+  `fetch_block_transactions`, `fetch_block_confirmations`) are all already
+  wrapped in try/catch with safe fallback returns — no change needed.
+- `client/src/networkNodes.js`'s shared fetchers (`fetch_node_benchmarks`,
+  `fetch_node_resources`, `fetch_node_geolocation`, built from one `_shared`
+  factory) already catch and return `[]` on failure — no change needed.
+- `client/src/apidata.js`'s `fetch_country_node_counts` and
+  `fetch_gpu_prices` are already fully try/catch-wrapped.
+- `main/apidata.js` is a two-line re-export shim (see issue #147) — no
+  fetch logic of its own.
+
+So the fix is narrowly scoped to the five named functions in
+`fetch_global_stats`.
+
+### Fix
+
+Wrap each of the five in try/catch, matching the exact pattern
+`fetchDaemonInfo` already uses one function above them in the same file
+(`console.log('error', error)` on catch, leave the store field at its
+zeroed default). No behavior change on the success path.
+
+## Part C — Issue #153: sessionStorage quota
+
+### Part C.1 — `homeAppSpecsRaw_v1` (~1.5MB): strip unused fields before caching
+
+`buildSpecIndex`/`specResources`/`categorizeAppSpec` and every other
+consumer of `rawSpecs` (`AppsSection`, `WorkhorsePanel`, `runningAppsCategorized.js`,
+`live/apidata.js`'s deploy-diffing, `analytics/topOwners.js`) collectively
+read exactly: `name`, `height`, `expire`, `instances`, `enterprise`,
+`owner`, `repotag`, and `compose[].{name,repotag,cpu,ram,hdd}`. Verified via
+direct grep of every consumer, not assumed. Every other field on a raw spec
+— `contacts`, `description`, `geolocation`, `hash`, `nodes`, `staticip`,
+`version` at the top level, and `commands`, `containerData`,
+`containerPorts`, `domains`, `environmentParameters`, `ports`, `repoauth`,
+`description` on each compose entry — is never read anywhere in
+`client/src`.
+
+Fix: `fetch_global_app_specs_raw()` strips each spec down to the used-field
+allowlist before writing to `sessionStorage` (the in-memory return value to
+callers is unaffected — only what gets cached is trimmed). This preserves
+full join-completeness (every app is still present, still keyed by name,
+still has its real repotag/category-relevant data) while cutting the
+cached payload's per-entry size substantially.
+
+### Part C.2 — loud failure on quota exceeded
+
+Every `sessionStorage.setItem` in `apidata.js` is currently wrapped in a
+silent `catch {}`. Add a `console.warn` naming the key and byte size on
+failure, matching the acceptance criteria in #153. This is a diagnostic
+change only — behavior on success is unchanged, and a failed write still
+doesn't crash anything (the app already tolerates cache misses by design).
+
+### Part C.3 — `globalPerfRankings_v3` (2.9MB, the dominant cost): stop pre-sorting the whole network
+
+This is the architecturally significant part of this spec.
+
+#### Current design
+
+`fetch_global_performance_rankings()` computes `nodeData` (one entry per
+benchmarked node: `{ip, tier, eps, dws, down_speed, up_speed, geo}`) as an
+intermediate step, then explodes it into:
+
+- `tierRankings[tier][metric]` — the **entire tier's** nodes, sorted
+  descending by that metric, as `{ip, rank, value}`. 3 tiers × 4 metrics =
+  12 full copies of "all nodes in this tier," each carrying only one
+  metric's value.
+- `countryRankings[cc].tiers[tier].metrics[metric]` — the same thing again,
+  bucketed per country instead of network-wide. Same shape, smaller
+  per-bucket, but summed across every country it's a comparable amount of
+  data, further duplicated.
+
+Every consumer of this structure was read precisely before designing the
+fix (all in `client/src/main/Gamification/achievements.js` unless noted):
+
+| Consumer | What it actually needs |
+|---|---|
+| `_bestRankInTier`, `_worstRankInTier`, `_bestRankInCountry` | For each of the **searched wallet's own nodes**, that one node's `{rank, value}` within its tier (or country+tier) + metric group. Never any other node's rank. |
+| `computeTierPerformanceAchievements` (medals), `computeCountryPerformanceAchievements` (medals) | The above, plus the group's total size (`officialNodeCounts` primary source, `metricRankings.length` fallback). |
+| `computeTierWorstPerformanceAchievements` ("Potato"/"Tortoise"/"Toaster"), `computeWoodenSpoonAchievements` | The wallet's worst-ranked own node, **and the group's exact total size** — `earned: worstRank >= metricRankings.length` literally checks "is my node dead last," which requires knowing the true total. |
+| `computeTryHardAchievements` ("top 5%") | The wallet's best-ranked own node, and `Math.ceil(metricRankings.length * 0.05)` — the true total, since 5% of a 3,000-node tier is ~150, far beyond any small fixed top-N. |
+| `apidata.js`'s `_extract_country_counts` (Home's Geo Distribution panel) | `tier.metrics.eps?.length` as a **node count** per country — not ranking data at all. |
+| `HomeOverview.jsx`'s `TopDogsPanel` | `rankings?.[m.key]?.[0]` — only the single #1-ranked node per tier+metric. |
+
+No consumer anywhere needs rank/value for a node that isn't one of the
+searched wallet's own — and every consumer that needs a "total," needs the
+**true** total, not a trimmed approximation. This is why a naive top-N trim
+(the originally-proposed fix) is unsafe: "Try Hard" alone can require depth
+in the hundreds, and "dead last" / "top 5%" both depend on the exact true
+count.
+
+#### New design
+
+Cache `nodeData` itself — the un-duplicated per-node array, already computed
+today as an intermediate step — instead of the 12-way-exploded
+`tierRankings`/`countryRankings`. Add small precomputed aggregate counts
+(`totalInTier: {CUMULUS, NIMBUS, STRATUS}`, `totalInCountryTier: {[cc_tier]: n}`)
+since those are needed by every threshold calculation and are cheap
+(O(tiers) / O(countries×tiers), not O(nodes)).
+
+New pure module `client/src/main/Gamification/rankInGroup.js`:
+
+```js
+/**
+ * Rank of one specific node within a group, by one metric — replaces the
+ * pre-sorted-array .find() lookup. Computed on demand: cheap because it
+ * only ever runs for the handful of nodes a searched wallet owns, never
+ * for the whole network.
+ *
+ * Tie-break MUST match the old pre-sort exactly (Array.sort is stable in
+ * this engine, so ties kept their original nodeData order) — rank = 1 +
+ * (nodes strictly greater) + (nodes equal AND appearing earlier in
+ * nodeData than the target). Getting this wrong flips medal outcomes on
+ * tied values, which is exactly the kind of silent behavior change this
+ * whole redesign must not introduce.
+ *
+ * Returns null if the target ip isn't found in groupNodes at all (offline/
+ * unbenchmarked node — matches the old code's "entry not found, skip"
+ * behavior, which callers already handle).
+ */
+export function rankInGroup(groupNodes, targetIp, metricKey) {
+  const targetIndex = groupNodes.findIndex((n) => n.ip === targetIp);
+  if (targetIndex === -1) return null;
+  const targetValue = groupNodes[targetIndex][metricKey] || 0;
+
+  let rank = 1;
+  for (let i = 0; i < groupNodes.length; i++) {
+    if (i === targetIndex) continue;
+    const v = groupNodes[i][metricKey] || 0;
+    if (v > targetValue) rank++;
+    else if (v === targetValue && i < targetIndex) rank++;
+  }
+  return { rank, value: targetValue, total: groupNodes.length };
+}
+
+/** The single highest-value node in a group for one metric (TopDogsPanel's "#1" need). Null for an empty group. */
+export function topInGroup(groupNodes, metricKey) {
+  if (groupNodes.length === 0) return null;
+  return groupNodes.reduce((best, n) =>
+    (n[metricKey] || 0) > (best[metricKey] || 0) ? n : best
+  );
+}
+```
+
+`achievements.js`'s `_bestRankInTier`/`_worstRankInTier`/`_bestRankInCountry`
+are rewritten to call `rankInGroup` per wallet-owned node instead of
+`.find()`-ing a pre-sorted array, filtering `nodeData` to the right group
+(`tier`, or `tier`+`countryCode`) first. The 6 dynamic achievement functions'
+own logic (medal assignment, percentile math, description strings) is
+**unchanged** — only where `{rank, value, total}` comes from changes.
+`_extract_country_counts` reads the new precomputed `totalInCountryTier`
+aggregate directly instead of `.metrics.eps.length`. `HomeOverview.jsx`'s
+`TopDogsPanel` calls `topInGroup` instead of indexing `[0]` on a pre-sorted
+array.
+
+Cache key bumps to `globalPerfRankings_v4` (old `_v3` added to the existing
+stale-key prune list, matching this repo's established versioning
+convention).
+
+#### Testing strategy (this is the part the user explicitly asked to get right)
+
+`achievements.js` has **zero existing test coverage** — this redesign is
+the first tests it will ever have. Given that, and given the explicit
+requirement not to change any achievement's earned/not-earned outcome or
+displayed numbers:
+
+1. **Before touching the implementation**, write characterization tests for
+   every one of the 6 dynamic achievement functions plus `_extract_country_counts`,
+   against the **current, unmodified** code — hand-constructed fixtures
+   covering: a clear win (rank 1), a clear loss (rank far from 1), an exact
+   tie between two wallet-relevant nodes (the case most likely to break
+   under a tie-break mistake), a node not present in the rankings at all
+   (offline/unbenchmarked), and the "dead last"/"top 5%" boundary
+   conditions specifically (since those are the ones most sensitive to
+   getting the true total right). Run these against the current code,
+   confirm they pass — this is the verified ground truth, not an assumption.
+2. Implement `rankInGroup`/`topInGroup` with their own dedicated unit tests
+   (the tie-break rule above, an empty group, a single-node group, a
+   target not present).
+3. Migrate `fetch_global_performance_rankings` and `achievements.js` to the
+   new design.
+4. **The Step 1 characterization tests must still pass, unmodified**,
+   against the new implementation. This is the actual proof nothing broke
+   — not a new set of tests written to match whatever the new code happens
+   to produce, but the same tests written against the old code first.
+5. Manual QA: `yarn start` against real data, search a wallet with several
+   nodes, open the Gamification tab, compare the actual rendered
+   achievements (earned/progress/description text) against what the same
+   wallet shows on `main` before this change.
+
+## Global Constraints
+
+- `client/src/` only — no Rust API changes.
+- No new npm dependency.
+- Test with `cd client && CI=true npx react-scripts test --watchAll=false`,
+  build with `npx react-scripts build`. Baseline before this work: 359
+  tests, build exit 0, 4 pre-existing baseline warning files (Navbar,
+  NodeGridTable, LayoutContext, WalletNodes).
+- Part C.3 is the highest-risk piece in this spec (untested code, real
+  money-no-object user-facing calculations people's earned achievements
+  depend on) — its task(s) must not be compressed or rushed relative to
+  the testing strategy above.

--- a/todo.md
+++ b/todo.md
@@ -9,7 +9,7 @@
 > lives. Update this file's status lines as work lands; don't let a second copy of the
 > plan drift in a session's memory file instead.
 
-**Last updated:** 2026-09-06.
+**Last updated:** 2026-09-09.
 
 ---
 
@@ -181,16 +181,38 @@ Consolidated from the now-retired `PREMIUM_FEATURES_PLAN.md`.
   `docs/superpowers/plans/2026-09-06-analytics-session5-chain-activity.md` for full
   detail. **This closes out the Analytics tab set originally scoped in
   `PREMIUM_FEATURES_PLAN.md`** — Apps/Network/Donor/Chain Activity are all shipped.
+- **Issue #187 fix (fluxinfo Image field removed)** — PR #188 (2026-09-09,
+  merged). FluxOS v8.18 dropped the docker `Image` field from
+  `stats.runonflux.io/fluxinfo`; running-app categorization now joins each
+  container's name against `globalappsspecifications` instead. New module
+  `client/src/runningAppsCategorized.js`.
+- **Live Redesign Session D (Resilience + final polish)** — PR #190
+  (2026-09-09, merged). Closes the entire 4-session Live Redesign (Sessions
+  A-D, PR #184/#185/#186/#190) — `LIVE_REDESIGN_PLAN.md`'s scope is fully
+  shipped.
+- **Accuracy/reliability pass — Top Hosted Apps categories, #153, #189** —
+  PR #191 (2026-09-09, opened, awaiting merge). Top Hosted Apps now
+  distinguishes Enterprise
+  apps from genuinely-unresolved ones (footnote on `/home` and
+  `/analytics`'s Apps tab); closes **#153** (sessionStorage quota — full
+  `globalPerfRankings`/`tierRankings`/`countryRankings` redesign onto an
+  on-demand `nodeData` + `rankInGroup`/`topInGroup` model, live-measured
+  86.3%→46.7% of the ~5,120KB quota on the same real wallet) and **#189**
+  (unguarded `fetch_global_stats` fetchers that could zero the whole Home
+  page on one rate-limited endpoint). Full characterization test coverage
+  added for `achievements.js` (previously zero). See
+  `docs/superpowers/specs/2026-09-09-accuracy-and-reliability-fixes-design.md`
+  and `docs/superpowers/plans/2026-09-09-accuracy-and-reliability-fixes.md`.
 
 ## Known, filed elsewhere or unfiled (not scheduled)
 
 - `stats.runonflux.io/fluxinfo` intermittently returns HTTP 200 with `status:
   "error"` — resilience layer (retry → last-known-good → stale marker) already
   handles it; still genuinely flaky upstream, nothing to build.
-- Older backlog items from 2026-08-26 (split `apidata.js` #147, sessionStorage-quota
-  #153, Rust `/header` endpoint #145, Titan Info #47, iOS column width #141) — never
-  picked back up across several sessions since; re-check the issue tracker before
-  assuming still relevant.
+- Older backlog items from 2026-08-26, re-checked 2026-09-09: split
+  `apidata.js` (#147), Rust `/header` endpoint (#145), Titan Info (#47), iOS
+  column width (#141) — still not picked up; sessionStorage-quota (#153) and
+  the unguarded-fetch issue (#189) are now closed, see Changelog above.
 - Home-vs-VPS/datacenter detection (ipinfo.io-based) — deferred, unscheduled, not
   blocking anything (see the git history of the now-retired
   `PREMIUM_FEATURES_PLAN.md` for the full research if this gets picked up later).


### PR DESCRIPTION
## Summary

Answers all four of your questions in one piece of work:

1. **Enterprise vs. Unknown in Top Hosted Apps** — now distinguished. The panel shows a footnote separating apps whose spec is genuinely Enterprise (encrypted, no image by design) from containers with no matching spec found at all.
2. **Two clear categories** — done, per #1.
3. **Two top-priority GitHub issues** — closes **#189** (unguarded fetches that could zero the whole Home page on one rate-limited endpoint) and **#153** (sessionStorage quota — see the numbers below).
4. **Donor feature status** — unrelated to this branch; not touched here.

Also fixes the two accuracy concerns you flagged separately: App Ecosystem's categorization was already sound (verified), but Top Hosted Apps really was missing ~23.5% of the network with no indication why — that's what the Enterprise/Unknown split now makes visible.

## Issue #153 — the actual payoff

Replaced the pre-sorted, massively-duplicated `tierRankings`/`countryRankings` sessionStorage cache with an on-demand `nodeData` array + small precomputed aggregates (`tierWinners`, `countryTierCounts`) + a `rankInGroup`/`topInGroup` helper that only ever computes a rank for the handful of nodes a searched wallet actually owns.

Measured on the same real wallet, live:

| | `main` | this branch |
|---|---|---|
| Total sessionStorage | 4,418 KB (**86.3%** of the ~5,120 KB quota) | 2,391 KB (**46.7%**) |
| `globalPerfRankings` | 2,966 KB | 1,593 KB |
| `homeAppSpecsRaw` | 1,452 KB | 793 KB |

`main` was genuinely at risk of hitting the real browser quota; this branch roughly halves usage and pulls it well clear.

## Issue #189

`fetch_global_stats`'s `fetchCurrency`/`fetchWallet`/`fetchNode`/`fetchBenchVer`/`fetchRichList` are now wrapped in try/catch (matching the existing `fetchDaemonInfo` pattern) — one rate-limited endpoint no longer blocks the rest of the Home page from populating.

## Two real bugs found and fixed via live verification, not just tests

The rankings redesign was validated against Task 1's synthetic characterization tests throughout (hand-derived, independently re-verified at every step), but a **live** side-by-side comparison against `main` — searching the same real wallet on both — surfaced something no synthetic fixture modeled: a host running several Flux nodes on different ports collapses to one bare-IP key in the new data model (unchanged pre-existing behavior). A plain array lookup by that IP could land on an arbitrary one of those co-located nodes instead of the wallet's actual best one, silently downgrading a real achievement.

Both fixed at the root (`rankInGroup` for the Gamification ranking path, `lookupNodeInfo` for the Live page's node-confirmation display — found by the final whole-branch review checking for other instances of the same class). The `rankInGroup` fix was verified with an **800,000-case randomized differential test** against `main`'s actual behavior: zero mismatches.

## Also in this branch

- Same-day accuracy pass: field-stripped the app-specs sessionStorage cache to just what any consumer reads, and every remaining silent `catch {}` around a cache write now logs loudly instead of swallowing quota errors.
- Full characterization test coverage added for `achievements.js` (previously zero), migrated onto the new data model with every expected value preserved exactly (verified byte-for-byte, not just "tests still pass").

## Verification

- 410/410 tests passing (up from 367 baseline on this branch's fork point)
- Production build: exit 0, only the 4 pre-existing baseline warnings (Navbar, NodeGridTable, LayoutContext, WalletNodes)
- `git diff --stat main`: only `client/src/` + the plan/spec docs — no unrelated files
- Manual live verification: Top Hosted Apps Enterprise/Unknown footnote, Top Dogs panel, and the Gamification achievement comparison (main vs. this branch, same real wallet) all confirmed on real production data

Built via `superpowers:subagent-driven-development` — 9 tasks, each independently reviewed (several at opus-level rigor), plus a final whole-branch review that found and closed the second duplicate-IP instance above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
