### PR TITLE
docs(live): correct extractP2pTransfers comment about confirmation txs

### DIFF
--- a/client/src/live/apidata.js
+++ b/client/src/live/apidata.js
@@ -201,15 +201,21 @@ export function lookupNodeInfo(ip, tier, { nodeGeoMap, nodeData } = {}) {
  * derived count: we already fetch the full transaction list to get the
  * coinbase, so this comes from the same call.
  *
- * In practice this often comes back empty. Node confirmations are NOT the
- * reason — they're a protocol-level special tx stored outside the normal
- * Merkle tree (see fetch_block_confirmations above), so the explorer's own
- * /api/txs/ endpoint this function's input comes from never returns them in
- * the first place; `otherTxs` can't contain confirmation noise to filter out.
- * The real explanation is simpler: genuine transparent wallet-to-wallet sends
- * are just rare relative to block cadence on this chain (most non-coinbase,
- * non-confirmation activity tends to be app-funding rather than a personal
- * send) — an empty section is not a sign this is broken.
+ * In practice this often comes back empty — genuine transparent wallet-to-
+ * wallet sends are just rare relative to block cadence on this chain (most
+ * non-coinbase activity tends to be app-funding rather than a personal send)
+ * — an empty section is not a sign this is broken.
+ *
+ * Node confirmations do NOT pollute this: contrary to an earlier version of
+ * this comment, the explorer's own /api/txs/ endpoint this function's input
+ * comes from DOES include them (live-verified 2026-09-10 against block
+ * 2,934,901 — 8 "Confirming a fluxnode" txs alongside the block's one real
+ * transfer). They're just shaped differently — no vin/vout, only fields like
+ * collateralOutput/ip/benchmarkTier (see fetch_block_confirmations above,
+ * which reads the same information from a separate daemon call). This
+ * function's own optional chaining (`tx?.vin?.[0]?.addr`, `tx?.vout || []`)
+ * already no-ops on that shape, so confirmation entries silently contribute
+ * zero transfers without needing any explicit filtering.
  */
 export function extractP2pTransfers(otherTxs) {
   const transfers = [];


### PR DESCRIPTION
## What

Fixes a factually-wrong code comment in `client/src/live/apidata.js` above `extractP2pTransfers`. Comment-only change, no behavior change.

## Why

While live-verifying that block 2,934,901 / tx `46ebc1517f0a5bc7e781e46e2c380f98fe6ce210b1699ab433e084d6a1ce2b2c` renders correctly on `/live` (a previously-open item from `todo.md`), I traced the real block data against the app's classification logic:

- Coinbase rewards (0.5/1.0/3.5/9.0 FLUX) correctly resolved to DEVFUND/CUMULUS/NIMBUS/STRATUS.
- The block's one real transaction correctly produced exactly 1 P2P transfer event (31.81 FLUX), with the change output and a 0-value OP_RETURN output both correctly excluded.
- The block's 8 "Confirming a fluxnode" special txs correctly produced 8 confirm events with the right tier/ip.

**No bug found in behavior** — but along the way, live data showed the old comment's claim that the explorer's `/api/txs/` endpoint "never returns" confirmation txs is wrong: this exact block's response included all 8 of them. The function still works correctly today only because those entries have no `vin`/`vout` fields, and the existing optional chaining (`tx?.vin?.[0]?.addr`, `tx?.vout || []`) already no-ops on that shape. Left the comment accurate for the next person who touches this function, with the live-verification evidence cited.

## Testing

Comment-only change — no test/build impact expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ducjscAa7rTWjX2Q1zEKt