### PR TITLE
Count donations to the old address — early supporters were losing achievements they'd earned

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -6,6 +6,7 @@ import { categorizeAppSpec } from 'main/Gamification/appCategories';
 import { fetch_fluxinfo_aggregate } from 'fluxinfo';
 import { specResources, buildSpecIndex } from 'appSpecs';
 import { categorizeRunningApps } from 'runningAppsCategorized';
+import { OLD_ADDRESS_FLUX } from 'donor/config';
 import {
   fetch_node_benchmarks,
   fetch_node_resources,
@@ -192,10 +193,30 @@ export function fill_rewards(gstore) {
   */
 }
 
+/*
+ * Counts how many donation TRANSACTIONS a wallet has sent -- not a FLUX sum.
+ * main/Gamification/achievements.js gates `donor` (>= 1), `super_donor` (>= 5)
+ * and `sugar_daddy` (>= 50) on this count, and its labels read "N / 5
+ * donations", so the unit is transactions.
+ *
+ * Scans BOTH donation addresses. The project's address changed 2026-09-03, and
+ * this function used to scan only the current one -- so every donation made
+ * before that date was invisible, costing early supporters achievements they
+ * had already earned. donor/donorStatus.js:166 was fixed for the same reason in
+ * PR #196; this was the second, unfixed copy of that bug. The asymmetry made it
+ * easy to miss: donorStatus.js still granted those wallets premium access, so
+ * only the achievements silently disappeared.
+ *
+ * Each address is scanned independently and a failure of one does not erase the
+ * other: an unreachable explorer for one address must not zero out donations
+ * already proven against the other. Only when BOTH scans fail outright does
+ * this resolve 0.
+ *
+ * Results are de-duplicated by txid, because a single transaction paying both
+ * addresses would otherwise be counted twice.
+ */
 export function fetch_total_donations(walletAddress) {
   return new Promise((resolve) => {
-    const baseUrl = 'https://explorer.runonflux.io/api/txs?address=' + window.gContent.ADDRESS_FLUX;
-
     const safeFetchJson = async (url) => {
       try {
         const res = await fetch(url);
@@ -208,12 +229,13 @@ export function fetch_total_donations(walletAddress) {
       }
     };
 
-    (async () => {
+    // Every page for one address. Returns null (not []) when the address could
+    // not be read at all, so "explorer unreachable" stays distinguishable from
+    // "this address has no donations".
+    const scanAddress = async (address) => {
+      const baseUrl = 'https://explorer.runonflux.io/api/txs?address=' + address;
       const firstPage = await safeFetchJson(baseUrl);
-      if (!firstPage) {
-        resolve(0); // explorer unavailable - fail gracefully instead of crashing
-        return;
-      }
+      if (!firstPage) return null;
 
       const { pagesTotal } = firstPage;
       const pageNums = pagesTotal <= 1 ? [] : new Array(pagesTotal - 1).fill(0).map((_v, i) => i + 1);
@@ -225,8 +247,30 @@ export function fetch_total_donations(walletAddress) {
         if (json) pages.push(json);
       }
 
-      const txs = pages.reduce((prev, current) => prev.concat(current.txs || []), []);
-      resolve(txs.filter((tx) => tx.vin.some((v) => v.addr === walletAddress)).length);
+      return pages.reduce((prev, current) => prev.concat(current.txs || []), []);
+    };
+
+    (async () => {
+      const scans = [];
+      for (const address of [window.gContent.ADDRESS_FLUX, OLD_ADDRESS_FLUX]) {
+        scans.push(await scanAddress(address));
+      }
+
+      if (scans.every((txs) => txs === null)) {
+        resolve(0); // explorer unavailable - fail gracefully instead of crashing
+        return;
+      }
+
+      const countedTxids = new Set();
+      for (const txs of scans) {
+        if (!txs) continue;
+        for (const tx of txs) {
+          if (!tx.vin?.some((v) => v.addr === walletAddress)) continue;
+          countedTxids.add(tx.txid);
+        }
+      }
+
+      resolve(countedTxids.size);
     })();
   });
 }

--- a/client/src/totalDonations.test.js
+++ b/client/src/totalDonations.test.js
@@ -1,0 +1,113 @@
+import { fetch_total_donations } from './apidata';
+import { OLD_ADDRESS_FLUX } from 'donor/config';
+
+/*
+ * Track 3 (calculation-correctness audit), domain D3.
+ *
+ * fetch_total_donations had ZERO test coverage, which is exactly why this bug
+ * survived a green suite for over a week. It scanned only
+ * window.gContent.ADDRESS_FLUX, while donor/donorStatus.js:166 -- fixed in
+ * PR #196 -- correctly iterates [ADDRESS_FLUX, OLD_ADDRESS_FLUX].
+ *
+ * The donation address changed 2026-09-03, so every donation made before that
+ * date was invisible here. That is not only a wrong "total donations" figure on
+ * Home/MainApp: the value feeds main/Gamification/achievements.js, where
+ * `donor` (>= 1), `super_donor` (>= 5) and `sugar_daddy` (>= 50) are gated on
+ * it. Early supporters were being silently denied achievements they had
+ * already earned, while donorStatus.js still granted them premium access --
+ * an asymmetry that made the bug easy to miss.
+ *
+ * The function returns a COUNT of donation transactions, not a FLUX sum. The
+ * achievement labels ("N / 5 donations") agree.
+ */
+
+const CURRENT_ADDRESS = 't1aUmu7HDr7BtwmdR1Y9i2K6KFRZs4Bumbt'; // setupTests.js
+const DONOR_WALLET = 't1DonorWalletAddressForTest';
+
+// One explorer "txs?address=" page. `vin[].addr` is the sender, which is what
+// fetch_total_donations filters on.
+function page(txids, sender = DONOR_WALLET) {
+  return {
+    pagesTotal: 1,
+    txs: txids.map((txid) => ({ txid, vin: [{ addr: sender }] })),
+  };
+}
+
+function mockExplorer(byAddress) {
+  global.fetch = jest.fn((url) => {
+    const address = Object.keys(byAddress).find((a) => url.includes(a));
+    const body = address ? byAddress[address] : { pagesTotal: 1, txs: [] };
+    return Promise.resolve({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve(body),
+    });
+  });
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('fetch_total_donations', () => {
+  it('counts donations made to the CURRENT address', async () => {
+    mockExplorer({ [CURRENT_ADDRESS]: page(['a', 'b']) });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(2);
+  });
+
+  it('counts donations made to the OLD address too', async () => {
+    // The regression: an early supporter whose donations all predate the
+    // 2026-09-03 address change. Before the fix this resolved to 0, costing
+    // them the `donor` achievement outright.
+    mockExplorer({
+      [CURRENT_ADDRESS]: page([]),
+      [OLD_ADDRESS_FLUX]: page(['old1', 'old2', 'old3']),
+    });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(3);
+  });
+
+  it('sums donations across both addresses', async () => {
+    mockExplorer({
+      [CURRENT_ADDRESS]: page(['new1']),
+      [OLD_ADDRESS_FLUX]: page(['old1', 'old2']),
+    });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(3);
+  });
+
+  it('does not double-count a txid that appears under both addresses', async () => {
+    // A single transaction paying both addresses would otherwise be counted
+    // twice once the second scan is added.
+    mockExplorer({
+      [CURRENT_ADDRESS]: page(['shared', 'new1']),
+      [OLD_ADDRESS_FLUX]: page(['shared']),
+    });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(2);
+  });
+
+  it('ignores transactions sent by a different wallet', async () => {
+    mockExplorer({
+      [CURRENT_ADDRESS]: page(['x'], 't1SomeoneElse'),
+      [OLD_ADDRESS_FLUX]: page(['y'], 't1SomeoneElse'),
+    });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(0);
+  });
+
+  it('still counts the reachable address when the other scan fails', async () => {
+    // Fails soft rather than resolving 0 for everyone: one address being
+    // unreachable must not erase donations proven against the other.
+    global.fetch = jest.fn((url) => {
+      if (url.includes(OLD_ADDRESS_FLUX)) return Promise.reject(new Error('explorer down'));
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve(page(['new1', 'new2'])),
+      });
+    });
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(2);
+  });
+
+  it('resolves 0 rather than throwing when the explorer is unavailable', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('explorer down')));
+    await expect(fetch_total_donations(DONOR_WALLET)).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
First finding of the Track 3 calculation-correctness audit (domain D3: donations & donor status).

## The bug

`apidata.js`'s `fetch_total_donations` scanned only `window.gContent.ADDRESS_FLUX`. `donor/donorStatus.js:166` — fixed in PR #196 — correctly iterates `[ADDRESS_FLUX, OLD_ADDRESS_FLUX]`. **This was the second, unfixed copy of that same bug.**

The donation address changed on 2026-09-03, so every donation made before that date was invisible here.

## Why it's worse than a wrong number on Home

`totalDonations` feeds `main/Gamification/achievements.js`:

```js
donor:        (totalDonations || 0) >= 1
super_donor:  (totalDonations || 0) >= 5
sugar_daddy:  (totalDonations || 0) >= 50
```

So **early supporters were being silently denied achievements they had already earned.** The people who backed the project first were the ones losing recognition for it.

**The asymmetry is what hid it.** `donorStatus.js` still granted those same wallets premium *access* — so donors saw their unlocked features working normally and nothing looked broken. Only the achievements quietly vanished, and a missing achievement looks identical to one you never earned.

## Why a green suite never caught it

`fetch_total_donations` had **zero test coverage.** `apidata.test.js` passes without ever exercising it, and `donorStatus.test.js` passes because *that* copy is correct. Two green test files, one live bug sitting between them.

This is exactly the failure mode Track 3 was designed around: adding more tests written from the same understanding as the code would not have found this. It took tracing a displayed value back to its source.

## The fix

Scans both addresses, mirroring `donorStatus.js`.

- **Independent scans.** One address failing does not erase the other — an unreachable explorer for one must not zero out donations already proven against the other. Only when *both* scans fail does it resolve `0`, preserving the previous fail-soft behaviour.
- **De-duplicated by txid**, since a single transaction paying both addresses would otherwise be counted twice.
- Adds a defensive `tx.vin?.some(...)` — the original would throw inside the async IIFE on a malformed transaction.

## Verification

Seven new tests, **two of which fail against the old implementation**:

| Case | Before | After |
|---|---|---|
| Early supporter, all donations pre-2026-09-03 | **0** | 3 |
| Mixed old + new donations | **1** | 3 |

The other five pin behaviour that was already correct (current-address counting, wrong-sender exclusion, txid de-duplication, per-address soft failure, total-failure fallback).

Suite: **458 tests / 30 suites, exit 0** (451 on `main`, plus 7). Build exit 0. No circular import — `donor/config.js` imports nothing.

## Note on cost

This roughly doubles the explorer pages fetched per call, since it now scans two addresses. `donor/config.js` records that the old address's entire history is 18 pages and is frozen (it stopped receiving donations at the switch), so this does not grow over time. Unlike `donorStatus.js`, this function has no result cache — worth considering separately if it shows up as slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)