### PR TITLE
fix(chain-activity): show blocks-remaining instead of two absolute heights

### DIFF
--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -40,8 +40,13 @@ function SyncStatusBanner({ syncStatus, lastSuccessAt, lastScannedHeight, scanSt
 
   const agoText = relativeTimeAgo(lastSuccessAt);
   const hasRange = syncStatus === 'in_progress' && scanTargetHeight > scanStartHeight;
+  // Two absolute chain heights this close together (e.g. "2,914,359 of
+  // 2,937,099") read as "syncing millions of blocks" at a glance, even
+  // though the actual gap being scanned is small (bounded by
+  // RETENTION_BLOCKS) — show the real remaining count instead.
+  const blocksRemaining = hasRange ? Math.max(0, scanTargetHeight - lastScannedHeight) : 0;
   const progressText = hasRange
-    ? ` Block ${fmtNum(lastScannedHeight)} of ${fmtNum(scanTargetHeight)} (${scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight })}%).`
+    ? ` ${fmtNum(blocksRemaining)} blocks remaining in this scan (${scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight })}%).`
     : '';
 
   return (


### PR DESCRIPTION
## What

The Chain Activity sync banner now shows "N blocks remaining in this scan" instead of "Block X of Y" with two large absolute chain heights.

## Why

Live-tested in Docker and initially looked alarming — the banner showed two nearly-identical ~2.9 million numbers, reading as "trying to sync the whole chain." Verified via the container's own logs this is **not a functional bug**:

```
[chain_activity] scan starting: 23040 blocks to cover (2914059 -> 2937099)
[chain_activity] batch done: checkpoint 2914359 / tip 2937099 (1% of this cycle's range)
```

The backfill correctly scans only the last `RETENTION_BLOCKS` (~23,040 blocks / 8 days) — the display just didn't communicate that, since two large absolute numbers close together look the same as "syncing everything" at a glance.

## Verification

Full suite: 438/438 passing. `scanProgressPct`'s own logic and tests are untouched — this only changes the JSX text rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ducjscAa7rTWjX2Q1zEKt