### PR TITLE
fix(chain-activity): show real sync status instead of a silent empty state

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -282,16 +282,27 @@ pub mod api_v1 {
             daily: Vec<services::chain_activity::DailyCount>,
             team_txs: Vec<services::chain_activity::TeamTx>,
             last_scanned_height: i64,
+            // Real health of the background scanner, not just whatever's on
+            // disk — `success` above only ever means "this HTTP request
+            // itself succeeded", it says nothing about whether the scanner
+            // is keeping up. See ScanStatus's own doc comment.
+            last_attempt_at: i64,
+            last_success_at: i64,
+            last_outcome: services::chain_activity::ScanOutcome,
         }
 
         // Synchronous read of whatever the background scanner has already
         // persisted — never triggers a scan on the request path.
         pub async fn handler() -> impl IntoResponse {
+            let scan_status = services::chain_activity::load_scan_status();
             let body = ChainActivityResultBody {
                 success: true,
                 daily: services::chain_activity::load_daily_rollup(),
                 team_txs: services::chain_activity::load_team_txs(),
                 last_scanned_height: services::chain_activity::load_checkpoint().last_scanned_height,
+                last_attempt_at: scan_status.last_attempt_at,
+                last_success_at: scan_status.last_success_at,
+                last_outcome: scan_status.last_outcome,
             };
             (StatusCode::OK, Json(body))
         }

--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -40,6 +40,7 @@ pub const DATA_DIR: &str = "data";
 pub const DAILY_ROLLUP_FILE: &str = "chain_activity_daily.json";
 pub const TEAM_TX_FILE: &str = "chain_activity_team_tx.json";
 pub const CHECKPOINT_FILE: &str = "chain_activity_checkpoint.json";
+pub const SCAN_STATUS_FILE: &str = "chain_activity_scan_status.json";
 
 const EXPLORER_BASE: &str = "https://explorer.runonflux.io/api";
 const APP_SPECS_URL: &str = "https://api.runonflux.io/apps/globalappsspecifications";
@@ -202,6 +203,47 @@ pub struct TeamTx {
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct Checkpoint {
     pub last_scanned_height: i64,
+}
+
+/*
+ * Whether the LAST run_scan_cycle() attempt actually made it to the tip, not
+ * whether any data exists — the /chain-activity endpoint used to hardcode
+ * success: true regardless of what was on disk, so a genuinely-stalled
+ * scanner (most often this API's own documented rate-limit bans — see
+ * get_with_backoff's comment) was indistinguishable from "still building
+ * initial history", both from the frontend's perspective.
+ *
+ * `Stalled` and `Unreachable` are honest, not maximally specific: a batch
+ * that made no progress could be a 429 ban, a timeout, or a transient
+ * explorer 500 — get_with_backoff already collapses all of those to `None`
+ * before run_scan_cycle ever sees them, and disentangling that further
+ * would mean threading a real error type through several more layers than
+ * this fix's scope covers. `Stalled` names the most likely cause (this
+ * API's own well-documented rate-limiting) without claiming certainty.
+ */
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanOutcome {
+    NeverRun,
+    CaughtUp,
+    Stalled,
+    Unreachable,
+}
+
+impl Default for ScanOutcome {
+    fn default() -> Self {
+        ScanOutcome::NeverRun
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct ScanStatus {
+    // Unix seconds. 0 (the Default) means "never attempted" — real timestamps
+    // post-2026 are all comfortably >0, so 0 doubles as a safe sentinel
+    // without needing an Option here or in the JSON the frontend reads.
+    pub last_attempt_at: i64,
+    pub last_success_at: i64,
+    pub last_outcome: ScanOutcome,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -396,6 +438,21 @@ pub fn save_checkpoint(last_scanned_height: i64) -> std::io::Result<()> {
     write_json_atomic(Path::new(DATA_DIR), CHECKPOINT_FILE, &Checkpoint { last_scanned_height })
 }
 
+pub fn load_scan_status() -> ScanStatus {
+    read_json_or_default(Path::new(DATA_DIR), SCAN_STATUS_FILE)
+}
+
+pub fn save_scan_status(status: &ScanStatus) -> std::io::Result<()> {
+    write_json_atomic(Path::new(DATA_DIR), SCAN_STATUS_FILE, status)
+}
+
+pub fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 pub async fn fetch_tip_height(client: &Client) -> Option<i64> {
     let url = format!("{}/blocks?limit=1", EXPLORER_BASE);
     let res = get_with_backoff(client, &url).await?;
@@ -521,12 +578,40 @@ async fn scan_range(
  * a cold-start replica catching up — same code path either way, just a
  * different `start_height` depending on how far behind the checkpoint is.
  */
+/*
+ * Pure decision of the persisted ScanStatus after one attempt, given what
+ * happened — kept separate from run_scan_cycle's network/IO orchestration so
+ * the actual rule ("only CaughtUp advances last_success_at, every outcome
+ * advances last_attempt_at, everything else about `previous` is preserved")
+ * is unit-testable without a live client or filesystem.
+ */
+fn next_scan_status(previous: ScanStatus, attempt_at: i64, outcome: ScanOutcome) -> ScanStatus {
+    ScanStatus {
+        last_attempt_at: attempt_at,
+        last_success_at: if outcome == ScanOutcome::CaughtUp { attempt_at } else { previous.last_success_at },
+        last_outcome: outcome,
+    }
+}
+
+fn persist_scan_status(status: ScanStatus) {
+    if let Err(e) = save_scan_status(&status) {
+        eprintln!("[chain_activity] failed to save scan status: {}", e);
+    }
+}
+
 pub async fn run_scan_cycle() {
+    let attempt_at = unix_now();
+    let previous_status = load_scan_status();
+
     let client = create_client();
 
     let tip_height = match fetch_tip_height(&client).await {
         Some(h) => h,
-        None => return, // explorer unreachable this cycle — try again next interval
+        None => {
+            // explorer unreachable this cycle — try again next interval
+            persist_scan_status(next_scan_status(previous_status, attempt_at, ScanOutcome::Unreachable));
+            return;
+        }
     };
 
     let checkpoint = load_checkpoint();
@@ -537,7 +622,9 @@ pub async fn run_scan_cycle() {
     let start_height = checkpoint.last_scanned_height.max(earliest_allowed);
 
     if start_height >= tip_height {
-        return; // already caught up to the tip
+        // already caught up to the tip — nothing to scan is itself success
+        persist_scan_status(next_scan_status(previous_status, attempt_at, ScanOutcome::CaughtUp));
+        return;
     }
 
     let deployment_heights = fetch_deployment_heights(&client).await;
@@ -545,6 +632,7 @@ pub async fn run_scan_cycle() {
     let mut team_txs = load_team_txs();
 
     let mut checkpoint_height = start_height;
+    let mut stalled = false;
 
     while checkpoint_height < tip_height {
         let batch_end = (checkpoint_height + SCAN_BATCH_SIZE).min(tip_height);
@@ -570,9 +658,13 @@ pub async fn run_scan_cycle() {
             // A gap was hit within this batch — stop the cycle here rather than
             // continuing to fire requests at an API that may still be rate-limiting
             // us. The next scheduled cycle resumes from this checkpoint.
+            stalled = true;
             break;
         }
     }
+
+    let outcome = if stalled { ScanOutcome::Stalled } else { ScanOutcome::CaughtUp };
+    persist_scan_status(next_scan_status(previous_status, attempt_at, outcome));
 
     println!(
         "[chain_activity] scanned up to {} (checkpoint now {})",
@@ -785,5 +877,62 @@ mod tests {
         let read_back: Checkpoint = read_json_or_default(&dir, "bad.json");
         assert_eq!(read_back, Checkpoint::default());
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_status_default_is_never_run_with_zeroed_timestamps() {
+        let status = ScanStatus::default();
+        assert_eq!(status.last_outcome, ScanOutcome::NeverRun);
+        assert_eq!(status.last_attempt_at, 0);
+        assert_eq!(status.last_success_at, 0);
+    }
+
+    #[test]
+    fn scan_status_round_trips_through_write_and_read() {
+        let dir = temp_test_dir("scan_status_roundtrip");
+        let status = ScanStatus { last_attempt_at: 1000, last_success_at: 900, last_outcome: ScanOutcome::Stalled };
+        write_json_atomic(&dir, "status.json", &status).expect("write should succeed");
+        let read_back: ScanStatus = read_json_or_default(&dir, "status.json");
+        assert_eq!(read_back, status);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_outcome_serializes_as_snake_case_matching_the_frontend_contract() {
+        assert_eq!(serde_json::to_string(&ScanOutcome::NeverRun).unwrap(), "\"never_run\"");
+        assert_eq!(serde_json::to_string(&ScanOutcome::CaughtUp).unwrap(), "\"caught_up\"");
+        assert_eq!(serde_json::to_string(&ScanOutcome::Stalled).unwrap(), "\"stalled\"");
+        assert_eq!(serde_json::to_string(&ScanOutcome::Unreachable).unwrap(), "\"unreachable\"");
+    }
+
+    #[test]
+    fn next_scan_status_caught_up_advances_both_timestamps() {
+        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::Stalled };
+        let next = next_scan_status(previous, 200, ScanOutcome::CaughtUp);
+        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 200, last_outcome: ScanOutcome::CaughtUp });
+    }
+
+    #[test]
+    fn next_scan_status_stalled_advances_attempt_but_preserves_last_success() {
+        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let next = next_scan_status(previous, 200, ScanOutcome::Stalled);
+        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Stalled });
+    }
+
+    #[test]
+    fn next_scan_status_unreachable_advances_attempt_but_preserves_last_success() {
+        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let next = next_scan_status(previous, 200, ScanOutcome::Unreachable);
+        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Unreachable });
+    }
+
+    #[test]
+    fn next_scan_status_from_never_run_stalled_leaves_last_success_at_zero() {
+        // The realistic cold-start-then-immediately-rate-limited case: a
+        // replica whose scanner has never once caught up should still show
+        // last_success_at: 0 (never), not silently inherit attempt_at.
+        let previous = ScanStatus::default();
+        let next = next_scan_status(previous, 500, ScanOutcome::Stalled);
+        assert_eq!(next, ScanStatus { last_attempt_at: 500, last_success_at: 0, last_outcome: ScanOutcome::Stalled });
     }
 }

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,7 +1,50 @@
 import { useEffect, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, filterDailyRange, summarizeDaily } from 'analytics/chainActivity';
+import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo } from 'analytics/chainActivity';
 import './index.scss';
+
+/*
+ * The one thing this whole tab used to be silent about: whether "no data"
+ * means the scanner is genuinely still building history, or something is
+ * actually wrong. See chainActivity.js's fetch_chain_activity doc comment
+ * for what each syncStatus value means. Hidden entirely once healthy
+ * (caught_up) — this is a "something to know about" banner, not a
+ * permanent status fixture.
+ */
+const SYNC_STATUS_COPY = {
+  api_unreachable: {
+    tone: 'error',
+    text: "Couldn't reach the activity service — this may be temporary.",
+  },
+  never_run: {
+    tone: 'info',
+    text: "Chain activity hasn't started syncing yet — check back shortly.",
+  },
+  stalled: {
+    tone: 'warning',
+    text: 'Sync is behind, possibly rate-limited by the block explorer.',
+  },
+  unreachable: {
+    tone: 'warning',
+    text: "Sync couldn't reach the block explorer on its last attempt.",
+  },
+};
+
+function SyncStatusBanner({ syncStatus, lastSuccessAt }) {
+  const copy = SYNC_STATUS_COPY[syncStatus];
+  if (!copy) return null; // caught_up (healthy) or an unrecognized future value — stay silent
+
+  const agoText = relativeTimeAgo(lastSuccessAt);
+  return (
+    <div className={`ca-sync-banner ca-sync-banner--${copy.tone}`}>
+      <span className="ca-sync-banner-dot" />
+      <span>
+        {copy.text}
+        {agoText ? ` Last successful update: ${agoText}.` : ''}
+      </span>
+    </div>
+  );
+}
 
 const RANGE_OPTIONS = [
   { label: '24H', days: 1 },
@@ -17,12 +60,17 @@ function pct(n, total) {
   return total > 0 ? ((n / total) * 100).toFixed(0) : '0';
 }
 
-function UtilitySummary({ daily, rangeDays, rangeLabel }) {
+function UtilitySummary({ daily, rangeDays, rangeLabel, syncStatus }) {
   const ranged = filterDailyRange(daily, rangeDays);
   const { utilityBlocks, emptyBlocks } = summarizeDaily(ranged);
   const total = utilityBlocks + emptyBlocks;
   const isPartial = daily.length > 0 && ranged.length < rangeDays;
   const badgeText = isPartial ? `${rangeLabel} (${ranged.length}d available)` : rangeLabel;
+  // "Still building history" is only accurate for a genuinely healthy,
+  // still-backfilling scanner — once the banner above is already showing a
+  // real problem, repeating an falsely-reassuring message here would
+  // contradict it.
+  const stillBuilding = syncStatus === 'never_run' || syncStatus === 'caught_up';
 
   return (
     <div className="hov-panel ca-utility-panel">
@@ -32,7 +80,9 @@ function UtilitySummary({ daily, rangeDays, rangeLabel }) {
       </div>
       {total === 0 ? (
         <div className="hov-empty">
-          {daily.length === 0 ? 'Still building history — check back shortly' : 'No blocks in this range yet'}
+          {daily.length === 0
+            ? (stillBuilding ? 'Still building history — check back shortly' : 'No data available')
+            : 'No blocks in this range yet'}
         </div>
       ) : (
         <>
@@ -83,7 +133,14 @@ function TeamTxList({ teamTxs, rangeDays, lastScannedHeight }) {
 }
 
 export function ChainActivityTab() {
-  const [data, setData] = useState({ daily: [], teamTxs: [], lastScannedHeight: 0 });
+  const [data, setData] = useState({
+    daily: [],
+    teamTxs: [],
+    lastScannedHeight: 0,
+    lastAttemptAt: 0,
+    lastSuccessAt: 0,
+    syncStatus: 'never_run',
+  });
   const [loading, setLoading] = useState(true);
   const [rangeDays, setRangeDays] = useState(1);
 
@@ -116,6 +173,7 @@ export function ChainActivityTab() {
 
   return (
     <div className="chain-activity-tab">
+      <SyncStatusBanner syncStatus={data.syncStatus} lastSuccessAt={data.lastSuccessAt} />
       <div className="ca-range-toggle">
         {RANGE_OPTIONS.map((r) => (
           <button
@@ -128,7 +186,7 @@ export function ChainActivityTab() {
           </button>
         ))}
       </div>
-      <UtilitySummary daily={data.daily} rangeDays={rangeDays} rangeLabel={activeRange.label} />
+      <UtilitySummary daily={data.daily} rangeDays={rangeDays} rangeLabel={activeRange.label} syncStatus={data.syncStatus} />
       <TeamTxList teamTxs={data.teamTxs} rangeDays={rangeDays} lastScannedHeight={data.lastScannedHeight} />
     </div>
   );

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -68,7 +68,7 @@ function UtilitySummary({ daily, rangeDays, rangeLabel, syncStatus }) {
   const badgeText = isPartial ? `${rangeLabel} (${ranged.length}d available)` : rangeLabel;
   // "Still building history" is only accurate for a genuinely healthy,
   // still-backfilling scanner — once the banner above is already showing a
-  // real problem, repeating an falsely-reassuring message here would
+  // real problem, repeating a falsely-reassuring message here would
   // contradict it.
   const stillBuilding = syncStatus === 'never_run' || syncStatus === 'caught_up';
 

--- a/client/src/analytics/ChainActivityTab/index.scss
+++ b/client/src/analytics/ChainActivityTab/index.scss
@@ -6,6 +6,43 @@
   gap: 16px;
 }
 
+.ca-sync-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-inset);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+}
+
+.ca-sync-banner-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ca-sync-banner--info .ca-sync-banner-dot {
+  background: var(--accent-blue);
+}
+
+.ca-sync-banner--warning {
+  border-color: rgba(224, 146, 5, 0.35);
+}
+.ca-sync-banner--warning .ca-sync-banner-dot {
+  background: var(--accent-amber);
+}
+
+.ca-sync-banner--error {
+  border-color: rgba(220, 58, 58, 0.35);
+}
+.ca-sync-banner--error .ca-sync-banner-dot {
+  background: var(--accent-red);
+}
+
 .ca-range-toggle {
   display: flex;
   gap: 6px;

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -7,9 +7,29 @@ import { FLUXNODE_INFO_API_URL } from 'app-buildinfo';
  * Mirrors the existing `${FLUXNODE_INFO_API_URL}/api/v1/...` fetch pattern already
  * used by getDemoWallet() (apidata.js). The backend's JSON is snake_case (Rust's
  * serde default) — normalized to camelCase here, once, at the boundary.
+ *
+ * `syncStatus` distinguishes two different layers, both collapsed into one
+ * field so the component only ever needs to switch on one thing:
+ *   - 'api_unreachable' — WE (the frontend) couldn't get a response at all
+ *     (network error, the backend down, a non-JSON body). This never
+ *     reaches the backend's own outcome, so it can't be one of the four
+ *     below.
+ *   - 'never_run' | 'caught_up' | 'stalled' | 'unreachable' — passed
+ *     straight through from the backend's own last_outcome, once a
+ *     response WAS received. 'unreachable' here means the SCANNER
+ *     couldn't reach the block explorer on its last attempt — a different
+ *     thing from 'api_unreachable' above, which is about reaching our own
+ *     API at all. See ScanOutcome's doc comment in chain_activity.rs.
  */
 export async function fetch_chain_activity() {
-  const empty = { daily: [], teamTxs: [], lastScannedHeight: 0 };
+  const empty = {
+    daily: [],
+    teamTxs: [],
+    lastScannedHeight: 0,
+    lastAttemptAt: 0,
+    lastSuccessAt: 0,
+    syncStatus: 'api_unreachable',
+  };
   try {
     const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/chain-activity`, {
       method: 'GET',
@@ -25,10 +45,34 @@ export async function fetch_chain_activity() {
       ? json.team_txs.map((t) => ({ txid: t.txid, blockHeight: t.block_height, from: t.from, to: t.to, amount: t.amount }))
       : [];
 
-    return { daily, teamTxs, lastScannedHeight: json.last_scanned_height || 0 };
+    return {
+      daily,
+      teamTxs,
+      lastScannedHeight: json.last_scanned_height || 0,
+      lastAttemptAt: json.last_attempt_at || 0,
+      lastSuccessAt: json.last_success_at || 0,
+      syncStatus: json.last_outcome || 'never_run',
+    };
   } catch {
     return empty;
   }
+}
+
+// "Xm ago"/"Xh ago"/"Xd ago" for the sync-status banner. A local helper
+// rather than reusing live/timeFormat.js's relativeTime: that one only
+// covers seconds/minutes (block timestamps are always within a couple
+// minutes of "now"), while a stalled chain-activity sync can genuinely be
+// hours or days stale, and analytics/ has no existing dependency on live/.
+export function relativeTimeAgo(unixSeconds) {
+  if (!unixSeconds) return null;
+  const seconds = Math.max(0, Math.round(Date.now() / 1000 - unixSeconds));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
 }
 
 // Client-side range filter — the backend always returns the full retained

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,8 +1,17 @@
-import { fetch_chain_activity, filterDailyRange, summarizeDaily } from './chainActivity';
+import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo } from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
 }
+
+const EMPTY_RESULT = {
+  daily: [],
+  teamTxs: [],
+  lastScannedHeight: 0,
+  lastAttemptAt: 0,
+  lastSuccessAt: 0,
+  syncStatus: 'api_unreachable',
+};
 
 describe('fetch_chain_activity', () => {
   beforeEach(() => {
@@ -19,6 +28,9 @@ describe('fetch_chain_activity', () => {
       daily: [{ date: '2026-09-06', utility_blocks: 5, empty_blocks: 2 }],
       team_txs: [{ txid: 'abc', block_height: 100, from: 't1a', to: 't1b', amount: 3.5 }],
       last_scanned_height: 12345,
+      last_attempt_at: 1788900000,
+      last_success_at: 1788899000,
+      last_outcome: 'caught_up',
     }));
 
     const result = await fetch_chain_activity();
@@ -26,18 +38,83 @@ describe('fetch_chain_activity', () => {
     expect(result.daily).toEqual([{ date: '2026-09-06', utilityBlocks: 5, emptyBlocks: 2 }]);
     expect(result.teamTxs).toEqual([{ txid: 'abc', blockHeight: 100, from: 't1a', to: 't1b', amount: 3.5 }]);
     expect(result.lastScannedHeight).toBe(12345);
+    expect(result.lastAttemptAt).toBe(1788900000);
+    expect(result.lastSuccessAt).toBe(1788899000);
+    expect(result.syncStatus).toBe('caught_up');
+  });
+
+  it('passes through a stalled outcome so the UI can show a non-misleading message', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      success: true,
+      daily: [],
+      team_txs: [],
+      last_scanned_height: 500,
+      last_attempt_at: 1788900000,
+      last_success_at: 1788800000,
+      last_outcome: 'stalled',
+    }));
+
+    const result = await fetch_chain_activity();
+    expect(result.syncStatus).toBe('stalled');
+    expect(result.lastSuccessAt).toBe(1788800000); // preserved even though the latest attempt stalled
+  });
+
+  it('defaults syncStatus to never_run when the backend omits last_outcome (older API version)', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      success: true,
+      daily: [],
+      team_txs: [],
+      last_scanned_height: 0,
+    }));
+
+    const result = await fetch_chain_activity();
+    expect(result.syncStatus).toBe('never_run');
   });
 
   it('returns empty defaults when success is false', async () => {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({ success: false }));
     const result = await fetch_chain_activity();
-    expect(result).toEqual({ daily: [], teamTxs: [], lastScannedHeight: 0 });
+    expect(result).toEqual(EMPTY_RESULT);
   });
 
-  it('fails soft on a network error', async () => {
+  it('fails soft on a network error, distinguishably from a genuinely-empty backend response', async () => {
     global.fetch.mockRejectedValueOnce(new Error('network down'));
     const result = await fetch_chain_activity();
-    expect(result).toEqual({ daily: [], teamTxs: [], lastScannedHeight: 0 });
+    expect(result).toEqual(EMPTY_RESULT);
+    expect(result.syncStatus).toBe('api_unreachable');
+  });
+});
+
+describe('relativeTimeAgo', () => {
+  const NOW = 1788900000;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW * 1000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null for a falsy/never-happened timestamp', () => {
+    expect(relativeTimeAgo(0)).toBeNull();
+    expect(relativeTimeAgo(null)).toBeNull();
+  });
+
+  it('returns "just now" for anything under a minute old', () => {
+    expect(relativeTimeAgo(NOW - 10)).toBe('just now');
+  });
+
+  it('formats minutes', () => {
+    expect(relativeTimeAgo(NOW - 5 * 60)).toBe('5m ago');
+  });
+
+  it('formats hours', () => {
+    expect(relativeTimeAgo(NOW - 3 * 3600)).toBe('3h ago');
+  });
+
+  it('formats days', () => {
+    expect(relativeTimeAgo(NOW - 2 * 86400)).toBe('2d ago');
   });
 });
 

--- a/todo.md
+++ b/todo.md
@@ -46,17 +46,32 @@ Process: same as every prior session in this repo — `superpowers:writing-plans
 `superpowers:subagent-driven-development` (fresh implementer per task, task review,
 final whole-branch review) → PR.
 
-### Track 2 — Analytics "Premium Feel" Visual Refresh (proposed, needs a decision pass before planning starts)
+### Track 2 — Analytics rework (in progress, scope expanded 2026-09-09)
 
-**Status: reviewed and scoped below, but NOT yet brainstormed/confirmed with the
-user** — the findings and proposed direction below are my analysis from a live visual
-pass (2026-09-06) plus a code read of the current SCSS/design-token system, not
-settled decisions. Genuine aesthetic choices here (palette, whether to add a charting
-library, how aggressive the redesign gets) need the same confirm-before-plan treatment
-every other piece of new work in this repo has gotten — run
-`superpowers:brainstorming` on this before writing an implementation plan. Queued
-**after** Track 1 per your instruction — pick it up once Live Redesign is done, or
-sooner if you'd rather interleave (same as Analytics/Live were interleaved before).
+**Status: brainstorming underway, one sub-piece already shipped.** Track 1 (Live
+Redesign) is fully done — see above. Track 2 started as a proposed "premium feel"
+visual refresh (2026-09-06 analysis below) and was expanded 2026-09-09 to also cover:
+bringing `/home` features into `/analytics` where it makes sense, rethinking the
+wallet-unlock UX for donor-gated content, and Chain Activity's sync-status messaging.
+
+- [x] **Chain Activity sync-status messaging** — split off as its own bounded fix
+  (existing flow, no spec needed) since it was small and independently valuable.
+  **PR #192** (2026-09-09, open). The `/api/v1/chain-activity` endpoint used to
+  hardcode `success: true` regardless of what was on disk, so a scanner that had
+  never run, stalled (most likely rate-limited by `explorer.runonflux.io`, a
+  documented failure mode of that API), or a frontend that couldn't reach the API
+  at all were all indistinguishable — same silent "Still building history" message
+  every time. Backend now tracks and exposes real scan health
+  (`last_attempt_at`/`last_success_at`/`last_outcome`); frontend shows an accurate
+  banner instead, hidden when healthy.
+- [ ] **Visual refresh + home→analytics migration + wallet-unlock UX** — the bigger,
+  still-architectural piece. Genuine aesthetic and IA choices here (palette, whether
+  to add a charting library, exactly what moves from `/home` to `/analytics` and
+  where it lands, how the unlock flow should work) need the same confirm-before-plan
+  treatment every other piece of work in this repo gets — run
+  `superpowers:brainstorming` on this before writing an implementation plan. The
+  2026-09-06 findings below are background/analysis for that pass, not settled
+  decisions.
 
 #### Why: what's actually wrong, specifically
 


### PR DESCRIPTION
## Summary

Chain Activity's `/api/v1/chain-activity` endpoint was a pure disk read that hardcoded `success: true` regardless of what was actually on disk. If the scanner had never run, stalled mid-backfill, or the frontend just couldn't reach the API at all, the tab silently showed the same "Still building history — check back shortly" message every time — genuinely indistinguishable from a healthy first-time backfill.

## What changed

**Backend** (`api/src/services/chain_activity.rs`, `api/src/main.rs`): the scanner now persists a small `ScanStatus` alongside the existing checkpoint — `last_attempt_at` (every cycle), `last_success_at` (only a cycle that actually reaches the tip), and a real `last_outcome`: `never_run` / `caught_up` / `stalled` / `unreachable`. `stalled` names the most likely cause (this API's own documented rate-limiting on `explorer.runonflux.io` — see `get_with_backoff`'s comment) without overclaiming certainty the code can't actually verify. The status-update rule is a small pure function (`next_scan_status`), unit-tested directly.

**Frontend** (`client/src/analytics/chainActivity.js`, `ChainActivityTab`): `fetch_chain_activity()` now returns a `syncStatus` field distinguishing "couldn't reach our own API at all" from the backend's real outcome once a response was received. The tab shows a banner reflecting the real state — hidden entirely when healthy — and the existing "Still building history" message no longer fires when something's actually wrong (it would have contradicted a warning banner sitting right above it).

## Testing

- Frontend: 410 → 417 tests (7 new: `fetch_chain_activity`'s `syncStatus` passthrough + `relativeTimeAgo`'s formatting)
- Backend: 21 → 28 tests (7 new: `ScanStatus`/`ScanOutcome` round-trip + serialization + all 5 `next_scan_status` transition cases), built and tested via Docker (`rust:1.67.1`, matching this repo's `Dockerfile`)
- Both builds clean, no new warnings

## Note

This was built without live-testing against production APIs, to avoid compounding a possible IP rate-limit from an earlier session. Recommend testing locally (`yarn start` + the API running with `REACT_APP_FLUXNODE_INFO_API_MODE=proxy`) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
