### PR TITLE
fix(donor): recognize donations to the old donation address too

### DIFF
--- a/client/src/donor/config.js
+++ b/client/src/donor/config.js
@@ -1,5 +1,6 @@
-// Sum of FLUX a wallet must have sent to ADDRESS_FLUX within DONOR_WINDOW_DAYS to
-// qualify as a donor. Tunable — not hardcoded inline anywhere else.
+// Sum of FLUX a wallet must have sent to ADDRESS_FLUX (or OLD_ADDRESS_FLUX,
+// see below) within DONOR_WINDOW_DAYS to qualify as a donor. Tunable — not
+// hardcoded inline anywhere else.
 export const DONOR_THRESHOLD_FLUX = 10;
 export const DONOR_WINDOW_DAYS = 365;
 
@@ -10,6 +11,30 @@ export const DONOR_STATUS_CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6h
 // Safety cap on explorer API pages fetched per check, for wallets whose donation
 // address has an unusually long transaction history.
 export const DONOR_MAX_PAGES_FETCHED = 20;
+
+/*
+ * The project's donation address changed on 2026-09-03 (commit c02f781,
+ * bundled silently into an unrelated "remove Guides page" commit — the old
+ * address was t1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG, current is
+ * content/index.js's ADDRESS_FLUX). Anyone who donated before the switch
+ * would otherwise get zero credit today. fetch_donor_status checks both
+ * addresses and sums matching donations from either — checked indefinitely,
+ * with no cutoff date, since it costs nothing to keep recognizing it and a
+ * date cutoff is one more thing to get wrong for no real benefit (nobody
+ * should be sending here anymore, but if they mistakenly do, there's no
+ * reason to penalize them for it either).
+ *
+ * Checked live 2026-09-10 against explorer.runonflux.io: this address's
+ * ENTIRE transaction history is 18 pages — comfortably under
+ * DONOR_MAX_PAGES_FETCHED (20) — so a scan of it always completes cleanly
+ * (either by reaching the window edge, or by exhausting all 18 real pages)
+ * rather than hitting the page cap and reporting `scanComplete: false` on
+ * every single check. Since this address stopped receiving new donations
+ * on the 2026-09-03 switch, its page count is effectively frozen going
+ * forward — this isn't a risk that grows over time. Re-check this figure
+ * only if `DONOR_MAX_PAGES_FETCHED` itself is ever lowered.
+ */
+export const OLD_ADDRESS_FLUX = 't1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG';
 
 /*
  * The full donor-gate mechanism (wallet -> chain-donation check -> unlock)

--- a/client/src/donor/donorStatus.js
+++ b/client/src/donor/donorStatus.js
@@ -1,5 +1,11 @@
 import { ADDRESS_FLUX } from 'content/index';
-import { DONOR_THRESHOLD_FLUX, DONOR_WINDOW_DAYS, DONOR_MAX_PAGES_FETCHED, DONOR_STATUS_CACHE_TTL_MS } from 'donor/config';
+import {
+  DONOR_THRESHOLD_FLUX,
+  DONOR_WINDOW_DAYS,
+  DONOR_MAX_PAGES_FETCHED,
+  DONOR_STATUS_CACHE_TTL_MS,
+  OLD_ADDRESS_FLUX,
+} from 'donor/config';
 
 const WINDOW_MS = DONOR_WINDOW_DAYS * 24 * 60 * 60 * 1000;
 
@@ -41,7 +47,11 @@ export function computeDonorStatus(records, nowMs = Date.now()) {
 }
 
 const TXS_BY_ADDRESS_ENDPOINT = 'https://explorer.runonflux.io/api/txs';
-const DONOR_STATUS_CACHE_KEY = 'donorStatus_v1';
+// v2: fetch_donor_status now sums donations to BOTH the current and old
+// donation address (see donor/config.js's OLD_ADDRESS_FLUX) — bumped so a
+// wallet's pre-fix single-address cache entry can't silently under-count
+// for up to DONOR_STATUS_CACHE_TTL_MS after this ships.
+const DONOR_STATUS_CACHE_KEY = 'donorStatus_v2';
 
 async function safeFetchJson(url) {
   try {
@@ -86,21 +96,20 @@ function writeDonorStatusCache(address, data) {
 }
 
 /*
- * Pages through the donation address's own transaction history (same
+ * Pages through ONE donation address's own transaction history (same
  * endpoint apidata.js's fetch_total_donations already uses), stopping as
  * soon as a transaction older than the DONOR_WINDOW_DAYS window is reached
  * — confirmed 2026-09-05 that this API returns newest-first, so early-stop
  * is safe. Unlike fetch_total_donations (which only counts matching tx
- * occurrences), this sums the real FLUX amount paid to the donation address
- * by `walletAddress` specifically.
+ * occurrences), this sums the real FLUX amount paid to `donationAddress` by
+ * `walletAddress` specifically.
+ *
+ * Extracted so fetch_donor_status can scan more than one donation address
+ * (see OLD_ADDRESS_FLUX below) with the same logic instead of duplicating
+ * it.
  */
-export async function fetch_donor_status(walletAddress) {
-  const cached = readDonorStatusCache(walletAddress);
-  if (cached) return cached;
-
-  const nowMs = Date.now();
-  const windowStartSec = Math.floor((nowMs - WINDOW_MS) / 1000);
-  const baseUrl = `${TXS_BY_ADDRESS_ENDPOINT}?address=${ADDRESS_FLUX}`;
+async function scanDonationsTo(walletAddress, donationAddress, windowStartSec) {
+  const baseUrl = `${TXS_BY_ADDRESS_ENDPOINT}?address=${donationAddress}`;
 
   const records = [];
   let pageNum = 0;
@@ -122,7 +131,7 @@ export async function fetch_donor_status(walletAddress) {
       }
       const sentByWallet = (tx.vin || []).some((v) => v.addr === walletAddress);
       if (!sentByWallet) continue;
-      const amount = sumVoutToAddress(tx, ADDRESS_FLUX);
+      const amount = sumVoutToAddress(tx, donationAddress);
       if (amount > 0) records.push({ date: tx.time * 1000, amount });
     }
 
@@ -132,11 +141,39 @@ export async function fetch_donor_status(walletAddress) {
   // A scan only counts as a trustworthy answer if it either reached the
   // window boundary (hitWindowEdge) or genuinely exhausted every page the
   // explorer reports (pageNum >= pagesTotal). Anything else — a fetch
-  // failing partway through, or hitting the page cap — is incomplete and
-  // must never be cached or reported as a confident "not a donor". A
-  // positive result is always trustworthy even from a partial scan, since
-  // more data can only raise totalInWindow, never lower it.
+  // failing partway through, or hitting the page cap — is incomplete.
   const scanComplete = hitWindowEdge || pageNum >= pagesTotal;
+  return { records, scanComplete };
+}
+
+/*
+ * Checks every donation address this project has ever used — the current
+ * one (ADDRESS_FLUX) and OLD_ADDRESS_FLUX (see donor/config.js for why) —
+ * and sums matching donations from either toward the same threshold. Scans
+ * run sequentially, not concurrently, matching this function's existing
+ * one-request-at-a-time pattern rather than doubling the burst size against
+ * an explorer API already known to be rate-limit-sensitive.
+ */
+export async function fetch_donor_status(walletAddress) {
+  const cached = readDonorStatusCache(walletAddress);
+  if (cached) return cached;
+
+  const nowMs = Date.now();
+  const windowStartSec = Math.floor((nowMs - WINDOW_MS) / 1000);
+
+  const records = [];
+  let scanComplete = true;
+  for (const donationAddress of [ADDRESS_FLUX, OLD_ADDRESS_FLUX]) {
+    const scan = await scanDonationsTo(walletAddress, donationAddress, windowStartSec);
+    records.push(...scan.records);
+    scanComplete = scanComplete && scan.scanComplete;
+  }
+
+  // A positive result is always trustworthy even from a partial scan, since
+  // more data can only raise totalInWindow, never lower it — so an
+  // unreachable/incomplete scan on either address must never be cached or
+  // reported as a confident "not a donor" unless the OTHER address already
+  // independently qualified the wallet.
   const computed = computeDonorStatus(records, nowMs);
   const result = { ...computed, verified: scanComplete || computed.isDonor };
 

--- a/client/src/donor/donorStatus.test.js
+++ b/client/src/donor/donorStatus.test.js
@@ -1,4 +1,5 @@
 import { computeDonorStatus, fetch_donor_status } from './donorStatus';
+import { OLD_ADDRESS_FLUX } from './config';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = new Date('2026-09-05T00:00:00Z').getTime();
@@ -71,7 +72,9 @@ describe('fetch_donor_status', () => {
   // Full Insight-API tx shape, same convention as live/apidata.test.js's
   // realTransparentTx() — the extra fields (n, scriptSig, confirmations, fees)
   // real /api/txs responses carry, not a hand-trimmed minimal fixture.
-  function realDonationTx({ blockheight, time, amount, fromWallet = WALLET }) {
+  // `toAddress` defaults to the current donation address but can be pointed
+  // at OLD_ADDRESS_FLUX to build a fixture for the old-address scan.
+  function realDonationTx({ blockheight, time, amount, fromWallet = WALLET, toAddress = DONATION_ADDR }) {
     return {
       txid: `tx-${blockheight}`,
       version: 4,
@@ -88,7 +91,7 @@ describe('fetch_donor_status', () => {
       vout: [
         {
           value: amount.toFixed(8), n: 0,
-          scriptPubKey: { hex: '...', asm: '...', addresses: [DONATION_ADDR], type: 'pubkeyhash' },
+          scriptPubKey: { hex: '...', asm: '...', addresses: [toAddress], type: 'pubkeyhash' },
           spentTxId: null,
         },
         {
@@ -118,6 +121,16 @@ describe('fetch_donor_status', () => {
     };
   }
 
+  // Every fetch_donor_status call now scans TWO addresses (current +
+  // OLD_ADDRESS_FLUX — see donor/config.js), current address first. Most
+  // tests below only care about the current-address scan, so this queues
+  // an empty, complete old-address page right after whatever mocks the
+  // test itself set up for the current address — same "no donations
+  // found, scan complete" shape a real empty history would produce.
+  function mockEmptyOldAddressScan() {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({ pagesTotal: 1, txs: [] }));
+  }
+
   it('sums donations from the wallet across a single page', async () => {
     const nowSec = Math.floor(Date.now() / 1000);
     global.fetch.mockResolvedValueOnce(mockJsonResponse({
@@ -127,6 +140,7 @@ describe('fetch_donor_status', () => {
         realDonationTx({ blockheight: 99, time: nowSec - 20 * 86400, amount: 6 }),
       ],
     }));
+    mockEmptyOldAddressScan();
 
     const result = await fetch_donor_status(WALLET);
 
@@ -141,6 +155,7 @@ describe('fetch_donor_status', () => {
       pagesTotal: 1,
       txs: [realDonationTx({ blockheight: 100, time: nowSec - 10 * 86400, amount: 50, fromWallet: 'someone-else' })],
     }));
+    mockEmptyOldAddressScan();
 
     const result = await fetch_donor_status(WALLET);
 
@@ -160,10 +175,11 @@ describe('fetch_donor_status', () => {
         pagesTotal: 2,
         txs: [realDonationTx({ blockheight: 199, time: nowSec - 6 * 86400, amount: 6 })],
       }));
+    mockEmptyOldAddressScan();
 
     const result = await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(3); // 2 pages for the current address + 1 for the old address
     expect(global.fetch.mock.calls[1][0]).toContain('&pageNum=1');
     expect(result.totalInWindow).toBeCloseTo(12);
     expect(result.isDonor).toBe(true);
@@ -179,10 +195,11 @@ describe('fetch_donor_status', () => {
         realDonationTx({ blockheight: 50, time: nowSec - 400 * 86400, amount: 999 }), // past the window — stop here
       ],
     }));
+    mockEmptyOldAddressScan();
 
     const result = await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1); // never fetched page 2 or 3
+    expect(global.fetch).toHaveBeenCalledTimes(2); // 1 for the current address (never fetched page 2/3) + 1 for the old address
     expect(result.totalInWindow).toBeCloseTo(20); // the 999 past the window never counted
     expect(result.verified).toBe(true); // hit the window edge — a complete, trustworthy scan
   });
@@ -193,17 +210,20 @@ describe('fetch_donor_status', () => {
       pagesTotal: 1,
       txs: [realDonationTx({ blockheight: 100, time: nowSec - 10 * 86400, amount: 15 })],
     }));
+    mockEmptyOldAddressScan();
 
     const first = await fetch_donor_status(WALLET);
     const second = await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // both scans, once — the second fetch_donor_status call hit the cache
     expect(second).toEqual(first);
     expect(first.verified).toBe(true);
   });
 
   it('fails soft — not a donor, not a throw — when the explorer is unreachable', async () => {
-    global.fetch.mockRejectedValueOnce(new Error('network down'));
+    global.fetch
+      .mockRejectedValueOnce(new Error('network down')) // current address
+      .mockRejectedValueOnce(new Error('network down')); // old address
 
     await expect(fetch_donor_status(WALLET)).resolves.toEqual(
       expect.objectContaining({ isDonor: false })
@@ -211,29 +231,36 @@ describe('fetch_donor_status', () => {
   });
 
   it('does not cache a result from a failed fetch — retry will re-attempt the network call', async () => {
-    global.fetch.mockRejectedValueOnce(new Error('network down'));
-    global.fetch.mockRejectedValueOnce(new Error('network down'));
+    global.fetch
+      .mockRejectedValueOnce(new Error('network down')) // 1st call, current address
+      .mockRejectedValueOnce(new Error('network down')) // 1st call, old address
+      .mockRejectedValueOnce(new Error('network down')) // 2nd call, current address
+      .mockRejectedValueOnce(new Error('network down')); // 2nd call, old address
 
     const first = await fetch_donor_status(WALLET);
     const second = await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(2); // both calls fetch, no cache from failure
+    expect(global.fetch).toHaveBeenCalledTimes(4); // both scans, both calls — no cache from failure
     expect(first).toEqual(expect.objectContaining({ isDonor: false }));
     expect(second).toEqual(expect.objectContaining({ isDonor: false }));
   });
 
   it('a scan that fails partway through a multi-page fetch is not verified and not cached', async () => {
     const nowSec = Math.floor(Date.now() / 1000);
-    // Page 1 succeeds but the donation total stays below threshold, so
-    // computeDonorStatus alone would say isDonor: false — the only thing
-    // that should keep this from being reported/cached as a confident
-    // "not a donor" is the page-2 failure below.
+    // Page 1 (current address) succeeds but the donation total stays below
+    // threshold, so computeDonorStatus alone would say isDonor: false — the
+    // only thing that should keep this from being reported/cached as a
+    // confident "not a donor" is the page-2 failure below. The old-address
+    // scan succeeds cleanly (empty) each attempt, so it's the current-
+    // address failure alone driving the unverified result, matching this
+    // test's original intent.
     global.fetch
       .mockResolvedValueOnce(mockJsonResponse({
         pagesTotal: 3,
         txs: [realDonationTx({ blockheight: 200, time: nowSec - 5 * 86400, amount: 2 })],
       }))
       .mockRejectedValueOnce(new Error('network down'));
+    mockEmptyOldAddressScan();
 
     const first = await fetch_donor_status(WALLET);
 
@@ -248,10 +275,86 @@ describe('fetch_donor_status', () => {
         txs: [realDonationTx({ blockheight: 200, time: nowSec - 5 * 86400, amount: 2 })],
       }))
       .mockRejectedValueOnce(new Error('network down'));
+    mockEmptyOldAddressScan();
 
     await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(4); // 2 calls per attempt, both attempts hit the network
+    expect(global.fetch).toHaveBeenCalledTimes(6); // 3 calls per attempt (2 current-address pages + 1 old-address) x 2 attempts
+  });
+
+  it('counts a donation sent to the OLD donation address toward the threshold', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({ pagesTotal: 1, txs: [] })); // current address: nothing
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      pagesTotal: 1,
+      txs: [realDonationTx({ blockheight: 300, time: nowSec - 30 * 86400, amount: 15, toAddress: OLD_ADDRESS_FLUX })],
+    }));
+
+    const result = await fetch_donor_status(WALLET);
+
+    // Not just "some second fetch happened to return this fixture" — the
+    // second scan must have actually requested the old address specifically.
+    // Without this, a bug that built the URL from ADDRESS_FLUX while summing
+    // against `donationAddress` would still pass every other assertion here.
+    expect(global.fetch.mock.calls[1][0]).toContain(OLD_ADDRESS_FLUX);
+    expect(result.isDonor).toBe(true);
+    expect(result.totalInWindow).toBeCloseTo(15);
+    expect(result.verified).toBe(true);
+  });
+
+  it('a legitimate current-address donor still qualifies and gets cached even if the old address is unreachable', async () => {
+    // The records are a union but completeness is an AND — the only thing
+    // keeping an unreachable old-address scan from wiping out a real,
+    // already-qualifying donor is the `|| computed.isDonor` short-circuit.
+    // This pins that specific direction of the asymmetry.
+    const nowSec = Math.floor(Date.now() / 1000);
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      pagesTotal: 1,
+      txs: [realDonationTx({ blockheight: 500, time: nowSec - 10 * 86400, amount: 15 })],
+    }));
+    global.fetch.mockRejectedValueOnce(new Error('network down')); // old address unreachable
+
+    const result = await fetch_donor_status(WALLET);
+
+    expect(result.isDonor).toBe(true);
+    expect(result.verified).toBe(true);
+
+    // And it's cached — a legitimate donor isn't forced to re-scan (and
+    // re-hit the unreachable old address) on every subsequent check.
+    const second = await fetch_donor_status(WALLET);
+    expect(second).toEqual(result);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // only from the first call
+  });
+
+  it('sums donations split across both the old and new donation address', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      pagesTotal: 1,
+      txs: [realDonationTx({ blockheight: 400, time: nowSec - 15 * 86400, amount: 6 })], // current address
+    }));
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      pagesTotal: 1,
+      txs: [realDonationTx({ blockheight: 300, time: nowSec - 30 * 86400, amount: 6, toAddress: OLD_ADDRESS_FLUX })],
+    }));
+
+    const result = await fetch_donor_status(WALLET);
+
+    // Neither address alone reaches the 10 FLUX threshold, but summed
+    // together (6 + 6 = 12) the wallet qualifies — this is the whole point
+    // of checking both addresses instead of just the current one.
+    expect(result.isDonor).toBe(true);
+    expect(result.totalInWindow).toBeCloseTo(12);
+    expect(result.verified).toBe(true);
+  });
+
+  it('an unreachable old address alone is enough to make an otherwise-empty result unverified', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({ pagesTotal: 1, txs: [] })); // current address: clean, empty scan
+    global.fetch.mockRejectedValueOnce(new Error('network down')); // old address: unreachable
+
+    const result = await fetch_donor_status(WALLET);
+
+    expect(result.isDonor).toBe(false);
+    expect(result.verified).toBe(false); // can't confidently say "not a donor" — the old address was never actually checked
   });
 
   // Page-cap truncation (pageNum reaches DONOR_MAX_PAGES_FETCHED without
@@ -259,9 +362,10 @@ describe('fetch_donor_status', () => {
   // a dedicated test here — mocking DONOR_MAX_PAGES_FETCHED (20) sequential
   // page responses to exercise it end-to-end would be a large, low-signal
   // fixture. The same `scanComplete = hitWindowEdge || pageNum >= pagesTotal`
-  // boundary is already exercised from both sides by the tests above (hit via
-  // hitWindowEdge in "stops paginating...", hit via pageNum >= pagesTotal in
-  // "sums donations...single page" and "ignores a transaction..."), and the
-  // cap only changes which of those two conditions is reached, not the logic
+  // boundary (now evaluated once per address, independently) is already
+  // exercised from both sides by the tests above (hit via hitWindowEdge in
+  // "stops paginating...", hit via pageNum >= pagesTotal in "sums
+  // donations...single page" and "ignores a transaction..."), and the cap
+  // only changes which of those two conditions is reached, not the logic
   // that decides verified from them.
 });


### PR DESCRIPTION
## What

`fetch_donor_status` (`client/src/donor/donorStatus.js`) now scans and sums donations to **both** the current donation address and the old one, instead of only the current one.

## Why

The donation address changed on 2026-09-03 (commit `c02f781`) from `t1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG` to the current `ADDRESS_FLUX` — silently, bundled into an unrelated "remove Guides page" commit with no mention of the address change. Anyone who donated before the switch has been getting zero donor credit ever since, with no way to know why.

## Design (confirmed with the user before implementing)

- Donations to both addresses are **summed** toward the same `DONOR_THRESHOLD_FLUX` — a wallet split 6+6 across both addresses now correctly qualifies at 12.
- The old address is checked **indefinitely**, no date cutoff — simplest option, and costs nothing since nobody should be sending there anymore anyway.
- Scans run **sequentially**, not concurrently — avoids doubling the request burst against `explorer.runonflux.io`, an API already documented elsewhere in this repo as rate-limit-sensitive.

## Verification

- Full suite: 428/428 passing.
- Live-verified the old address still resolves real transaction history (18 pages total) via the explorer API before relying on it in tests — also confirms the page-cap safety margin documented in `config.js` (18 pages, comfortably under the 20-page scan cap, so a scan of it always completes cleanly).
- Independently reviewed (opus-level): approved, with 3 Important findings addressed before this PR — a test for the asymmetry where a legitimate current-address donor must still qualify/cache even if the old address is unreachable, a test asserting the second scan actually requests the old address's URL, and the page-cap risk above.
- Cache key bumped `donorStatus_v1` → `donorStatus_v2` so a wallet's already-cached single-address result can't silently under-count for up to 6h after this ships.

## Known, out of scope for this PR

- `apidata.js`'s `fetch_total_donations` (the "total donations" figure shown on Home/MainApp) still only counts the current address — same underlying bug, second place. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ducjscAa7rTWjX2Q1zEKt