### PR TITLE
Fix the Analytics dark-mode background bug (todo.md item 8) at its root

### DIFF
--- a/client/src/home/Home.scss
+++ b/client/src/home/Home.scss
@@ -11,8 +11,11 @@
     color: var(--text-secondary);
 }
 
+// Home layers its dot pattern over the global .App background (styles/_global.scss).
+// The background-COLOUR that used to live here moved there: a page stylesheet
+// painting a shared global ancestor is what made /analytics theme-dependent on
+// navigation history.
 .App {
-    background-color: var(--surface-secondary);
     background-image: radial-gradient(var(--border-secondary) 1px, transparent 1px);
     background-size: 24px 24px;
 }

--- a/client/src/main/MainApp.scss
+++ b/client/src/main/MainApp.scss
@@ -14,12 +14,10 @@
     }
 }
 
-.App {
-    background-color: #f8f9fa;
-    @include qualify('.app-mode-dark') {
-        background-color: #1b1e1f;
-    }
-}
+// The .App background that used to live here moved to styles/_global.scss so
+// every route is painted, not just this one. Its hardcoded #f8f9fa/#1b1e1f are
+// now --surface-secondary (#f5f6f8/#111113) -- a deliberate, slight shift onto
+// the design tokens rather than two more literals.
 
 .pa-heading {
     @include rule-mode-dark() {

--- a/client/src/styles/_global.scss
+++ b/client/src/styles/_global.scss
@@ -59,7 +59,11 @@ body {
     font-weight: 400;
     line-height: 1.5;
     letter-spacing: -0.01em;
-    background-color: #ffffff;
+    // Token-driven, not a literal: this was hardcoded #ffffff with no
+    // dark-mode override, so a dark-mode page whose .App did not paint its
+    // own background showed near-white --text-primary over white. See the
+    // .App rule below and styles/globalBackground.test.js.
+    background-color: var(--surface-secondary);
     padding: 0;
     margin: 0;
 
@@ -88,6 +92,14 @@ code {
     width: 100%;
     height: 100%;
     overflow: auto;
+    // Every route gets a themed page background from here. This used to be
+    // set ONLY by home/Home.scss and main/MainApp.scss -- two PAGE
+    // stylesheets painting a shared global ancestor. Those ship in per-route
+    // lazy chunks, so /analytics and /live had a correct dark background only
+    // if the user happened to have visited /home or /nodes first in the same
+    // session. That navigation-dependence is why the resulting bug looked
+    // like an intermittent theme-toggle timing artifact for so long.
+    background-color: var(--surface-secondary);
     // A page shorter than the viewport (e.g. /live) used to leave the footer
     // stranded wherever the content ended, with dead space below it — there
     // was nothing pinning it to the bottom. This is the standard sticky-footer

--- a/client/src/styles/globalBackground.test.js
+++ b/client/src/styles/globalBackground.test.js
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * Guards the fix for the Analytics dark-mode bug (todo.md item 8).
+ *
+ * Root cause, established 2026-09-11: `body` hardcoded `background-color:
+ * #ffffff` with no dark-mode override, and the global `.App` rule set layout
+ * only -- no background at all. The ONLY rules painting `.App` lived in two
+ * PAGE stylesheets, `home/Home.scss` and `main/MainApp.scss`. Those ship in
+ * per-route lazy chunks, so whether `/analytics` had a dark background
+ * depended on whether the user had previously visited `/home` or `/nodes` in
+ * the same session -- lazy CSS chunks persist once loaded. Landing on
+ * `/analytics` directly in dark mode left `--text-primary: #ededef`
+ * (near-white) painted over `body`'s `#ffffff`.
+ *
+ * That navigation-dependence is why the bug read as an intermittent
+ * "transition-timing artifact" for so long and was never root-caused.
+ *
+ * These are source-level assertions rather than rendered-DOM ones on purpose:
+ * jsdom does not resolve CSS custom properties across a cascade, and the real
+ * failure was a MISSING rule, which no amount of rendering can surface. The
+ * complementary check is a grep of the BUILT css chunk -- see the fix's
+ * commit message.
+ */
+
+const GLOBAL_SCSS = fs.readFileSync(path.join(__dirname, '_global.scss'), 'utf8');
+
+// Grabs a top-level rule's body by selector, e.g. "body" or ".App".
+function ruleBody(scss, selector) {
+  // Anchored at line start so `.App` does not also match `.App-header` etc.
+  const re = new RegExp(`^${selector.replace('.', '\\.')}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm');
+  const match = scss.match(re);
+  return match ? match[1] : null;
+}
+
+describe('global background tokens (Analytics dark-mode regression guard)', () => {
+  it('body sets a background-color', () => {
+    const body = ruleBody(GLOBAL_SCSS, 'body');
+    expect(body).not.toBeNull();
+    expect(body).toMatch(/background-color\s*:/);
+  });
+
+  it('body background-color is token-driven, not a hardcoded hex', () => {
+    // A literal hex here cannot follow the theme -- that was the bug.
+    const body = ruleBody(GLOBAL_SCSS, 'body');
+    const decl = body.match(/background-color\s*:\s*([^;]+);/);
+    expect(decl).not.toBeNull();
+    expect(decl[1].trim()).toMatch(/^var\(--/);
+  });
+
+  it('.App sets a background-color globally, so every route is painted', () => {
+    // The bug: this rule existed but set layout only, leaving /analytics and
+    // /live dependent on another route's lazy chunk having been loaded.
+    const app = ruleBody(GLOBAL_SCSS, '.App');
+    expect(app).not.toBeNull();
+    expect(app).toMatch(/background-color\s*:/);
+  });
+
+  it('.App background-color is token-driven, not a hardcoded hex', () => {
+    const app = ruleBody(GLOBAL_SCSS, '.App');
+    const decl = app.match(/background-color\s*:\s*([^;]+);/);
+    expect(decl).not.toBeNull();
+    expect(decl[1].trim()).toMatch(/^var\(--/);
+  });
+
+  it('the token .App uses is genuinely redefined under .app-mode-dark', () => {
+    // A token-driven background is only a fix if that token actually has a
+    // dark value. --surface-secondary must appear in BOTH :root and the
+    // .app-mode-dark block, or the page stays light in dark mode.
+    const app = ruleBody(GLOBAL_SCSS, '.App');
+    const token = app.match(/background-color\s*:\s*var\((--[a-z-]+)\)/)[1];
+
+    const darkBlock = GLOBAL_SCSS.match(/\.app-mode-dark\s*\{([\s\S]*?)\n\}/);
+    expect(darkBlock).not.toBeNull();
+    expect(darkBlock[1]).toContain(`${token}:`);
+  });
+
+  it('no page stylesheet paints a bare .App background any more', () => {
+    // Home.scss and MainApp.scss each used to define a top-level `.App`
+    // background. Page-scoped stylesheets reaching up to paint a shared
+    // global ancestor, in separately-loaded chunks, IS the bug class -- the
+    // same one as the duplicated unscoped `hov-*` selectors.
+    // Home may still layer a background-IMAGE (its dot pattern); only a
+    // background-COLOR on a bare `.App` is forbidden.
+    const pageStylesheets = [
+      path.join(__dirname, '..', 'home', 'Home.scss'),
+      path.join(__dirname, '..', 'main', 'MainApp.scss'),
+    ];
+
+    for (const file of pageStylesheets) {
+      const body = ruleBody(fs.readFileSync(file, 'utf8'), '.App');
+      if (body === null) continue; // rule removed entirely -- ideal
+      expect(body).not.toMatch(/background-color\s*:/);
+    }
+  });
+});


### PR DESCRIPTION
Root-causes and fixes the long-standing "Analytics header/tab labels look washed-out after toggling dark mode" issue (`todo.md` item 8). **It was never a transition-timing artifact.**

Closes the item that the Analytics Rework spec assigned to Session 5.

## Root cause

Three facts combine:

1. `styles/_global.scss` — `body { background-color: #ffffff; }`, hardcoded, **no dark-mode override anywhere**.
2. The global `.App` rule set layout only — **no background at all**.
3. The only rules painting `.App` lived in two **page** stylesheets: `home/Home.scss` and `main/MainApp.scss`.

Those page stylesheets ship in per-route lazy chunks, and lazy CSS persists once loaded. So `/analytics` had a correct dark background **only if the user happened to have visited `/home` or `/nodes` earlier in the same session**. Landing on `/analytics` directly — or reloading there — in dark mode left `--text-primary` (`#ededef`, near-white) painted over body's `#ffffff`.

## Why it went un-root-caused for so long

That navigation-dependence made it look random. It reproduces on a direct load or a reload, and hides after any visit to Home or Nodes — which is exactly the shape of "I caught it mid-frame once and couldn't reproduce it."

It also explains the two details in the original report that made it confusing:

| Observation | Explanation |
|---|---|
| Nav and footer had already switched | Both paint their own backgrounds |
| `ChainActivityTab`'s panels rendered dark correctly in the same pass | `.hov-panel` uses `--surface-primary`, so it paints its own dark surface |

**This is the same bug class as the duplicated unscoped `hov-*` selectors** fixed in Sessions 3 and 4: page-scoped stylesheets reaching up to style a shared global ancestor, across separately-loaded chunks.

## The fix

Moves the background into `styles/_global.scss` so every route is painted, present and future:

- `body` and `.App` both take `var(--surface-secondary)` — genuinely redefined under `.app-mode-dark` (`#f5f6f8` light / `#111113` dark).
- `home/Home.scss` keeps its radial-gradient dot pattern and layers it over the global colour.
- `main/MainApp.scss`'s rule is removed entirely.

**One deliberate visual change:** MainApp's hardcoded `#f8f9fa`/`#1b1e1f` become the tokens `#f5f6f8`/`#111113`. Both shifts are small and land on the design system rather than on two more literals — but the Nodes page background does change slightly, so it is worth a look.

A side effect worth noting: `#root` is `100vw/100vh` and `.App` is `100%/100%`, so an opaque `.App` now also covers the inline `background-color` that `public/index.html`'s anti-FOUC script writes onto `body` and `componentDidMount` never clears. That leak was a latent light-mode bug (a dark-booted session keeps a hardcoded dark body forever, and inline styles beat every stylesheet rule); it is now harmless rather than latent.

## Verification

- **`src/styles/globalBackground.test.js`** guards the source-level shape, including that the token `.App` uses is genuinely redefined under `.app-mode-dark` — a token-driven background is only a fix if the token has a dark value. **5 of its 6 assertions failed before this change.**
- **Verified against the BUILT css, not just source** — the check that actually proves a cascade fix:
  - `.App` carries `background-color:var(--surface-secondary)` in `main.css` (not a lazy chunk).
  - `--surface-secondary` is emitted for both themes.
  - No lazy chunk paints `.App`'s `background-color` any more.
  - Home's chunk now carries only the dot pattern.
- Suite: **444 tests / 28 suites, exit 0** (438 on `main`, plus the 6 new guards). Build exit 0.

## Not verified — needs a human at a browser

- [ ] `/analytics` in dark mode on a **direct load / hard reload** (the actual repro — do not navigate via Home first, that masks it)
- [ ] `/home` still shows its dot pattern over the new global colour, both themes
- [ ] `/nodes` background after the token shift, both themes
- [ ] `/live` in dark mode — it had the same latent exposure and should now be fixed too

Disjoint from #209 (Session 4) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)