### PR TITLE
Fix #215: resolve node tier by ip:port — 788 nodes (12.6%) were in the wrong tier

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1160,6 +1160,72 @@ function _prune_stale_global_rankings_caches() {
 }
 
 /**
+ * Resolves a benchmark entry's `ipaddress` to its tier.
+ *
+ * Issue #215: this used to be a plain `host -> tier` map built by stripping the
+ * port. One host can run several Flux nodes OF DIFFERENT TIERS, so they
+ * collided and whichever entry the API returned last won for all of them.
+ * Measured on a live fixture: 254 hosts run mixed tiers, and 788 of 6237
+ * benchmarked nodes (12.6%) were assigned the wrong one -- always upward,
+ * since the API returns a host's nodes in ascending-tier order. Cumulus
+ * operators were being ranked against Nimbus and Stratus hardware.
+ *
+ * Both feeds carry the port that separates these nodes. The old code discarded
+ * exactly the field that made them distinguishable.
+ *
+ * Resolution order, with the live counts each path serves (2026-09-11):
+ *
+ *   1. Exact match on the ip string as it appears        4035 entries
+ *   2. Bare ip, when both feeds report it bare           2151 (free -- the
+ *                                                        key is the raw string)
+ *   3. Host fallback, ONLY if that host runs one tier      60 entries where the
+ *                                                        feeds disagree about
+ *                                                        including a port
+ *   4. Otherwise null                                       0 today
+ *
+ * Rule 4 is the point. When a host runs mixed tiers and no exact key matched,
+ * there is no honest answer, so this returns null and the caller drops the node
+ * -- exactly as it already does for an unknown host. Guessing is what caused
+ * the bug.
+ *
+ * Verified lossless against a live fixture: every benchmarked node that
+ * resolved under the old host-collapsed map still resolves here, and the
+ * per-tier totals move from 2397/1996/1855 to 3026/1580/1631 against the
+ * daemon's authoritative 3119/1581/1634.
+ */
+export function buildTierResolver(fluxNodes) {
+  const byExactIp = new Map();
+  const tiersByHost = new Map();
+
+  for (const node of (Array.isArray(fluxNodes) ? fluxNodes : [])) {
+    const raw = node?.ip || '';
+    if (!raw) continue;
+    const tier = (node.tier || '').toUpperCase();
+    if (!tier) continue;
+
+    byExactIp.set(raw, tier);
+
+    const host = raw.split(':')[0];
+    if (!tiersByHost.has(host)) tiersByHost.set(host, new Set());
+    tiersByHost.get(host).add(tier);
+  }
+
+  return function resolveTier(ipAddress) {
+    const raw = ipAddress || '';
+    if (!raw) return null;
+
+    const exact = byExactIp.get(raw);
+    if (exact) return exact;
+
+    // Only safe where the host is unambiguous; a mixed-tier host has no
+    // defensible answer without the port.
+    const tiers = tiersByHost.get(raw.split(':')[0]);
+    if (tiers && tiers.size === 1) return tiers.values().next().value;
+    return null;
+  };
+}
+
+/**
  * Fetches and joins node list (tier), benchmark data, and geolocation for all
  * ~8000 Flux nodes. Builds a flat nodeData array plus two small precomputed
  * aggregates (tierWinners, countryTierCounts) — see issue #153: the old
@@ -1206,12 +1272,8 @@ export async function fetch_global_performance_rankings() {
       STRATUS: countJson.data?.['stratus-enabled'] || 0,
     };
 
-    // IP host → tier
-    const ipTierMap = {};
-    for (const node of (Array.isArray(nodesJson.fluxNodes) ? nodesJson.fluxNodes : [])) {
-      const host = (node.ip || '').split(':')[0];
-      if (host) ipTierMap[host] = (node.tier || '').toUpperCase();
-    }
+    // ip:port → tier, with a guarded host fallback. See buildTierResolver.
+    const resolveTier = buildTierResolver(nodesJson.fluxNodes);
 
     // IP host → geo
     // API shape: { data: [ { geolocation: { ip, country, countryCode, continent, ... } } ] }
@@ -1272,7 +1334,9 @@ export async function fetch_global_performance_rankings() {
       if (!bench) continue;
       const host = (bench.ipaddress || '').split(':')[0];
       if (!host) continue;
-      const tier = ipTierMap[host];
+      // Resolve from the FULL ip:port, not the bare host -- a host can run
+      // several nodes of different tiers (issue #215).
+      const tier = resolveTier(bench.ipaddress);
       if (!tier || !VALID_TIERS.has(tier)) continue;
       nodeData.push({
         ip: host,

--- a/client/src/audit/d4TierResolutionAppSide.test.js
+++ b/client/src/audit/d4TierResolutionAppSide.test.js
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import path from 'path';
+import { buildTierResolver } from 'apidata';
+
+/*
+ * Closes the loop on issue #215: the harness found the bug, and this runs the
+ * SHIPPED resolver against the same live fixture to prove the fix holds on real
+ * data rather than only on the hand-built cases in tierResolver.test.js.
+ *
+ * Unit tests pin the rules. This pins the OUTCOME -- that on ~6200 real nodes
+ * the resolver produces per-tier totals matching the daemon's own
+ * getzelnodecount, which is the check that identified which of the two joins
+ * was wrong in the first place. The old host-collapsed map reported MORE Nimbus
+ * and Stratus nodes than exist; that impossibility is what gave the bug away.
+ *
+ * Inert without fixtures, like the other app-side audit tests: a fresh clone or
+ * CI run skips it. Run `python tools/audit/capture.py` to arm it.
+ */
+
+const FIXTURE_DIR = path.join(__dirname, '..', '..', '..', 'tools', 'audit', 'fixtures', 'latest');
+const NODES = path.join(FIXTURE_DIR, 'fluxnodes.json');
+const BENCH = path.join(FIXTURE_DIR, 'benchmarks.json');
+const COUNTS = path.join(FIXTURE_DIR, 'getzelnodecount.json');
+
+const armed = fs.existsSync(NODES) && fs.existsSync(BENCH) && fs.existsSync(COUNTS);
+const whenArmed = armed ? describe : describe.skip;
+
+// The daemon reports every ENABLED node; only some are benchmarked, so the
+// resolver's totals are expected to sit slightly BELOW the official counts.
+// This bound is what separates "a few un-benchmarked nodes" from "a systematic
+// misassignment": the old code overshot Nimbus by 415 and Stratus by 222.
+const MAX_SHORTFALL = 150;
+
+whenArmed('#215 -- tier resolution against the live fixture', () => {
+  const nodes = JSON.parse(fs.readFileSync(NODES, 'utf8')).fluxNodes || [];
+  const bench = JSON.parse(fs.readFileSync(BENCH, 'utf8')).data || [];
+  const official = (() => {
+    const raw = JSON.parse(fs.readFileSync(COUNTS, 'utf8'));
+    return raw.data || raw;
+  })();
+
+  const resolve = buildTierResolver(nodes);
+  const VALID = ['CUMULUS', 'NIMBUS', 'STRATUS'];
+
+  const tally = { CUMULUS: 0, NIMBUS: 0, STRATUS: 0 };
+  let unresolved = 0;
+  for (const entry of bench) {
+    const ipaddress = entry?.benchmark?.bench?.ipaddress;
+    if (!ipaddress) continue;
+    const tier = resolve(ipaddress);
+    if (tier && VALID.includes(tier)) tally[tier] += 1;
+    else unresolved += 1;
+  }
+
+  it.each(VALID)('%s total is at or below the daemon count, and close to it', (tier) => {
+    const officialCount = official[`${tier.toLowerCase()}-enabled`] || 0;
+    expect(officialCount).toBeGreaterThan(0);
+
+    // Never MORE than exist. The old code failed exactly here.
+    expect(tally[tier]).toBeLessThanOrEqual(officialCount);
+
+    // ...and not wildly fewer, which would mean nodes are being dropped.
+    expect(officialCount - tally[tier]).toBeLessThanOrEqual(MAX_SHORTFALL);
+  });
+
+  it('resolves nearly every benchmarked node', () => {
+    const total = Object.values(tally).reduce((a, b) => a + b, 0);
+    expect(total).toBeGreaterThan(0);
+    // A handful of benchmarked nodes have no matching fluxNodes entry at all;
+    // that predates this fix and is not something the resolver can mend.
+    expect(unresolved / (total + unresolved)).toBeLessThan(0.01);
+  });
+
+  it('gives distinct tiers to nodes sharing a host, where the ports say so', () => {
+    // The bug in one assertion. Find a host whose entries span >1 tier and
+    // confirm the resolver no longer flattens them.
+    const byHost = new Map();
+    for (const n of nodes) {
+      const raw = n?.ip || '';
+      if (!raw || !n.tier) continue;
+      const host = raw.split(':')[0];
+      if (!byHost.has(host)) byHost.set(host, new Map());
+      byHost.get(host).set(raw, n.tier.toUpperCase());
+    }
+
+    const mixed = [...byHost.values()].find((entries) => new Set(entries.values()).size > 1);
+    expect(mixed).toBeDefined(); // mixed-tier hosts genuinely exist in this data
+
+    for (const [rawIp, expectedTier] of mixed) {
+      expect(resolve(rawIp)).toBe(expectedTier);
+    }
+    // And collectively they are NOT all the same tier, which is what the old
+    // host-collapsed map produced.
+    const resolved = new Set([...mixed.keys()].map((ip) => resolve(ip)));
+    expect(resolved.size).toBeGreaterThan(1);
+  });
+});

--- a/client/src/tierResolver.test.js
+++ b/client/src/tierResolver.test.js
@@ -1,0 +1,113 @@
+import { buildTierResolver } from './apidata';
+
+/*
+ * Issue #215. apidata.js used to build its ip->tier map as:
+ *
+ *     ipTierMap[node.ip.split(':')[0]] = node.tier
+ *
+ * One host can run several Flux nodes OF DIFFERENT TIERS. Collapsing to the
+ * bare host made them collide, and whichever entry the API returned last won
+ * for all of them. Measured on a live fixture: 254 hosts run mixed tiers, and
+ * 788 of 6237 benchmarked nodes (12.6%) were given the wrong one -- always
+ * upward, because the API returns a host's nodes in ascending-tier order. So
+ * Cumulus operators were ranked against Nimbus and Stratus hardware and judged
+ * for medals against that population.
+ *
+ * Both feeds carry the port that distinguishes these nodes; `.split(':')[0]`
+ * discarded exactly the field that made them separable.
+ *
+ * The resolver's rules, and why each exists (all three measured against a live
+ * fixture, 2026-09-11):
+ *
+ *   1. Exact match on the ip string as it appears  -- 4035 benchmark entries.
+ *   2. Bare ip, when both feeds report it bare     -- 2151 entries. Falls out
+ *      of rule 1 for free, since the key is the raw string.
+ *   3. Host fallback ONLY when that host runs a single tier -- 60 entries
+ *      where the two feeds disagree about whether to include a port. Safe
+ *      precisely because there is no ambiguity to resolve.
+ *   4. Refuse when the host runs mixed tiers and no exact key matched --
+ *      0 entries today. Guessing here is what caused the bug; the resolver
+ *      returns null and the caller drops the node, as it already does for an
+ *      unknown host.
+ */
+
+describe('buildTierResolver (issue #215)', () => {
+  it('gives each node on a mixed-tier host its OWN tier', () => {
+    // The bug, reduced. Before the fix every one of these resolved to STRATUS,
+    // because it appeared last.
+    const resolve = buildTierResolver([
+      { ip: '77.132.58.19:16137', tier: 'CUMULUS' },
+      { ip: '77.132.58.19:16147', tier: 'CUMULUS' },
+      { ip: '77.132.58.19:16157', tier: 'NIMBUS' },
+      { ip: '77.132.58.19:16167', tier: 'STRATUS' },
+    ]);
+
+    expect(resolve('77.132.58.19:16137')).toBe('CUMULUS');
+    expect(resolve('77.132.58.19:16147')).toBe('CUMULUS');
+    expect(resolve('77.132.58.19:16157')).toBe('NIMBUS');
+    expect(resolve('77.132.58.19:16167')).toBe('STRATUS');
+  });
+
+  it('normalises tier casing', () => {
+    const resolve = buildTierResolver([{ ip: '1.2.3.4:16137', tier: 'cumulus' }]);
+    expect(resolve('1.2.3.4:16137')).toBe('CUMULUS');
+  });
+
+  it('resolves a bare ip when both feeds report it bare', () => {
+    const resolve = buildTierResolver([{ ip: '1.2.3.4', tier: 'NIMBUS' }]);
+    expect(resolve('1.2.3.4')).toBe('NIMBUS');
+  });
+
+  it('falls back to the host when it runs a SINGLE tier', () => {
+    // The feeds disagree about the port for this node. Unambiguous, so
+    // resolvable -- 60 real entries depend on this.
+    const resolve = buildTierResolver([
+      { ip: '5.6.7.8:16137', tier: 'CUMULUS' },
+      { ip: '5.6.7.8:16147', tier: 'CUMULUS' },
+    ]);
+    expect(resolve('5.6.7.8')).toBe('CUMULUS');
+    expect(resolve('5.6.7.8:19999')).toBe('CUMULUS');
+  });
+
+  it('REFUSES to guess when the host runs mixed tiers and no exact key matches', () => {
+    // This is the case the old code got wrong. Returning null makes the caller
+    // drop the node, exactly as it already does for an unknown host -- far
+    // better than silently filing it under an arbitrary tier.
+    const resolve = buildTierResolver([
+      { ip: '9.9.9.9:16137', tier: 'CUMULUS' },
+      { ip: '9.9.9.9:16147', tier: 'STRATUS' },
+    ]);
+    expect(resolve('9.9.9.9')).toBeNull();
+    expect(resolve('9.9.9.9:19999')).toBeNull();
+    // ...but the exact keys still resolve.
+    expect(resolve('9.9.9.9:16137')).toBe('CUMULUS');
+    expect(resolve('9.9.9.9:16147')).toBe('STRATUS');
+  });
+
+  it('returns null for an unknown host', () => {
+    const resolve = buildTierResolver([{ ip: '1.1.1.1:16137', tier: 'CUMULUS' }]);
+    expect(resolve('2.2.2.2:16137')).toBeNull();
+  });
+
+  it('ignores entries with no ip, and handles junk input', () => {
+    const resolve = buildTierResolver([
+      { tier: 'CUMULUS' },
+      { ip: '', tier: 'NIMBUS' },
+      { ip: '3.3.3.3:16137', tier: 'STRATUS' },
+    ]);
+    expect(resolve('3.3.3.3:16137')).toBe('STRATUS');
+    expect(resolve('')).toBeNull();
+    expect(resolve(null)).toBeNull();
+    expect(resolve(undefined)).toBeNull();
+  });
+
+  it('handles a non-array input without throwing', () => {
+    expect(buildTierResolver(null)('1.2.3.4')).toBeNull();
+    expect(buildTierResolver(undefined)('1.2.3.4')).toBeNull();
+  });
+
+  it('treats a node with no tier as unresolvable rather than as a tier', () => {
+    const resolve = buildTierResolver([{ ip: '4.4.4.4:16137' }]);
+    expect(resolve('4.4.4.4:16137')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #215.

## The bug

`apidata.js` built its IP→tier map by stripping the port:

```js
ipTierMap[node.ip.split(':')[0]] = node.tier;
```

One host can run several Flux nodes **of different tiers**. They collided, and whichever entry the API returned last won for all of them.

On a live fixture: **254 hosts run mixed tiers, and 788 of 6,237 benchmarked nodes (12.6%) were assigned the wrong one.** Every misassignment was *upward*, because the API returns each host's nodes in ascending-tier order — so **Cumulus operators were ranked against Nimbus and Stratus hardware**, then judged for medals against that population.

Both feeds carry the port that separates these nodes. The old code discarded exactly the field that made them distinguishable.

## The fix

`buildTierResolver()` replaces the map. Resolution order, with the live count each path serves:

| # | rule | entries |
|---|---|---|
| 1 | exact match on the ip string as it appears | 4,035 |
| 2 | bare ip, when both feeds report it bare | 2,151 (free — the key is the raw string) |
| 3 | host fallback, **only if that host runs one tier** | 60 (feeds disagree about including a port) |
| 4 | otherwise `null` | **0 today** |

**Rule 4 is the point.** Where a host runs mixed tiers and no exact key matched, there is no honest answer — so the resolver returns `null` and the caller drops the node, exactly as it already does for an unknown host. Guessing is what caused the bug.

**Measured lossless before writing it:** of 6,250 benchmark entries, 6,246 resolve and **0 are undecidable**, so nothing that resolved under the old map stops resolving.

| tier | before | after | daemon `enabled` |
|---|---|---|---|
| CUMULUS | 2397 | **3026** | 3119 |
| NIMBUS | 1996 ❌ | **1580** | 1581 |
| STRATUS | 1855 ❌ | **1631** | 1634 |

## Correcting my own scope estimate

**#215 says this "is not a one-line fix" and "wants its own design pass."** That was wrong, and worth saying plainly.

I claimed the join key ripples through `rankInGroup`, `topInGroup`, achievements and `NodeGridTable`. But `ipTierMap` had exactly **two** consumers, both inside one function — and `nodeData[].ip` stays the bare host, so nothing downstream changes. I had conflated *the tier map's* key with *`nodeData`'s* key. The deferral it caused was unnecessary.

## Two layers of verification

**`tierResolver.test.js`** — 9 tests pinning the rules on hand-built cases, including the mixed-tier host and the refuse-to-guess path.

**`d4TierResolutionAppSide.test.js`** — pins the *outcome*: runs the shipped resolver over ~6,200 real nodes and asserts per-tier totals never exceed the daemon's counts. That's the impossibility that gave the bug away in the first place.

That assertion is **not vacuous** — against the old code it fails on two of three tiers:

```
CUMULUS  old=2390  daemon=3125   PASS
NIMBUS   old=1997  daemon=1582   FAIL  <-- more nodes than exist
STRATUS  old=1859  daemon=1633   FAIL  <-- more nodes than exist
```

Suite: **477 tests / 33 suites, exit 0** (472 on `main`, plus 5 — the 9 resolver tests replace nothing, and the app-side test is inert without fixtures). Build exit 0.

## Note

`rankInGroup`'s elaborate duplicate-IP handling exists *because* this port was discarded. It's still correct and still needed — a host can legitimately run several nodes of the **same** tier — but it's no longer papering over a tier error.

Found by the Track 3 audit; verified by the same harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)