### PR TITLE
Calculation-correctness audit harness, with D1 (earnings) verified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ CLAUDE.md
 .worktrees/
 worktrees/
 .superpowers/
+
+# Calculation-audit fixtures: evidence for one run, not source.
+tools/audit/fixtures/

--- a/client/src/audit/constantsParity.test.js
+++ b/client/src/audit/constantsParity.test.js
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * The site's economic constants exist in TWO hand-maintained copies:
+ *
+ *   client/public/runtime/app-content.js  -- what production actually serves
+ *   client/src/setupTests.js              -- what every Jest test sees
+ *
+ * Nothing enforced that they agree. That is a live trap, not a hypothetical
+ * one: issue #202 records that the first PoN subsidy reduction lands at block
+ * 3,071,200 (~2026-10-25) and takes CC_BLOCK_REWARD from 14 to 12.6. If only
+ * app-content.js is updated on that date, every test keeps passing against the
+ * stale 14 -- and apidata.test.js derives its expected values FROM these
+ * constants, so it would not merely miss the change, it would actively certify
+ * the wrong arithmetic as correct.
+ *
+ * This test makes that drift impossible to merge quietly. It is also load-
+ * bearing for the audit harness: d1AppSide.test.js runs the app's real
+ * functions under Jest, so it reads setupTests.js's values rather than
+ * production's. Its output is only meaningful while these two agree.
+ *
+ * Deliberately compares only the CC_* economic constants. URLs, e-mail and the
+ * REQUIREMENTS block are presentation, drift harmlessly, and pinning them here
+ * would produce failures nobody should have to care about.
+ */
+
+const CLIENT_SRC = path.join(__dirname, '..');
+const APP_CONTENT = path.join(CLIENT_SRC, '..', 'public', 'runtime', 'app-content.js');
+const SETUP_TESTS = path.join(CLIENT_SRC, 'setupTests.js');
+
+// `window.gContent.CC_NAME = 12.5;`
+function parseAppContent(source) {
+  const found = {};
+  const re = /window\.gContent\.(CC_[A-Z_]+)\s*=\s*([0-9.]+)\s*;/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    found[match[1]] = Number(match[2]);
+  }
+  return found;
+}
+
+// `CC_NAME: 12.5,` inside the setupTests object literal.
+function parseSetupTests(source) {
+  const found = {};
+  const re = /(CC_[A-Z_]+)\s*:\s*([0-9.]+)\s*,/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    found[match[1]] = Number(match[2]);
+  }
+  return found;
+}
+
+const production = parseAppContent(fs.readFileSync(APP_CONTENT, 'utf8'));
+const testDoubles = parseSetupTests(fs.readFileSync(SETUP_TESTS, 'utf8'));
+
+describe('economic constant parity: setupTests.js vs app-content.js', () => {
+  it('finds constants in both files (guards the parser itself)', () => {
+    // If a regex silently matched nothing, every assertion below would pass
+    // vacuously and this test would be theatre.
+    expect(Object.keys(production).length).toBeGreaterThan(5);
+    expect(Object.keys(testDoubles).length).toBeGreaterThan(5);
+  });
+
+  it('every production CC_* constant is mirrored in setupTests.js', () => {
+    const missing = Object.keys(production).filter((name) => !(name in testDoubles));
+    expect(missing).toEqual([]);
+  });
+
+  it('every constant holds the same value in both files', () => {
+    const drifted = Object.keys(production)
+      .filter((name) => name in testDoubles && production[name] !== testDoubles[name])
+      .map((name) => `${name}: production=${production[name]} tests=${testDoubles[name]}`);
+
+    // Listing the drifted names rather than asserting per-constant, so one run
+    // reports everything that moved instead of only the first.
+    expect(drifted).toEqual([]);
+  });
+
+  it('setupTests.js declares no CC_* constant production does not have', () => {
+    // A stale test double for a deleted constant is dead weight that can make
+    // a removed feature look alive in tests.
+    const orphans = Object.keys(testDoubles).filter((name) => !(name in production));
+    expect(orphans).toEqual([]);
+  });
+});

--- a/client/src/audit/d1AppSide.test.js
+++ b/client/src/audit/d1AppSide.test.js
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import path from 'path';
+import { create_global_store, fill_rewards } from 'apidata';
+
+/*
+ * The APP side of the D1 (earnings) audit.
+ *
+ * This runs the app's OWN functions -- that is the point. The independent
+ * reimplementation lives in tools/audit/reference/d1_earnings.py, and the two
+ * are compared by tools/audit/compare.py. Both are fed the same captured
+ * fixture, so nothing here depends on the network or on when it runs.
+ *
+ * It lives as a Jest test rather than a standalone Node script for one
+ * practical reason: Jest already resolves this project's module aliases
+ * (`apidata`, `content/index`, ...) and already provides `window.gContent` via
+ * setupTests.js. Reimplementing that resolution in a bare script would be a
+ * second, subtly-different loader -- exactly the kind of near-duplicate that
+ * causes the bugs this audit hunts.
+ *
+ * It is INERT in a normal test run: with no fixture captured it skips, so
+ * `npm test` neither fails nor writes files. Run `python tools/audit/capture.py`
+ * first to arm it.
+ *
+ * Note the dependency this creates: because it runs under Jest, it reads
+ * setupTests.js's `window.gContent`, NOT production's app-content.js. That is
+ * only sound while those two agree -- which constantsParity.test.js enforces.
+ * If that test fails, this file's output is meaningless and compare.py says so.
+ */
+
+const FIXTURE_DIR = path.join(__dirname, '..', '..', '..', 'tools', 'audit', 'fixtures', 'latest');
+const NODE_COUNT_FIXTURE = path.join(FIXTURE_DIR, 'getzelnodecount.json');
+
+const armed = fs.existsSync(NODE_COUNT_FIXTURE);
+const whenArmed = armed ? describe : describe.skip;
+
+whenArmed('D1 earnings -- app side', () => {
+  it('emits the projections the app would display, from the captured fixture', () => {
+    const payload = JSON.parse(fs.readFileSync(NODE_COUNT_FIXTURE, 'utf8'));
+    const stats = payload.data || payload;
+
+    const gstore = create_global_store();
+    gstore.node_count.cumulus = stats['cumulus-enabled'];
+    gstore.node_count.nimbus = stats['nimbus-enabled'];
+    gstore.node_count.stratus = stats['stratus-enabled'];
+
+    fill_rewards(gstore);
+
+    const out = {};
+    for (const tier of ['cumulus', 'nimbus', 'stratus']) {
+      const p = gstore.reward_projections[tier];
+      out[tier] = {
+        pay_frequency: p.pay_frequency,
+        payment_amount: p.payment_amount,
+        pa_amount: p.pa_amount,
+        apy: p.apy,
+      };
+    }
+
+    fs.writeFileSync(
+      path.join(FIXTURE_DIR, 'appside-d1.json'),
+      JSON.stringify(out, null, 2),
+      'utf8'
+    );
+
+    // Assertions here are deliberately weak. This is a data-emitting step, not
+    // the check -- the real verdict is compare.py's diff against the
+    // independent reference. Asserting expected VALUES here would just be the
+    // app grading its own homework.
+    for (const tier of ['cumulus', 'nimbus', 'stratus']) {
+      expect(Number.isFinite(out[tier].payment_amount)).toBe(true);
+      expect(out[tier].payment_amount).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tools/audit/README.md
+++ b/tools/audit/README.md
@@ -1,0 +1,121 @@
+# Calculation-correctness audit harness
+
+Verifies the numbers this site displays against an **independently derived**
+reference, rather than against more tests written from the same understanding
+as the code.
+
+## Why not just write more unit tests
+
+Because that provably does not work here. When this audit began:
+
+- `donor/donorStatus.test.js` passed.
+- `apidata.test.js` passed.
+- And `apidata.js`'s `fetch_total_donations` carried the exact bug PR #196 had
+  already fixed in the file next door — scanning only the current donation
+  address, so every pre-2026-09-03 donation was invisible. It fed the `donor`,
+  `super_donor` and `sugar_daddy` achievement gates, silently denying early
+  supporters achievements they had earned.
+
+Two green test files, one live bug sitting between them. The function had zero
+coverage, and tests written from the same assumptions as the code would not
+have found it. Finding it took tracing a displayed value back to its source.
+
+Tests earn their keep *after* the harness finds something — as the regression
+guard on the fix.
+
+## The method
+
+**The app side runs the app's own code. The reference side is independently
+reimplemented. Both are fed the same captured bytes.**
+
+That last clause matters more than it looks. Comparing a figure the app computed
+at T1 against upstream data fetched at T2 produces false positives all day —
+node counts, prices and block heights all move between the two reads. Capturing
+once removes the timing variable entirely and makes a run reproducible months
+later.
+
+The reference is deliberately *not* a port of `apidata.js`. A port would
+reproduce the app's bugs and agree with them perfectly, which is the exact
+failure this exists to avoid. Every formula in `reference/` is re-derived from
+documented protocol facts, with the derivation written out in the file.
+
+## Running it
+
+```bash
+# 1. Snapshot upstream (writes tools/audit/fixtures/<stamp>/ and .../latest/)
+python tools/audit/capture.py
+
+# 2. App side — runs the app's real functions against that snapshot
+cd client && CI=true npx react-scripts test --watchAll=false d1AppSide && cd ..
+
+# 3. Independent reference
+python tools/audit/reference/d1_earnings.py
+
+# 4. Verdict
+python tools/audit/compare.py
+```
+
+`compare.py` exits **0** when the two agree, **1** on disagreement, **2** when
+an input is missing.
+
+Fixtures are gitignored — they are evidence for one run, not source.
+
+## What a disagreement means
+
+**One of the two is wrong. Not necessarily the app.** The reference is an
+independent derivation, not an oracle; a mismatch means the two disagree and
+both are worth reading before deciding which to change.
+
+## What "AGREE" does *not* establish
+
+It shows the app's arithmetic matches an independently derived formula **over
+the same inputs**. It says nothing about whether the inputs are right.
+
+A stale `CC_BLOCK_REWARD` is the live example: issue #202 records that the first
+PoN subsidy reduction lands at block 3,071,200 (~2026-10-25), taking it from 14
+to 12.6. After that date the app and this reference would still agree perfectly
+— both reading the same stale constant — while every earnings figure on the
+site read ~11% high. Input correctness is a separate problem from arithmetic
+correctness, and this harness only addresses the second.
+
+`constantsParity.test.js` covers one narrow slice of the first: it fails if
+`setupTests.js` and `public/runtime/app-content.js` ever disagree. That matters
+because the app side runs under Jest and therefore reads the *test* constants —
+its output is only meaningful while those two agree. It is also how the #202
+update gets caught if someone edits production without the test doubles.
+
+## Verifying the harness itself
+
+A harness that always reports "agree" is worthless. This one was mutation-tested
+by recomputing the reference at a 12.6 subsidy — the exact change #202 predicts
+— and confirming `compare.py` reported all nine affected figures and exited 1.
+`pay_frequency` correctly did *not* flag, since it depends on node count rather
+than subsidy: the harness discriminates rather than blanket-failing.
+
+Re-run that check after any change to `compare.py`.
+
+## Domains
+
+The audit is carved by data-dependency rather than by page, because
+`apidata.js` alone feeds Home, Nodes and Analytics — page-by-page would audit
+shared code three times.
+
+| Domain | Covers | Status |
+|---|---|---|
+| **D1** earnings & rewards | tier projections, per-node payment, PA amount, APY, pay frequency | **built** — agrees |
+| **D2** node & app counts | `fluxinfo`, `appSpecs`, running-app categorisation | fixture captured, reference not written |
+| **D3** donations & donor status | `fetch_total_donations`, `donorStatus` | audited by hand; found and fixed the bug above |
+| **D4** rankings & achievements | `rankInGroup`, `globalRankings`, `achievements` | not started — has broken twice before |
+| **D5** live & chain | `blockFlowSummary`, reward extraction, `chainActivity` | not started |
+
+## Adding a domain
+
+1. Add its upstream to `SOURCES` in `capture.py`, with a `why` line saying what
+   the data is for.
+2. Write `reference/<domain>.py`. **Derive the formulas; do not port them.**
+   Write the derivation into the module docstring — if you cannot state why a
+   formula is right without pointing at the app, you have ported it.
+3. Add `client/src/audit/<domain>AppSide.test.js`, guarded on fixture presence
+   so it stays inert during a normal `npm test`.
+4. Teach `compare.py` the new pair of files.
+5. Mutation-test it before trusting a green result.

--- a/tools/audit/capture.py
+++ b/tools/audit/capture.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Snapshot the upstream data the site computes from, so app and reference
+recompute over IDENTICAL bytes.
+
+This exists because the obvious approach does not work. Comparing a figure the
+app computed at T1 against upstream data fetched at T2 produces false positives
+all day -- node counts, prices and block heights all move between the two
+reads. Capturing once and feeding both sides the same file removes the timing
+variable entirely, and makes a run reproducible months later.
+
+Usage:
+    python tools/audit/capture.py                 # -> fixtures/<UTC stamp>/ + fixtures/latest
+    python tools/audit/capture.py --label pre-fix # a named snapshot you can diff against
+
+Fixtures are gitignored. They are evidence for one audit run, not source.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+# Every upstream this audit reads. Keyed by the filename written into the
+# snapshot; `domains` records which audit domain consumes it, so a partial
+# capture still says what it can and cannot support.
+SOURCES = {
+    "getzelnodecount.json": {
+        "url": "https://api.runonflux.io/daemon/getzelnodecount",
+        "domains": ["D1"],
+        "why": "cumulus/nimbus/stratus-enabled -- the divisor in every per-node reward projection",
+    },
+    "fluxinfo.json": {
+        "url": "https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Names,apps.resources",
+        "domains": ["D2"],
+        "why": "canonical running-apps source (never api.runonflux.io -- that counts ORDERED, not running)",
+    },
+}
+
+# The explorer rejects the default Python-urllib User-Agent outright. Cost a
+# confusing failure once already; do not remove.
+HEADERS = {"User-Agent": "Mozilla/5.0 (FluxNode calculation audit)"}
+
+
+def fetch(url, timeout=45):
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", help="name this snapshot instead of using a UTC timestamp")
+    parser.add_argument("--only", help="capture a single source by filename")
+    args = parser.parse_args()
+
+    stamp = args.label or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = FIXTURES / stamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "sources": {},
+        "failures": {},
+    }
+
+    for filename, spec in SOURCES.items():
+        if args.only and filename != args.only:
+            continue
+        print("fetching %-22s %s" % (filename, spec["url"]))
+        try:
+            payload = fetch(spec["url"])
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as exc:
+            # A failed source is recorded rather than fatal: a D1-only run is
+            # still worth having when the D2 upstream is down.
+            print("  FAILED: %s" % exc)
+            manifest["failures"][filename] = str(exc)
+            continue
+
+        (out_dir / filename).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        manifest["sources"][filename] = {
+            "url": spec["url"],
+            "domains": spec["domains"],
+            "why": spec["why"],
+            "bytes": len(json.dumps(payload)),
+        }
+        print("  ok (%d bytes)" % manifest["sources"][filename]["bytes"])
+
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    # `latest` is what the app side and the reference both read. A copy, not a
+    # symlink: Windows needs elevation for symlinks and this must work for
+    # everyone on the team.
+    latest = FIXTURES / "latest"
+    latest.mkdir(parents=True, exist_ok=True)
+    for item in out_dir.iterdir():
+        (latest / item.name).write_bytes(item.read_bytes())
+
+    print("\nsnapshot: %s" % out_dir)
+    print("latest:   %s" % latest)
+    if manifest["failures"]:
+        print("\n%d source(s) failed -- domains depending on them cannot be audited from this snapshot:" % len(manifest["failures"]))
+        for filename, error in manifest["failures"].items():
+            print("  %s (%s): %s" % (filename, ",".join(SOURCES[filename]["domains"]), error))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/compare.py
+++ b/tools/audit/compare.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Diff the app's own output against the independent reference, and report.
+
+This is the step that produces a verdict. Everything before it just generates
+the two sides.
+
+Usage:
+    python tools/audit/compare.py
+    python tools/audit/compare.py --tolerance 1e-9
+
+Exit codes: 0 = agree, 1 = disagreement found, 2 = cannot run (missing input).
+A disagreement is NOT automatically an app bug -- the reference can be wrong
+too. It means one of the two is, and both are worth reading.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures" / "latest"
+
+# Floating-point arithmetic in two languages will not agree bit-for-bit, and
+# demanding that would produce noise rather than findings. This tolerance is
+# RELATIVE and tight enough that any real formula difference -- a wrong
+# constant, a dropped term, an off-by-one divisor -- lands far outside it,
+# while IEEE-754 ordering differences land far inside.
+DEFAULT_TOLERANCE = 1e-9
+
+FIELD_MEANINGS = {
+    "pay_frequency": "minutes between payments for one node",
+    "payment_amount": "FLUX per day per node",
+    "pa_amount": "parallel-asset FLUX per day per node",
+    "apy": "annual percentage yield on collateral",
+}
+
+
+def load(name):
+    path = FIXTURES / name
+    if not path.exists():
+        return None, path
+    return json.loads(path.read_text(encoding="utf-8")), path
+
+
+def relative_difference(a, b):
+    if a == b:
+        return 0.0
+    scale = max(abs(a), abs(b))
+    if scale == 0:
+        return 0.0
+    return abs(a - b) / scale
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    args = parser.parse_args()
+
+    app, app_path = load("appside-d1.json")
+    ref, ref_path = load("reference-d1.json")
+
+    if app is None:
+        print("missing %s" % app_path)
+        print("  run: cd client && CI=true npx react-scripts test --watchAll=false d1AppSide")
+        return 2
+    if ref is None:
+        print("missing %s" % ref_path)
+        print("  run: python tools/audit/reference/d1_earnings.py")
+        return 2
+
+    meta = ref.pop("_meta", {})
+
+    print("=" * 74)
+    print("D1 EARNINGS -- app vs independent reference")
+    print("=" * 74)
+    if meta:
+        print("block subsidy %s over %s blocks/day; tier shares total %.3f%% "
+              "(implied dev fund %.3f%%)"
+              % (meta.get("block_subsidy"), meta.get("blocks_per_day"),
+                 meta.get("tier_share_pct_total", 0.0), meta.get("implied_dev_fund_pct", 0.0)))
+        print()
+
+    disagreements = []
+    for tier in sorted(ref):
+        if tier not in app:
+            disagreements.append((tier, "-", "missing from app output", "", ""))
+            continue
+
+        print("%s (%s nodes)" % (tier.upper(), meta.get("node_counts", {}).get(tier, "?")))
+        for field in sorted(ref[tier]):
+            ref_value = ref[tier][field]
+            if field not in app[tier]:
+                disagreements.append((tier, field, "missing from app output", "", ""))
+                continue
+            app_value = app[tier][field]
+            delta = relative_difference(app_value, ref_value)
+            agrees = delta <= args.tolerance
+            print("  %-16s app=%-20.10f ref=%-20.10f %s"
+                  % (field, app_value, ref_value, "ok" if agrees else "MISMATCH"))
+            if not agrees:
+                disagreements.append((tier, field, "relative delta %.3e" % delta, app_value, ref_value))
+        print()
+
+    if not disagreements:
+        print("AGREE -- every D1 figure matches the independent reference "
+              "within %g relative tolerance." % args.tolerance)
+        print()
+        print("Note what this does and does not establish. It shows the app's "
+              "arithmetic matches an independently-derived formula over the "
+              "same inputs. It does NOT establish that the INPUTS are right -- "
+              "a stale CC_BLOCK_REWARD would agree perfectly here while being "
+              "wrong on-chain (see issue #202).")
+        return 0
+
+    print("-" * 74)
+    print("%d DISAGREEMENT(S)" % len(disagreements))
+    print("-" * 74)
+    for tier, field, detail, app_value, ref_value in disagreements:
+        meaning = FIELD_MEANINGS.get(field, "")
+        print("  %s.%s %s" % (tier, field, ("-- " + meaning) if meaning else ""))
+        print("      %s" % detail)
+        if app_value != "":
+            print("      app=%r  reference=%r" % (app_value, ref_value))
+    print()
+    print("One of the two is wrong. Read both before deciding which: the "
+          "reference is an independent derivation, not an oracle.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/reference/d1_earnings.py
+++ b/tools/audit/reference/d1_earnings.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Domain D1 -- earnings and reward projections, recomputed INDEPENDENTLY.
+
+The whole value of this file is that it is NOT a transcription of
+client/src/apidata.js. Every formula below is derived from documented protocol
+facts and re-stated here; if it were ported from the app, it would reproduce the
+app's bugs and agree with them perfectly, which is exactly the failure mode this
+audit exists to avoid. When this disagrees with the app, one of the two is
+wrong and BOTH are worth reading before deciding which.
+
+Derivation, from the Flux protocol rather than from the app:
+
+  blocks/day      Flux targets a 30-second block. 86400 / 30 = 2880.
+  network per day A tier's share of the block subsidy, every block, all day:
+                    2880 * subsidy * (tier_share_pct / 100)
+  per node        Payment rotates through a tier's nodes in order, so over a
+                  day a tier's emission divides evenly across its members:
+                    network_per_day / node_count
+  pay frequency   One full rotation is node_count blocks. At 30s each that is
+                    node_count * 30 seconds = node_count / 2 minutes
+  parallel asset  A configured percentage of the native reward:
+                    per_node * (pa_pct / 100)
+  APY             Annualised return on the tier's locked collateral:
+                    100 * ((per_node + pa_amount) * 365) / collateral
+
+Constants are READ FROM PRODUCTION (client/public/runtime/app-content.js), not
+hardcoded here. That is deliberate: it means this reference audits the values
+the site actually ships, and a constant edited in production without a matching
+test-double update is caught by the parity test rather than silently passing.
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+APP_CONTENT = REPO / "client" / "public" / "runtime" / "app-content.js"
+FIXTURES = pathlib.Path(__file__).resolve().parents[1] / "fixtures" / "latest"
+
+SECONDS_PER_DAY = 86_400
+BLOCK_TARGET_SECONDS = 30
+BLOCKS_PER_DAY = SECONDS_PER_DAY // BLOCK_TARGET_SECONDS  # 2880
+
+TIERS = ("CUMULUS", "NIMBUS", "STRATUS")
+
+
+def read_production_constants():
+    """Parse the constants the deployed site actually uses.
+
+    Regex rather than a JS parser on purpose: app-content.js is a flat list of
+    `window.gContent.NAME = value;` assignments with no logic, and adding a JS
+    runtime dependency to read ten numbers would not be a trade worth making.
+    A malformed value raises here rather than silently defaulting -- an audit
+    that quietly substitutes a guess is worse than one that stops.
+    """
+    text = APP_CONTENT.read_text(encoding="utf-8")
+    constants = {}
+    for match in re.finditer(r"window\.gContent\.(CC_[A-Z_]+)\s*=\s*([0-9.]+)\s*;", text):
+        constants[match.group(1)] = float(match.group(2))
+
+    required = (
+        ["CC_BLOCK_REWARD", "CC_PA_REWARD"]
+        + ["CC_FLUX_REWARD_%s" % t for t in TIERS]
+        + ["CC_COLLATERAL_%s" % t for t in TIERS]
+    )
+    missing = [name for name in required if name not in constants]
+    if missing:
+        raise SystemExit("app-content.js is missing required constants: %s" % ", ".join(missing))
+    return constants
+
+
+def read_node_counts():
+    path = FIXTURES / "getzelnodecount.json"
+    if not path.exists():
+        raise SystemExit(
+            "no fixture at %s -- run `python tools/audit/capture.py` first" % path
+        )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    # The daemon wraps its payload; the site reads `data`. Accept either shape
+    # rather than assuming, since a wrapper change would otherwise look like
+    # a calculation error rather than a shape change.
+    stats = payload.get("data", payload)
+
+    counts = {}
+    for tier in TIERS:
+        key = "%s-enabled" % tier.lower()
+        if key not in stats:
+            raise SystemExit("fixture has no '%s' -- upstream shape changed?" % key)
+        counts[tier] = int(stats[key])
+        if counts[tier] <= 0:
+            # Guarding explicitly: a zero would make every per-node figure
+            # infinite, and an audit reporting `inf` teaches nobody anything.
+            raise SystemExit("fixture reports %d %s nodes -- refusing to divide by that" % (counts[tier], tier))
+    return counts
+
+
+def compute(constants, counts):
+    subsidy = constants["CC_BLOCK_REWARD"]
+    pa_pct = constants["CC_PA_REWARD"]
+
+    projections = {}
+    for tier in TIERS:
+        share_pct = constants["CC_FLUX_REWARD_%s" % tier]
+        collateral = constants["CC_COLLATERAL_%s" % tier]
+        node_count = counts[tier]
+
+        network_per_day = BLOCKS_PER_DAY * subsidy * (share_pct / 100.0)
+        per_node = network_per_day / node_count
+        pa_amount = per_node * (pa_pct / 100.0)
+
+        projections[tier.lower()] = {
+            "pay_frequency": node_count / 2.0,          # minutes
+            "payment_amount": per_node,                 # FLUX/day
+            "pa_amount": pa_amount,                     # FLUX/day
+            "apy": 100.0 * ((per_node + pa_amount) * 365.0) / collateral,
+        }
+
+    # A sanity check the app never makes: the three tier shares plus the dev
+    # fund must account for the whole subsidy. If they do not, one of the
+    # percentages is wrong regardless of whether app and reference agree.
+    tier_share_total = sum(constants["CC_FLUX_REWARD_%s" % t] for t in TIERS)
+    projections["_meta"] = {
+        "blocks_per_day": BLOCKS_PER_DAY,
+        "block_subsidy": subsidy,
+        "tier_share_pct_total": tier_share_total,
+        "implied_dev_fund_pct": 100.0 - tier_share_total,
+        "node_counts": {t.lower(): counts[t] for t in TIERS},
+    }
+    return projections
+
+
+def main():
+    constants = read_production_constants()
+    counts = read_node_counts()
+    result = compute(constants, counts)
+
+    out = FIXTURES / "reference-d1.json"
+    out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    meta = result["_meta"]
+    print("reference D1 written to %s" % out)
+    print("  block subsidy      %s FLUX over %d blocks/day" % (meta["block_subsidy"], meta["blocks_per_day"]))
+    print("  tier shares total  %.3f%%  (implied dev fund %.3f%%)" % (meta["tier_share_pct_total"], meta["implied_dev_fund_pct"]))
+    for tier in TIERS:
+        p = result[tier.lower()]
+        print("  %-8s %8d nodes  %10.6f FLUX/day  APY %6.2f%%"
+              % (tier.lower(), meta["node_counts"][tier.lower()], p["payment_amount"], p["apy"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Builds the independent-recomputation harness for the Track 3 calculation audit, and uses it to verify domain **D1 — earnings and reward projections**.

## Why not just add more unit tests

Because that provably doesn't work here. When this audit started:

- `donor/donorStatus.test.js` passed ✅
- `apidata.test.js` passed ✅
- And `fetch_total_donations` still carried the exact bug PR #196 had fixed in the file next door — costing early supporters their `donor` / `super_donor` / `sugar_daddy` achievements (see #213).

**Two green test files, one live bug sitting between them.** That function had zero coverage, and tests written from the same understanding as the code inherit its assumptions. Tests earn their keep *after* the harness finds something, as the regression guard on the fix.

## The method

> The app side runs the app's own code. The reference side is independently reimplemented. **Both are fed the same captured bytes.**

That last clause isn't incidental. Comparing a figure the app computed at T1 against upstream fetched at T2 produces false positives all day — node counts and prices move between the reads. Capturing once removes the timing variable and makes a run reproducible months later.

The reference is deliberately **not** a port of `apidata.js`. A port would reproduce the app's bugs and agree with them perfectly. Every formula in `reference/d1_earnings.py` is re-derived from protocol facts — 30s block target → 2880 blocks/day, rotation-based pay frequency, APY over collateral — with the derivation written into the module docstring.

## D1 result: agree

All twelve figures across three tiers, within `1e-9` relative tolerance.

```
CUMULUS (3115 nodes)   payment_amount  app=0.9244476404  ref=0.9244476404  ok
NIMBUS  (1581 nodes)   payment_amount  app=6.3757115750  ref=6.3757115750  ok
STRATUS (1633 nodes)   payment_amount  app=15.8712161666 ref=15.8712161666 ok
```

## The harness was mutation-tested, not trusted

A harness that always says "agree" is worthless. Recomputing the reference at a **12.6** subsidy — the exact reduction #202 predicts for ~2026-10-25 — makes `compare.py` report all nine affected figures and exit `1`.

Critically, `pay_frequency` correctly does **not** flag, because it depends on node count rather than subsidy. The harness discriminates; it doesn't blanket-fail.

## `constantsParity.test.js` — closing a live trap

The economic constants live in **two hand-maintained copies**: `public/runtime/app-content.js` (production) and `setupTests.js` (every test), with nothing enforcing agreement.

They agree today. When #202 lands and `CC_BLOCK_REWARD` goes 14 → 12.6, updating only production would leave every test passing against the stale value — and `apidata.test.js` derives its expectations *from* those constants, so it wouldn't merely miss the change, it would **certify the wrong arithmetic as correct**.

This also underwrites the harness: the app side runs under Jest and therefore reads the *test* constants, so its output is only meaningful while the two agree.

## What "AGREE" does not establish

It shows the app's arithmetic matches an independently derived formula **over the same inputs**. It says nothing about whether the inputs are right — a stale `CC_BLOCK_REWARD` would agree perfectly here while being wrong on-chain. Input correctness is a separate problem, and the README says so explicitly rather than letting a green run imply more than it earned.

## Safe to merge

The app-side test is **inert without fixtures**:

| | Suites | Result |
|---|---|---|
| Fresh clone / CI | 31 | **1 skipped**, 455 passed |
| With fixtures | 31 | 456 passed |

Fixtures are gitignored — evidence for one run, not source. `yarn.lock` install drift was deliberately discarded, since no dependency changed here.

## Remaining domains

| Domain | Status |
|---|---|
| D1 earnings | **built — agrees** |
| D2 node & app counts | fixture captured, reference not written |
| D3 donations | audited by hand → #213 |
| D4 rankings & achievements | not started — has broken twice |
| D5 live & chain | not started |

`README.md` documents how to add one, including the rule that matters: *derive the formulas, don't port them — if you can't state why a formula is right without pointing at the app, you've ported it.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)