### PR TITLE
Lazy-load Recharts: 97.72 kB -> 15.5 kB for every /analytics visitor

### DIFF
--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,8 +1,29 @@
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
 import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks } from 'analytics/chainActivity';
-import { UtilityTrendChart } from './UtilityTrendChart';
 import './index.scss';
+
+/*
+ * Recharts is ~82 kB gzipped -- by far the largest thing this tab pulls in --
+ * and it was a static import, so it landed in the shared /analytics chunk and
+ * downloaded for EVERY analytics visitor. Locked visitors can never see the
+ * chart at all: Analytics.jsx wraps this tab in <PanelGate panelKey=
+ * "chainActivity">, which defaults to preview='plain' and does not render its
+ * children when locked. They were paying 82 kB for a component that never
+ * mounts.
+ *
+ * Splitting here rather than at the tab boundary keeps the sync banner, hero
+ * stat and team-transaction list rendering immediately -- they are cheap, and
+ * deferring them behind the same fetch would trade real perceived speed for a
+ * tidier split.
+ *
+ * The .then() unwrap is because React.lazy requires a default export and this
+ * file uses named exports throughout, as does the rest of the repo. Adding a
+ * default export purely to satisfy lazy() would be the tail wagging the dog.
+ */
+const UtilityTrendChart = lazy(() =>
+  import('./UtilityTrendChart').then((m) => ({ default: m.UtilityTrendChart }))
+);
 
 /*
  * The one thing this whole tab used to be silent about: whether "no data"
@@ -95,7 +116,9 @@ function UtilitySummary({ daily, syncStatus, theme }) {
         </div>
       ) : (
         <>
-          <UtilityTrendChart daily={daily} theme={theme} />
+          <Suspense fallback={<div className="ca-trend-chart-loading" aria-label="Loading chart" />}>
+            <UtilityTrendChart daily={daily} theme={theme} />
+          </Suspense>
           <div className="ca-utility-stats">
             <span className="ca-utility-stat ca-utility-stat--utility">
               {fmtNum(utilityBlocks)} utility ({pct(utilityBlocks, total)}%)

--- a/client/src/analytics/ChainActivityTab/index.scss
+++ b/client/src/analytics/ChainActivityTab/index.scss
@@ -178,6 +178,27 @@
   }
 }
 
+// Suspense fallback for the lazily-loaded chart. Height matches
+// UtilityTrendChart's ResponsiveContainer exactly (200px) so swapping the real
+// chart in causes no layout shift, and it reuses the ca-shimmer keyframes
+// already defined above rather than introducing a second loading idiom.
+.ca-trend-chart-loading {
+  height: 200px;
+  margin-bottom: 10px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--surface-inset) 40%,
+    var(--surface-secondary) 50%,
+    var(--surface-inset) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: ca-shimmer 1.8s ease-in-out infinite;
+  opacity: 0.6;
+}
+
 .ca-trend-chart {
   margin-bottom: 10px;
 


### PR DESCRIPTION
Closes the performance item parked during Session 4's final review.

## The problem

Recharts is ~82 kB gzipped — by far the largest thing `/analytics` pulls in — and it was a **static** import in `ChainActivityTab/index.jsx`. So webpack bundled it into the shared analytics chunk, and it downloaded for **every** visitor to the page.

Locked visitors can never see the chart at all. `Analytics.jsx` wraps the tab in `<PanelGate panelKey="chainActivity">`, which defaults to `preview='plain'` and does not render its children when locked. They were paying 82 kB for a component that never mounts.

## Measured, not assumed

| | Before | After |
|---|---|---|
| Analytics chunk — **every** visitor | **97.72 kB** | **15.50 kB** |
| Recharts — own chunk, fetched on demand | — | 97.66 kB |

**Verified by grepping the built chunks, not by reading the size table.** Chunk IDs change between builds, so the table alone is genuinely misleading here — the post-split output still shows a ~97 kB chunk, and it looks at a glance like nothing happened. It's a different chunk:

- `535` (15.5 kB) — contains all four tabs: Apps, Network, Donor, Chain Activity. Confirmed by grepping for each tab's own strings.
- `215` (97.66 kB) — recharts alone, referenced by `535` only **dynamically**.

## Why the split is at the chart, not the tab

Splitting at the `ChainActivityTab` boundary would have been conceptually tidier, but it would defer the sync-status banner, the hero stat and the team-transaction list behind the same fetch. Those are cheap and currently instant. That trades real perceived speed for a neater diagram.

## Implementation notes

- `React.lazy` requires a default export; this file and the rest of the repo use named exports. The `.then((m) => ({ default: m.UtilityTrendChart }))` unwrap keeps the existing convention rather than adding a default export purely to satisfy `lazy()`.
- The Suspense fallback is **height-matched** to the chart's `ResponsiveContainer` (200px), so swapping the real chart in causes no layout shift. It reuses the `ca-shimmer` keyframes already defined in that stylesheet rather than introducing a second loading idiom.

## Verification

- **451 tests / 29 suites, exit 0** — unchanged from `main`'s current baseline (Session 4's 445 plus the dark-mode fix's 6 guards). No tests added: the behaviour here is a build-output property, and the build measurement above is the evidence.
- Production build exit 0.

## Not verified — needs a human at a browser

- [ ] The shimmer fallback appears briefly and the chart swaps in without a visible jump
- [ ] The chart still renders correctly in both themes after the async load
- [ ] A locked visitor on `/analytics` sees no network request for the recharts chunk (visible in devtools — this is the whole point of the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)