### PR TITLE
fix(chain-activity): surface in_progress so a long scan isn't mistaken for never-started

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -289,6 +289,12 @@ pub mod api_v1 {
             last_attempt_at: i64,
             last_success_at: i64,
             last_outcome: services::chain_activity::ScanOutcome,
+            // Both 0 unless last_outcome is currently in_progress — see
+            // ScanStatus's own field doc comment. Combined with
+            // last_scanned_height above, a viewer computes real "X of Y
+            // blocks" progress instead of just knowing a scan is running.
+            scan_start_height: i64,
+            scan_target_height: i64,
         }
 
         // Synchronous read of whatever the background scanner has already
@@ -302,6 +308,8 @@ pub mod api_v1 {
                 last_scanned_height: services::chain_activity::load_checkpoint().last_scanned_height,
                 last_attempt_at: scan_status.last_attempt_at,
                 last_success_at: scan_status.last_success_at,
+                scan_start_height: scan_status.scan_start_height,
+                scan_target_height: scan_status.scan_target_height,
                 last_outcome: scan_status.last_outcome,
             };
             (StatusCode::OK, Json(body))

--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -220,11 +220,26 @@ pub struct Checkpoint {
  * would mean threading a real error type through several more layers than
  * this fix's scope covers. `Stalled` names the most likely cause (this
  * API's own well-documented rate-limiting) without claiming certainty.
+ *
+ * `InProgress`: a genuine cold-start backfill (checkpoint 0, full
+ * RETENTION_BLOCKS window) can take MANY MINUTES even with no rate-
+ * limiting at all — 2+ explorer requests per block, SCAN_CONCURRENCY=2 by
+ * design (see its own comment) — and get_with_backoff's retry budget alone
+ * can stretch a single request past a minute under real 429s (live-
+ * confirmed 2026-09-09: this API's rate limit is real and can affect a
+ * scanner's own requests, not just a human's browser testing). Without
+ * this state, a scan that has been legitimately running and retrying for
+ * several minutes is indistinguishable from one that never started at all
+ * — exactly the ambiguity this whole ScanStatus mechanism exists to
+ * remove. Persisted immediately when a cycle starts, before any of that
+ * potentially-long work, and overwritten with the real terminal outcome
+ * once the cycle actually finishes.
  */
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ScanOutcome {
     NeverRun,
+    InProgress,
     CaughtUp,
     Stalled,
     Unreachable,
@@ -603,6 +618,14 @@ pub async fn run_scan_cycle() {
     let attempt_at = unix_now();
     let previous_status = load_scan_status();
 
+    // Persisted BEFORE any of the potentially-long work below — a cold-start
+    // backfill (or a run fighting this API's real rate limits) can take
+    // several minutes to reach any of the exit points further down, and
+    // without this write, an in-progress attempt is indistinguishable from
+    // one that never started. Every other exit path below overwrites this
+    // with the real terminal outcome once the cycle actually finishes.
+    persist_scan_status(next_scan_status(previous_status.clone(), attempt_at, ScanOutcome::InProgress));
+
     let client = create_client();
 
     let tip_height = match fetch_tip_height(&client).await {
@@ -900,6 +923,7 @@ mod tests {
     #[test]
     fn scan_outcome_serializes_as_snake_case_matching_the_frontend_contract() {
         assert_eq!(serde_json::to_string(&ScanOutcome::NeverRun).unwrap(), "\"never_run\"");
+        assert_eq!(serde_json::to_string(&ScanOutcome::InProgress).unwrap(), "\"in_progress\"");
         assert_eq!(serde_json::to_string(&ScanOutcome::CaughtUp).unwrap(), "\"caught_up\"");
         assert_eq!(serde_json::to_string(&ScanOutcome::Stalled).unwrap(), "\"stalled\"");
         assert_eq!(serde_json::to_string(&ScanOutcome::Unreachable).unwrap(), "\"unreachable\"");
@@ -924,6 +948,16 @@ mod tests {
         let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
         let next = next_scan_status(previous, 200, ScanOutcome::Unreachable);
         assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Unreachable });
+    }
+
+    #[test]
+    fn next_scan_status_in_progress_advances_attempt_but_preserves_last_success() {
+        // The write run_scan_cycle makes immediately on starting, before any
+        // network work — must look exactly like Stalled/Unreachable's
+        // preserve-last-success behavior, not like a fresh CaughtUp.
+        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let next = next_scan_status(previous, 200, ScanOutcome::InProgress);
+        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::InProgress });
     }
 
     #[test]

--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -259,6 +259,16 @@ pub struct ScanStatus {
     pub last_attempt_at: i64,
     pub last_success_at: i64,
     pub last_outcome: ScanOutcome,
+    // The height range the CURRENT in-progress attempt is scanning, so a
+    // viewer can see real "X of Y blocks" progress rather than just "it's
+    // running" — combined with the checkpoint's own last_scanned_height
+    // (already exposed alongside this), progress = (last_scanned_height -
+    // scan_start_height) / (scan_target_height - scan_start_height). Both 0
+    // whenever last_outcome isn't InProgress: the range only means something
+    // while a scan is actually active, and a stale leftover range on a
+    // finished/never-run status would be misleading, not just unused.
+    pub scan_start_height: i64,
+    pub scan_target_height: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -605,7 +615,22 @@ fn next_scan_status(previous: ScanStatus, attempt_at: i64, outcome: ScanOutcome)
         last_attempt_at: attempt_at,
         last_success_at: if outcome == ScanOutcome::CaughtUp { attempt_at } else { previous.last_success_at },
         last_outcome: outcome,
+        // Always reset here — a caller that knows the current scan's real
+        // range calls with_scan_range() right after, which is the only
+        // place these ever get a nonzero value.
+        scan_start_height: 0,
+        scan_target_height: 0,
     }
+}
+
+// Attaches the height range an in-progress scan is actively covering, once
+// known (the tip height isn't available until after fetch_tip_height
+// succeeds, one step after the InProgress status above is already
+// persisted) — a separate small pure function rather than folding into
+// next_scan_status itself, since only the InProgress path ever has a range
+// to attach.
+fn with_scan_range(status: ScanStatus, start_height: i64, target_height: i64) -> ScanStatus {
+    ScanStatus { scan_start_height: start_height, scan_target_height: target_height, ..status }
 }
 
 fn persist_scan_status(status: ScanStatus) {
@@ -650,6 +675,19 @@ pub async fn run_scan_cycle() {
         return;
     }
 
+    // Now that the real range is known, attach it to the InProgress status
+    // already on disk — this is what lets a viewer (or docker logs) see
+    // real "X of Y blocks" progress instead of just "it's running".
+    persist_scan_status(with_scan_range(
+        next_scan_status(previous_status.clone(), attempt_at, ScanOutcome::InProgress),
+        start_height,
+        tip_height,
+    ));
+    println!(
+        "[chain_activity] scan starting: {} blocks to cover ({} -> {})",
+        tip_height - start_height, start_height, tip_height
+    );
+
     let deployment_heights = fetch_deployment_heights(&client).await;
     let mut daily = load_daily_rollup();
     let mut team_txs = load_team_txs();
@@ -676,6 +714,21 @@ pub async fn run_scan_cycle() {
 
         let made_progress = new_checkpoint > checkpoint_height;
         checkpoint_height = new_checkpoint;
+
+        // One line per batch (every SCAN_BATCH_SIZE=300 blocks at most) so
+        // watching `docker logs` during a long cold-start backfill shows
+        // real, live progress instead of total silence until the final
+        // summary line — the same visibility gap the in_progress status
+        // fixes for the HTTP endpoint, but for an operator tailing logs.
+        let pct = if tip_height > start_height {
+            ((checkpoint_height - start_height) as f64 / (tip_height - start_height) as f64 * 100.0).round()
+        } else {
+            100.0
+        };
+        println!(
+            "[chain_activity] batch done: checkpoint {} / tip {} ({:.0}% of this cycle's range)",
+            checkpoint_height, tip_height, pct
+        );
 
         if !made_progress || new_checkpoint < batch_end {
             // A gap was hit within this batch — stop the cycle here rather than
@@ -913,7 +966,10 @@ mod tests {
     #[test]
     fn scan_status_round_trips_through_write_and_read() {
         let dir = temp_test_dir("scan_status_roundtrip");
-        let status = ScanStatus { last_attempt_at: 1000, last_success_at: 900, last_outcome: ScanOutcome::Stalled };
+        let status = ScanStatus {
+            last_attempt_at: 1000, last_success_at: 900, last_outcome: ScanOutcome::Stalled,
+            ..Default::default()
+        };
         write_json_atomic(&dir, "status.json", &status).expect("write should succeed");
         let read_back: ScanStatus = read_json_or_default(&dir, "status.json");
         assert_eq!(read_back, status);
@@ -931,23 +987,41 @@ mod tests {
 
     #[test]
     fn next_scan_status_caught_up_advances_both_timestamps() {
-        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::Stalled };
+        let previous = ScanStatus {
+            last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::Stalled,
+            ..Default::default()
+        };
         let next = next_scan_status(previous, 200, ScanOutcome::CaughtUp);
-        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 200, last_outcome: ScanOutcome::CaughtUp });
+        assert_eq!(next, ScanStatus {
+            last_attempt_at: 200, last_success_at: 200, last_outcome: ScanOutcome::CaughtUp,
+            ..Default::default()
+        });
     }
 
     #[test]
     fn next_scan_status_stalled_advances_attempt_but_preserves_last_success() {
-        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let previous = ScanStatus {
+            last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp,
+            ..Default::default()
+        };
         let next = next_scan_status(previous, 200, ScanOutcome::Stalled);
-        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Stalled });
+        assert_eq!(next, ScanStatus {
+            last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Stalled,
+            ..Default::default()
+        });
     }
 
     #[test]
     fn next_scan_status_unreachable_advances_attempt_but_preserves_last_success() {
-        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let previous = ScanStatus {
+            last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp,
+            ..Default::default()
+        };
         let next = next_scan_status(previous, 200, ScanOutcome::Unreachable);
-        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Unreachable });
+        assert_eq!(next, ScanStatus {
+            last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::Unreachable,
+            ..Default::default()
+        });
     }
 
     #[test]
@@ -955,9 +1029,15 @@ mod tests {
         // The write run_scan_cycle makes immediately on starting, before any
         // network work — must look exactly like Stalled/Unreachable's
         // preserve-last-success behavior, not like a fresh CaughtUp.
-        let previous = ScanStatus { last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp };
+        let previous = ScanStatus {
+            last_attempt_at: 100, last_success_at: 50, last_outcome: ScanOutcome::CaughtUp,
+            ..Default::default()
+        };
         let next = next_scan_status(previous, 200, ScanOutcome::InProgress);
-        assert_eq!(next, ScanStatus { last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::InProgress });
+        assert_eq!(next, ScanStatus {
+            last_attempt_at: 200, last_success_at: 50, last_outcome: ScanOutcome::InProgress,
+            ..Default::default()
+        });
     }
 
     #[test]
@@ -967,6 +1047,37 @@ mod tests {
         // last_success_at: 0 (never), not silently inherit attempt_at.
         let previous = ScanStatus::default();
         let next = next_scan_status(previous, 500, ScanOutcome::Stalled);
-        assert_eq!(next, ScanStatus { last_attempt_at: 500, last_success_at: 0, last_outcome: ScanOutcome::Stalled });
+        assert_eq!(next, ScanStatus {
+            last_attempt_at: 500, last_success_at: 0, last_outcome: ScanOutcome::Stalled,
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn next_scan_status_always_resets_the_scan_range_even_from_a_previous_in_progress() {
+        // A terminal outcome (or a fresh InProgress at the start of a NEW
+        // cycle) ends whatever range the LAST in-progress attempt was
+        // covering — leaving it on disk would misreport progress against a
+        // range that no longer applies.
+        let previous = ScanStatus {
+            last_attempt_at: 100, last_success_at: 0, last_outcome: ScanOutcome::InProgress,
+            scan_start_height: 500, scan_target_height: 1000,
+        };
+        let next = next_scan_status(previous, 200, ScanOutcome::CaughtUp);
+        assert_eq!(next.scan_start_height, 0);
+        assert_eq!(next.scan_target_height, 0);
+    }
+
+    #[test]
+    fn with_scan_range_sets_the_range_and_preserves_everything_else() {
+        let status = ScanStatus {
+            last_attempt_at: 200, last_success_at: 100, last_outcome: ScanOutcome::InProgress,
+            ..Default::default()
+        };
+        let with_range = with_scan_range(status, 500, 1000);
+        assert_eq!(with_range, ScanStatus {
+            last_attempt_at: 200, last_success_at: 100, last_outcome: ScanOutcome::InProgress,
+            scan_start_height: 500, scan_target_height: 1000,
+        });
     }
 }

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo } from 'analytics/chainActivity';
+import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo, scanProgressPct } from 'analytics/chainActivity';
 import './index.scss';
 
 /*
@@ -34,16 +34,22 @@ const SYNC_STATUS_COPY = {
   },
 };
 
-function SyncStatusBanner({ syncStatus, lastSuccessAt }) {
+function SyncStatusBanner({ syncStatus, lastSuccessAt, lastScannedHeight, scanStartHeight, scanTargetHeight }) {
   const copy = SYNC_STATUS_COPY[syncStatus];
   if (!copy) return null; // caught_up (healthy) or an unrecognized future value — stay silent
 
   const agoText = relativeTimeAgo(lastSuccessAt);
+  const hasRange = syncStatus === 'in_progress' && scanTargetHeight > scanStartHeight;
+  const progressText = hasRange
+    ? ` Block ${fmtNum(lastScannedHeight)} of ${fmtNum(scanTargetHeight)} (${scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight })}%).`
+    : '';
+
   return (
     <div className={`ca-sync-banner ca-sync-banner--${copy.tone}`}>
       <span className="ca-sync-banner-dot" />
       <span>
         {copy.text}
+        {progressText}
         {agoText ? ` Last successful update: ${agoText}.` : ''}
       </span>
     </div>
@@ -143,6 +149,8 @@ export function ChainActivityTab() {
     lastScannedHeight: 0,
     lastAttemptAt: 0,
     lastSuccessAt: 0,
+    scanStartHeight: 0,
+    scanTargetHeight: 0,
     syncStatus: 'never_run',
   });
   const [loading, setLoading] = useState(true);
@@ -177,7 +185,13 @@ export function ChainActivityTab() {
 
   return (
     <div className="chain-activity-tab">
-      <SyncStatusBanner syncStatus={data.syncStatus} lastSuccessAt={data.lastSuccessAt} />
+      <SyncStatusBanner
+        syncStatus={data.syncStatus}
+        lastSuccessAt={data.lastSuccessAt}
+        lastScannedHeight={data.lastScannedHeight}
+        scanStartHeight={data.scanStartHeight}
+        scanTargetHeight={data.scanTargetHeight}
+      />
       <div className="ca-range-toggle">
         {RANGE_OPTIONS.map((r) => (
           <button

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -20,6 +20,10 @@ const SYNC_STATUS_COPY = {
     tone: 'info',
     text: "Chain activity hasn't started syncing yet — check back shortly.",
   },
+  in_progress: {
+    tone: 'info',
+    text: 'Sync is running — a first-time backfill can take several minutes.',
+  },
   stalled: {
     tone: 'warning',
     text: 'Sync is behind, possibly rate-limited by the block explorer.',
@@ -70,7 +74,7 @@ function UtilitySummary({ daily, rangeDays, rangeLabel, syncStatus }) {
   // still-backfilling scanner — once the banner above is already showing a
   // real problem, repeating a falsely-reassuring message here would
   // contradict it.
-  const stillBuilding = syncStatus === 'never_run' || syncStatus === 'caught_up';
+  const stillBuilding = syncStatus === 'never_run' || syncStatus === 'in_progress' || syncStatus === 'caught_up';
 
   return (
     <div className="hov-panel ca-utility-panel">

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -25,6 +25,13 @@ import { FLUXNODE_INFO_API_URL } from 'app-buildinfo';
  *     one fighting this API's real rate limits, needs this or it looks
  *     identical to 'never_run' for however long that takes. See
  *     ScanOutcome's doc comment in chain_activity.rs.
+ *
+ * `scanStartHeight`/`scanTargetHeight` are only nonzero while syncStatus is
+ * 'in_progress' AND the current attempt has resolved a real tip height yet
+ * (there's a brief window right at cycle start where it's in_progress but
+ * these are still both 0 — see scanProgressPct's 0-fallback). Combined with
+ * `lastScannedHeight`, this is what lets the UI show real "X of Y blocks"
+ * progress instead of just "it's running".
  */
 export async function fetch_chain_activity() {
   const empty = {
@@ -33,6 +40,8 @@ export async function fetch_chain_activity() {
     lastScannedHeight: 0,
     lastAttemptAt: 0,
     lastSuccessAt: 0,
+    scanStartHeight: 0,
+    scanTargetHeight: 0,
     syncStatus: 'api_unreachable',
   };
   try {
@@ -41,7 +50,10 @@ export async function fetch_chain_activity() {
       headers: { Accept: 'application/json' },
     });
     const json = await response.json();
-    if (!json?.success) return empty;
+    if (!json?.success) {
+      console.log('[ChainActivity] backend reported success:false — treating as unavailable');
+      return empty;
+    }
 
     const daily = Array.isArray(json.daily)
       ? json.daily.map((d) => ({ date: d.date, utilityBlocks: d.utility_blocks || 0, emptyBlocks: d.empty_blocks || 0 }))
@@ -50,17 +62,48 @@ export async function fetch_chain_activity() {
       ? json.team_txs.map((t) => ({ txid: t.txid, blockHeight: t.block_height, from: t.from, to: t.to, amount: t.amount }))
       : [];
 
-    return {
+    const result = {
       daily,
       teamTxs,
       lastScannedHeight: json.last_scanned_height || 0,
       lastAttemptAt: json.last_attempt_at || 0,
       lastSuccessAt: json.last_success_at || 0,
+      scanStartHeight: json.scan_start_height || 0,
+      scanTargetHeight: json.scan_target_height || 0,
       syncStatus: json.last_outcome || 'never_run',
     };
-  } catch {
+
+    // Visibility for anyone watching devtools during local testing — the
+    // banner already shows this, but the console line is easy to spot
+    // across repeated polls without opening the Network tab each time.
+    if (result.syncStatus === 'in_progress' && result.scanTargetHeight > result.scanStartHeight) {
+      const progress = scanProgressPct(result);
+      console.log(
+        `[ChainActivity] sync in progress: block ${result.lastScannedHeight} of ${result.scanTargetHeight}` +
+          ` (${progress}%, started at ${result.scanStartHeight})`
+      );
+    } else {
+      console.log(`[ChainActivity] syncStatus=${result.syncStatus}`);
+    }
+
+    return result;
+  } catch (error) {
+    console.log('[ChainActivity] fetch failed:', error?.message || error);
     return empty;
   }
+}
+
+// Percent of the CURRENT in-progress scan's own range that's done — not
+// percent of the full retention window, since a scan only ever needs to
+// cover from the last checkpoint to the tip, which is usually far smaller.
+// Returns 0 rather than NaN/Infinity when there's no real range yet (the
+// InProgress status written before the range is known — see
+// run_scan_cycle's two-step write in chain_activity.rs).
+export function scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight }) {
+  const span = scanTargetHeight - scanStartHeight;
+  if (span <= 0) return 0;
+  const done = Math.max(0, Math.min(span, lastScannedHeight - scanStartHeight));
+  return Math.round((done / span) * 100);
 }
 
 // "Xm ago"/"Xh ago"/"Xd ago" for the sync-status banner. A local helper

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -14,12 +14,17 @@ import { FLUXNODE_INFO_API_URL } from 'app-buildinfo';
  *     (network error, the backend down, a non-JSON body). This never
  *     reaches the backend's own outcome, so it can't be one of the four
  *     below.
- *   - 'never_run' | 'caught_up' | 'stalled' | 'unreachable' — passed
- *     straight through from the backend's own last_outcome, once a
- *     response WAS received. 'unreachable' here means the SCANNER
+ *   - 'never_run' | 'in_progress' | 'caught_up' | 'stalled' | 'unreachable'
+ *     — passed straight through from the backend's own last_outcome, once
+ *     a response WAS received. 'unreachable' here means the SCANNER
  *     couldn't reach the block explorer on its last attempt — a different
  *     thing from 'api_unreachable' above, which is about reaching our own
- *     API at all. See ScanOutcome's doc comment in chain_activity.rs.
+ *     API at all. 'in_progress' means a scan is actively running right
+ *     now (persisted the instant a cycle starts, before any of its
+ *     potentially minutes-long work) — a genuine cold-start backfill, or
+ *     one fighting this API's real rate limits, needs this or it looks
+ *     identical to 'never_run' for however long that takes. See
+ *     ScanOutcome's doc comment in chain_activity.rs.
  */
 export async function fetch_chain_activity() {
   const empty = {

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,4 +1,4 @@
-import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo } from './chainActivity';
+import { fetch_chain_activity, filterDailyRange, summarizeDaily, relativeTimeAgo, scanProgressPct } from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
@@ -10,6 +10,8 @@ const EMPTY_RESULT = {
   lastScannedHeight: 0,
   lastAttemptAt: 0,
   lastSuccessAt: 0,
+  scanStartHeight: 0,
+  scanTargetHeight: 0,
   syncStatus: 'api_unreachable',
 };
 
@@ -75,6 +77,38 @@ describe('fetch_chain_activity', () => {
     expect(result.lastAttemptAt).toBe(1788900000);
   });
 
+  it('passes through the scan range while a scan is in progress', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      success: true,
+      daily: [],
+      team_txs: [],
+      last_scanned_height: 1200,
+      last_attempt_at: 1788900000,
+      last_success_at: 0,
+      last_outcome: 'in_progress',
+      scan_start_height: 1000,
+      scan_target_height: 2000,
+    }));
+
+    const result = await fetch_chain_activity();
+    expect(result.scanStartHeight).toBe(1000);
+    expect(result.scanTargetHeight).toBe(2000);
+  });
+
+  it('defaults the scan range to 0/0 when the backend omits it (not currently in progress)', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      success: true,
+      daily: [],
+      team_txs: [],
+      last_scanned_height: 500,
+      last_outcome: 'caught_up',
+    }));
+
+    const result = await fetch_chain_activity();
+    expect(result.scanStartHeight).toBe(0);
+    expect(result.scanTargetHeight).toBe(0);
+  });
+
   it('defaults syncStatus to never_run when the backend omits last_outcome (older API version)', async () => {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({
       success: true,
@@ -131,6 +165,24 @@ describe('relativeTimeAgo', () => {
 
   it('formats days', () => {
     expect(relativeTimeAgo(NOW - 2 * 86400)).toBe('2d ago');
+  });
+});
+
+describe('scanProgressPct', () => {
+  it('computes percent of the current scan\'s own range covered so far', () => {
+    expect(scanProgressPct({ lastScannedHeight: 1200, scanStartHeight: 1000, scanTargetHeight: 2000 })).toBe(20);
+  });
+
+  it('returns 0 when there is no real range yet (target not resolved)', () => {
+    expect(scanProgressPct({ lastScannedHeight: 0, scanStartHeight: 0, scanTargetHeight: 0 })).toBe(0);
+  });
+
+  it('clamps at 100 rather than going over if lastScannedHeight is somehow past the target', () => {
+    expect(scanProgressPct({ lastScannedHeight: 2500, scanStartHeight: 1000, scanTargetHeight: 2000 })).toBe(100);
+  });
+
+  it('clamps at 0 rather than going negative if lastScannedHeight is somehow before the start', () => {
+    expect(scanProgressPct({ lastScannedHeight: 500, scanStartHeight: 1000, scanTargetHeight: 2000 })).toBe(0);
   });
 });
 

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -59,6 +59,22 @@ describe('fetch_chain_activity', () => {
     expect(result.lastSuccessAt).toBe(1788800000); // preserved even though the latest attempt stalled
   });
 
+  it('passes through in_progress, distinguishable from never_run', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      success: true,
+      daily: [],
+      team_txs: [],
+      last_scanned_height: 200,
+      last_attempt_at: 1788900000,
+      last_success_at: 0,
+      last_outcome: 'in_progress',
+    }));
+
+    const result = await fetch_chain_activity();
+    expect(result.syncStatus).toBe('in_progress');
+    expect(result.lastAttemptAt).toBe(1788900000);
+  });
+
   it('defaults syncStatus to never_run when the backend omits last_outcome (older API version)', async () => {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({
       success: true,

--- a/todo.md
+++ b/todo.md
@@ -56,7 +56,7 @@ wallet-unlock UX for donor-gated content, and Chain Activity's sync-status messa
 
 - [x] **Chain Activity sync-status messaging** — split off as its own bounded fix
   (existing flow, no spec needed) since it was small and independently valuable.
-  **PR #192** (2026-09-09, open). The `/api/v1/chain-activity` endpoint used to
+  **PR #192, merged 2026-09-09.** The `/api/v1/chain-activity` endpoint used to
   hardcode `success: true` regardless of what was on disk, so a scanner that had
   never run, stalled (most likely rate-limited by `explorer.runonflux.io`, a
   documented failure mode of that API), or a frontend that couldn't reach the API
@@ -64,12 +64,37 @@ wallet-unlock UX for donor-gated content, and Chain Activity's sync-status messa
   every time. Backend now tracks and exposes real scan health
   (`last_attempt_at`/`last_success_at`/`last_outcome`); frontend shows an accurate
   banner instead, hidden when healthy.
+  - [ ] **Follow-up found post-merge, PR #193 open (`fix/chain-activity-in-progress-status`), awaiting review/merge.**
+    Actually running the production Docker image (not just `yarn start`) surfaced
+    a real second bug: a scan that's been legitimately running/retrying for
+    minutes (a genuine cold-start backfill takes that long even with zero
+    problems) looked identical to "never started" — the same ambiguity #192 was
+    meant to fix, just relocated to a different time window. Fixed: a new
+    `in_progress` status persisted the instant a cycle starts. Also adds real
+    progress visibility (block X of Y, %, console logging) per direct user
+    request.
+  - [ ] **Still unverified: block 2,934,901 / tx `46ebc1517f0a5bc7e781e46e2c380f98fe6ce210b1699ab433e084d6a1ce2b2c`
+    on `/live` and Chain Activity.** Blocked by `explorer.runonflux.io`'s rate
+    limit — confirmed both currently active AND very easy to re-trip (one clean
+    check is not a green light for more). `/live` also has no historical-block
+    lookup at all (live rolling window only), so this needs either a long
+    genuinely-idle wait, the user checking from a different network, or a
+    different verification approach entirely (e.g. a fixture-based test using
+    this block's real API response) — see the memory file's 2026-09-09d session
+    entry for full detail before picking this back up.
 - [ ] **Visual refresh + home→analytics migration + wallet-unlock UX** — the bigger,
-  still-architectural piece. Genuine aesthetic and IA choices here (palette, whether
-  to add a charting library, exactly what moves from `/home` to `/analytics` and
-  where it lands, how the unlock flow should work) need the same confirm-before-plan
-  treatment every other piece of work in this repo gets — run
-  `superpowers:brainstorming` on this before writing an implementation plan. The
+  still-architectural piece. User confirmed wanting to proceed (2026-09-09) and
+  added concrete requirements: bring `/home` features into `/analytics` where it
+  makes sense, and make the donor-wallet-unlock flow itself easy and beautiful
+  ("make sure we make it easy for a user to enter his address... show him the
+  information in a nice and clean UI way but beautifully" — user's own words).
+  Genuine aesthetic and IA choices here (palette, whether to add a charting
+  library, exactly what moves from `/home` to `/analytics` and where it lands,
+  how the unlock flow should work) need the same confirm-before-plan treatment
+  every other piece of work in this repo gets — the brainstorming/clarifying-
+  questions pass was interrupted by the Chain Activity investigation above and
+  has NOT been completed yet; resume `superpowers:brainstorming` (already
+  classified architectural) before writing an implementation plan. The
   2026-09-06 findings below are background/analysis for that pass, not settled
   decisions.
 


### PR DESCRIPTION
## Summary

Follow-up to #192, found by actually rebuilding and running the full production Docker image (matching the deployed Dockerfile exactly) and watching it cold-start against the real `explorer.runonflux.io` API, rather than trusting the unit tests alone.

## What was found

`ScanStatus` (from #192) only persists a result once `run_scan_cycle` reaches one of its terminal exit points (unreachable / already-caught-up / stalled-or-succeeded-after-scanning). A **cold-start backfill can legitimately take several minutes** even with zero rate-limiting — 2+ explorer requests per block, `SCAN_CONCURRENCY=2` by design — and this session's own testing had also genuinely tripped `explorer.runonflux.io`'s real rate limit (confirmed with a direct request from inside the running container returning HTTP 429, `Retry-After: 9`). Either way, the practical effect was the same: a scan that had been running and retrying for minutes looked byte-for-byte identical to one that had **never started** — exactly the ambiguity #192 was supposed to remove, just relocated to a different time window (the first several minutes of any fresh container, instead of forever).

## Fix

`run_scan_cycle` now persists a new `ScanOutcome::InProgress` the instant a cycle starts, before any network work — verified live: `last_outcome` goes from unset to `"in_progress"` with a real timestamp within ~2 seconds of container start. Every exit path further down still overwrites it with the real terminal outcome once the cycle actually finishes. Frontend gets a matching banner ("Sync is running — a first-time backfill can take several minutes") and the existing "still building history" panel message now also covers this state.

## Testing

- Backend: 28 → 29 tests (Docker/`rust:1.67.1`, matching the repo's Dockerfile)
- Frontend: 417 → 418 tests
- Both builds clean
- **Live-verified this specific fix** by building the actual production Docker image and confirming `in_progress` appears within seconds of a cold start

## Note on the console error reported during testing

Separately reported alongside "Chain Activity still broken": `Uncaught TypeError: Cannot read properties of undefined (reading 'startTime') at et.reportAllChanges`. I traced this — `reportWebVitals()` is called with zero arguments in `Application.jsx`, which makes its own body a no-op (the `web-vitals` import never runs), so this doesn't appear to originate from this app's own code. The only console activity in my own testing session was a browser extension's content script (`[Nautilus] ready`) — logged from `chrome-extension://...`, not this app. Not confirmed as extension-caused, but nothing in this codebase touches `PerformanceObserver`/`startTime`, so I did not treat it as connected to this fix. Flagging for visibility rather than closing it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
