### PR TITLE
Explorer failover: the "CORS errors" are 429s in disguise (fixes items 1, 6, 7)

### DIFF
--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -42,7 +42,21 @@ pub const TEAM_TX_FILE: &str = "chain_activity_team_tx.json";
 pub const CHECKPOINT_FILE: &str = "chain_activity_checkpoint.json";
 pub const SCAN_STATUS_FILE: &str = "chain_activity_scan_status.json";
 
-const EXPLORER_BASE: &str = "https://explorer.runonflux.io/api";
+/*
+ * A POOL, not a single host. Confirmed 2026-09-11: explorer.runonflux.io was
+ * returning 429 with `Retry-After: 31` while explorer.app.runonflux.io served
+ * the same endpoints with HTTP 200. Trying the other host costs one request;
+ * sleeping out a backoff on a banned host costs up to 62 seconds.
+ *
+ * That distinction is what made a cold start effectively never finish. A
+ * full backfill is RETENTION_BLOCKS (23,040) blocks at 2+ requests each; at
+ * up to 62s of sleep per rate-limited request on one host, the scan reports
+ * "block 0 of <tip>" indefinitely and Chain Activity renders nothing.
+ */
+const EXPLORER_BASES: &[&str] = &[
+    "https://explorer.runonflux.io/api",
+    "https://explorer.app.runonflux.io/api",
+];
 const APP_SPECS_URL: &str = "https://api.runonflux.io/apps/globalappsspecifications";
 const HTTP_TIMEOUT_SECS: u64 = 15;
 
@@ -82,6 +96,51 @@ async fn get_with_backoff(client: &Client, url: &str) -> Option<reqwest::Respons
             }
             Ok(res) => return Some(res),
             Err(_) => return None,
+        }
+    }
+    None
+}
+
+/*
+ * GET `path` from the first explorer host that answers.
+ *
+ * Ordering matters: every host is tried BEFORE any sleeping. A 429 on one host
+ * says nothing about the other, so switching is strictly cheaper than backing
+ * off -- one request versus up to 62 seconds. Only when the whole pool is
+ * rate-limited in the same pass does this fall back to exponential backoff and
+ * try the pool again.
+ *
+ * A non-429 response is returned as-is, preserving the previous contract that
+ * a 404/500 is this request's failure rather than something to retry.
+ */
+async fn explorer_get(client: &Client, path: &str) -> Option<reqwest::Response> {
+    for attempt in 0..=MAX_RETRIES {
+        let mut all_rate_limited = true;
+
+        for base in EXPLORER_BASES {
+            let url = format!("{}{}", base, path);
+            match client.get(&url).send().await {
+                Ok(res) if res.status() == reqwest::StatusCode::TOO_MANY_REQUESTS => continue,
+                Ok(res) => return Some(res),
+                Err(_) => {
+                    // Host unreachable rather than throttled: try the next one,
+                    // but do not let it trigger a pool-wide backoff by itself.
+                    all_rate_limited = false;
+                    continue;
+                }
+            }
+        }
+
+        if attempt == MAX_RETRIES {
+            return None;
+        }
+        if all_rate_limited {
+            let delay_ms = RETRY_BASE_DELAY_MS * 2u64.pow(attempt);
+            println!(
+                "[chain_activity] every explorer host rate-limited, backing off {}ms",
+                delay_ms
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
     }
     None
@@ -479,8 +538,7 @@ pub fn unix_now() -> i64 {
 }
 
 pub async fn fetch_tip_height(client: &Client) -> Option<i64> {
-    let url = format!("{}/blocks?limit=1", EXPLORER_BASE);
-    let res = get_with_backoff(client, &url).await?;
+    let res = explorer_get(client, "/blocks?limit=1").await?;
     let parsed: RecentBlocksResponse = res.json().await.ok()?;
     parsed.blocks.get(0).map(|b| b.height)
 }
@@ -511,8 +569,7 @@ pub async fn fetch_deployment_heights(client: &Client) -> HashSet<i64> {
 }
 
 async fn resolve_block_hash(client: &Client, height: i64) -> Option<String> {
-    let url = format!("{}/block-index/{}", EXPLORER_BASE, height);
-    let res = get_with_backoff(client, &url).await?;
+    let res = explorer_get(client, &format!("/block-index/{}", height)).await?;
     let parsed: BlockIndexResponse = res.json().await.ok()?;
     Some(parsed.block_hash)
 }
@@ -534,8 +591,7 @@ async fn fetch_all_block_txs(client: &Client, block_hash: &str) -> Option<Vec<Ra
     let mut pages_total = 1i64;
 
     while page_num < pages_total {
-        let url = format!("{}/txs/?block={}&pageNum={}", EXPLORER_BASE, block_hash, page_num);
-        let res = get_with_backoff(client, &url).await?;
+        let res = explorer_get(client, &format!("/txs/?block={}&pageNum={}", block_hash, page_num)).await?;
         let page = res.json::<TxsPageResponse>().await.ok()?;
         pages_total = page.pages_total.max(1);
         all_txs.extend(page.txs);
@@ -683,9 +739,12 @@ pub async fn run_scan_cycle() {
         start_height,
         tip_height,
     ));
+    // Report the REMAINING count, not two absolute heights. "block 0 of
+    // 2,939,881" reads as a 2.9-million-block sync when the real work is the
+    // difference between them -- bounded by RETENTION_BLOCKS (23,040).
     println!(
-        "[chain_activity] scan starting: {} blocks to cover ({} -> {})",
-        tip_height - start_height, start_height, tip_height
+        "[chain_activity] scan starting: {} blocks remaining (heights {} -> {}, retention window {})",
+        tip_height - start_height, start_height, tip_height, RETENTION_BLOCKS
     );
 
     let deployment_heights = fetch_deployment_heights(&client).await;

--- a/client/src/analytics/topOwners.js
+++ b/client/src/analytics/topOwners.js
@@ -1,4 +1,5 @@
-const NODE_LIST_URL = 'https://explorer.runonflux.io/api/status?q=getFluxNodes';
+import { explorerFetchJson } from 'explorer';
+const NODE_LIST_PATH = '/status?q=getFluxNodes';
 export const DEFAULT_TOP_N = 20;
 
 /*
@@ -24,9 +25,8 @@ export function rankNodeOperators(nodes, topN = DEFAULT_TOP_N) {
 
 export async function fetch_top_node_operators(topN = DEFAULT_TOP_N) {
   try {
-    const res = await fetch(NODE_LIST_URL);
-    const data = await res.json();
-    const nodes = Array.isArray(data?.fluxNodes) ? data.fluxNodes : [];
+    const json = await explorerFetchJson(NODE_LIST_PATH);
+    const nodes = Array.isArray(json?.fluxNodes) ? json.fluxNodes : [];
     return rankNodeOperators(nodes, topN);
   } catch {
     return [];

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -6,6 +6,7 @@ import { categorizeAppSpec } from 'main/Gamification/appCategories';
 import { fetch_fluxinfo_aggregate } from 'fluxinfo';
 import { specResources, buildSpecIndex } from 'appSpecs';
 import { categorizeRunningApps } from 'runningAppsCategorized';
+import { explorerFetchJson } from 'explorer';
 import { OLD_ADDRESS_FLUX } from 'donor/config';
 import {
   fetch_node_benchmarks,
@@ -31,7 +32,7 @@ import {
 } from 'content/index';
 import { appStore, StoreKeys } from 'persistance/store';
 
-const API_FLUX_NODES_ALL_URL = 'https://explorer.runonflux.io/api/status?q=getFluxNodes';
+const API_FLUX_NODES_ALL_PATH = '/status?q=getFluxNodes';
 const API_FLUX_NODE_URL = 'https://api.runonflux.io/daemon/viewdeterministiczelnodelist?filter=';
 const API_DOS_LIST = 'https://api.runonflux.io/daemon/getdoslist';
 const API_NODE_BENCHMARKS = 'https://stats.runonflux.io/fluxinfo?projection=benchmark';
@@ -217,24 +218,18 @@ export function fill_rewards(gstore) {
  */
 export function fetch_total_donations(walletAddress) {
   return new Promise((resolve) => {
-    const safeFetchJson = async (url) => {
-      try {
-        const res = await fetch(url);
-        if (!res.ok) return null; // e.g. 400/500 - skip this page
-        const contentType = res.headers.get('content-type') || '';
-        if (!contentType.includes('application/json')) return null; // e.g. "Loading block index..."
-        return await res.json();
-      } catch (e) {
-        return null;
-      }
-    };
+    // Routed through the explorer pool (explorer.js) rather than one hardcoded
+    // host: a 429 on the primary now fails over instead of ending the scan.
+    // explorerFetchJson already rejects non-2xx and non-JSON bodies -- the
+    // "Loading block index..." text/plain case this used to handle by hand.
+    const safeFetchJson = (path) => explorerFetchJson(path);
 
     // Every page for one address. Returns null (not []) when the address could
     // not be read at all, so "explorer unreachable" stays distinguishable from
     // "this address has no donations".
     const scanAddress = async (address) => {
-      const baseUrl = 'https://explorer.runonflux.io/api/txs?address=' + address;
-      const firstPage = await safeFetchJson(baseUrl);
+      const basePath = '/txs?address=' + address;
+      const firstPage = await safeFetchJson(basePath);
       if (!firstPage) return null;
 
       const { pagesTotal } = firstPage;
@@ -243,7 +238,7 @@ export function fetch_total_donations(walletAddress) {
       // fetch pages sequentially (or in small batches) instead of all at once
       const pages = [firstPage];
       for (const page of pageNums) {
-        const json = await safeFetchJson(`${baseUrl}&pageNum=${page}`);
+        const json = await safeFetchJson(`${basePath}&pageNum=${page}`);
         if (json) pages.push(json);
       }
 
@@ -458,9 +453,8 @@ export async function fetch_global_stats(walletAddress = null) {
 
   const fetchCurrency = async () => {
     try {
-      const res = await fetch('https://explorer.runonflux.io/api/currency');
-      const json = await res.json();
-      store.flux_price_usd = json.data.rate;
+      const json = await explorerFetchJson('/currency');
+      if (json?.data?.rate != null) store.flux_price_usd = json.data.rate;
     } catch (error) {
       console.log('error', error);
     }
@@ -469,10 +463,11 @@ export async function fetch_global_stats(walletAddress = null) {
   const fetchWallet = async () => {
     try {
       if (walletAddress) {
-        const res = await fetch('https://explorer.runonflux.io/api/addr/' + walletAddress + '/?noTxList=1');
-        const json = await res.json();
-        const balance = json['balance'];
-        store.wallet_amount_flux = Math.round((balance + Number.EPSILON) * 100) / 100;
+        const json = await explorerFetchJson('/addr/' + walletAddress + '/?noTxList=1');
+        if (json && json.balance != null) {
+          const balance = json.balance;
+          store.wallet_amount_flux = Math.round((balance + Number.EPSILON) * 100) / 100;
+        }
       }
     } catch (error) {
       console.log('error', error);
@@ -547,9 +542,10 @@ export async function fetch_global_stats(walletAddress = null) {
 
   const fetchRichList = async () => {
     try {
-      const res = await fetch('https://explorer.runonflux.io/api/statistics/richest-addresses-list');
-      const json = await res.json();
-      store.in_rich_list = json.some((wAddress) => wAddress.address === walletAddress);
+      const json = await explorerFetchJson('/statistics/richest-addresses-list');
+      if (Array.isArray(json)) {
+        store.in_rich_list = json.some((wAddress) => wAddress.address === walletAddress);
+      }
     } catch (error) {
       console.log('error', error);
     }
@@ -1253,14 +1249,14 @@ export async function fetch_global_performance_rankings() {
   try {
     // benchmark and geolocation come from the shared fetchers so they are not
     // pulled a second time by fetch_total_network_utils / fetch_country_node_counts
-    const [nodesRes, benchData, geoData, countRes] = await Promise.all([
-      fetch(API_FLUX_NODES_ALL_URL),
+    const [nodesJsonRaw, benchData, geoData, countRes] = await Promise.all([
+      explorerFetchJson(API_FLUX_NODES_ALL_PATH),
       fetch_node_benchmarks(),
       fetch_node_geolocation(),
       fetch('https://api.runonflux.io/daemon/getzelnodecount'),
     ]);
 
-    const nodesJson = await nodesRes.json();
+    const nodesJson = nodesJsonRaw || {};
     const benchJson = { data: benchData };
     const geoJson = { data: geoData };
     const countJson = await countRes.json();

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -739,9 +739,12 @@ export async function getWalletNodes(walletAddress) {
       wNodes = (await res.json())?.data;
     } catch {}
   } else {
-    const listResponse = await fetch(API_FLUX_NODES_ALL_URL);
-    const data = await listResponse.json();
-    wNodes = data.fluxNodes.filter((n) => n.payment_address == walletAddress);
+    // Through the explorer pool: this is the wallet-search path, so a rate
+    // limit here means a user sees no nodes at all.
+    const data = await explorerFetchJson(API_FLUX_NODES_ALL_PATH);
+    wNodes = Array.isArray(data?.fluxNodes)
+      ? data.fluxNodes.filter((n) => n.payment_address == walletAddress)
+      : [];
   }
   return wNodes;
 }

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -472,10 +472,18 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
   function mockFetchByUrl() {
     global.fetch = jest.fn((url) => {
       const u = typeof url === 'string' ? url : '';
-      if (u.includes('getFluxNodes')) return Promise.resolve({ json: async () => FLUX_NODES });
-      if (u.includes('projection=benchmark')) return Promise.resolve({ json: async () => ({ status: 'success', data: BENCH_DATA }) });
-      if (u.includes('projection=geolocation')) return Promise.resolve({ json: async () => ({ status: 'success', data: GEO_DATA }) });
-      if (u.includes('getzelnodecount')) return Promise.resolve({ json: async () => NODE_COUNT });
+      // ok/status/headers included because a real Response always has them,
+      // and the explorer pool checks status before parsing a body.
+      const res = (body) => Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => body,
+      });
+      if (u.includes('getFluxNodes')) return res(FLUX_NODES);
+      if (u.includes('projection=benchmark')) return res({ status: 'success', data: BENCH_DATA });
+      if (u.includes('projection=geolocation')) return res({ status: 'success', data: GEO_DATA });
+      if (u.includes('getzelnodecount')) return res(NODE_COUNT);
       return Promise.reject(new Error(`unexpected fetch: ${u}`));
     });
   }

--- a/client/src/audit/d4TierResolutionAppSide.test.js
+++ b/client/src/audit/d4TierResolutionAppSide.test.js
@@ -31,16 +31,24 @@ const whenArmed = armed ? describe : describe.skip;
 // misassignment": the old code overshot Nimbus by 415 and Stratus by 222.
 const MAX_SHORTFALL = 150;
 
-whenArmed('#215 -- tier resolution against the live fixture', () => {
+const VALID = ['CUMULUS', 'NIMBUS', 'STRATUS'];
+
+/*
+ * Loaded lazily inside the tests, NOT in the describe body.
+ *
+ * `describe.skip` still EXECUTES its callback -- Jest evaluates it to build the
+ * test tree and only then marks the tests skipped. Reading fixtures at that
+ * level therefore throws on a fresh clone or in CI, where they do not exist,
+ * which is exactly the opposite of the "inert without fixtures" property this
+ * file is supposed to have. (It shipped that way in PR #217 and was caught the
+ * first time the suite ran in a worktree without fixtures.)
+ */
+function loadFixtures() {
   const nodes = JSON.parse(fs.readFileSync(NODES, 'utf8')).fluxNodes || [];
   const bench = JSON.parse(fs.readFileSync(BENCH, 'utf8')).data || [];
-  const official = (() => {
-    const raw = JSON.parse(fs.readFileSync(COUNTS, 'utf8'));
-    return raw.data || raw;
-  })();
-
+  const rawCounts = JSON.parse(fs.readFileSync(COUNTS, 'utf8'));
+  const official = rawCounts.data || rawCounts;
   const resolve = buildTierResolver(nodes);
-  const VALID = ['CUMULUS', 'NIMBUS', 'STRATUS'];
 
   const tally = { CUMULUS: 0, NIMBUS: 0, STRATUS: 0 };
   let unresolved = 0;
@@ -51,8 +59,13 @@ whenArmed('#215 -- tier resolution against the live fixture', () => {
     if (tier && VALID.includes(tier)) tally[tier] += 1;
     else unresolved += 1;
   }
+  return { nodes, official, resolve, tally, unresolved };
+}
+
+whenArmed('#215 -- tier resolution against the live fixture', () => {
 
   it.each(VALID)('%s total is at or below the daemon count, and close to it', (tier) => {
+    const { official, tally } = loadFixtures();
     const officialCount = official[`${tier.toLowerCase()}-enabled`] || 0;
     expect(officialCount).toBeGreaterThan(0);
 
@@ -64,6 +77,7 @@ whenArmed('#215 -- tier resolution against the live fixture', () => {
   });
 
   it('resolves nearly every benchmarked node', () => {
+    const { tally, unresolved } = loadFixtures();
     const total = Object.values(tally).reduce((a, b) => a + b, 0);
     expect(total).toBeGreaterThan(0);
     // A handful of benchmarked nodes have no matching fluxNodes entry at all;
@@ -72,6 +86,7 @@ whenArmed('#215 -- tier resolution against the live fixture', () => {
   });
 
   it('gives distinct tiers to nodes sharing a host, where the ports say so', () => {
+    const { nodes, resolve } = loadFixtures();
     // The bug in one assertion. Find a host whose entries span >1 tier and
     // confirm the resolver no longer flattens them.
     const byHost = new Map();

--- a/client/src/donor/donorStatus.js
+++ b/client/src/donor/donorStatus.js
@@ -1,3 +1,4 @@
+import { explorerFetchJson } from 'explorer';
 import { ADDRESS_FLUX } from 'content/index';
 import {
   DONOR_THRESHOLD_FLUX,
@@ -46,23 +47,23 @@ export function computeDonorStatus(records, nowMs = Date.now()) {
   return { isDonor: true, totalInWindow, expiresAt, daysLeft };
 }
 
-const TXS_BY_ADDRESS_ENDPOINT = 'https://explorer.runonflux.io/api/txs';
+const TXS_BY_ADDRESS_PATH = '/txs';
 // v2: fetch_donor_status now sums donations to BOTH the current and old
 // donation address (see donor/config.js's OLD_ADDRESS_FLUX) — bumped so a
 // wallet's pre-fix single-address cache entry can't silently under-count
 // for up to DONOR_STATUS_CACHE_TTL_MS after this ships.
 const DONOR_STATUS_CACHE_KEY = 'donorStatus_v2';
 
-async function safeFetchJson(url) {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    const contentType = res.headers.get('content-type') || '';
-    if (!contentType.includes('application/json')) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+/*
+ * Routed through the explorer pool rather than a single host. The
+ * null-on-failure contract is unchanged, so the caller's incomplete-scan
+ * handling (scanComplete) still behaves exactly as before -- but a rate
+ * limit on one host no longer ends the scan, since the other host is tried
+ * first. explorerFetchJson already rejects non-JSON bodies and non-2xx
+ * responses, which is what this wrapper used to do by hand.
+ */
+async function safeFetchJson(path) {
+  return explorerFetchJson(path);
 }
 
 // Sums every vout in `tx` paid to `address` — a tx can pay the same address
@@ -109,7 +110,7 @@ function writeDonorStatusCache(address, data) {
  * it.
  */
 async function scanDonationsTo(walletAddress, donationAddress, windowStartSec) {
-  const baseUrl = `${TXS_BY_ADDRESS_ENDPOINT}?address=${donationAddress}`;
+  const basePath = `${TXS_BY_ADDRESS_PATH}?address=${donationAddress}`;
 
   const records = [];
   let pageNum = 0;
@@ -117,8 +118,8 @@ async function scanDonationsTo(walletAddress, donationAddress, windowStartSec) {
   let hitWindowEdge = false;
 
   while (!hitWindowEdge && pageNum < pagesTotal && pageNum < DONOR_MAX_PAGES_FETCHED) {
-    const url = pageNum === 0 ? baseUrl : `${baseUrl}&pageNum=${pageNum}`;
-    const json = await safeFetchJson(url);
+    const path = pageNum === 0 ? basePath : `${basePath}&pageNum=${pageNum}`;
+    const json = await safeFetchJson(path);
     if (!json) break; // explorer unreachable partway through — incomplete scan, see scanComplete below
 
     pagesTotal = json.pagesTotal || 1;

--- a/client/src/donor/donorStatus.test.js
+++ b/client/src/donor/donorStatus.test.js
@@ -1,4 +1,5 @@
 import { computeDonorStatus, fetch_donor_status } from './donorStatus';
+import { EXPLORER_HOSTS } from 'explorer';
 import { OLD_ADDRESS_FLUX } from './config';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -127,6 +128,19 @@ describe('fetch_donor_status', () => {
   // an empty, complete old-address page right after whatever mocks the
   // test itself set up for the current address — same "no donations
   // found, scan complete" shape a real empty history would produce.
+  /*
+   * "Unreachable" means EVERY explorer host failed, not just one.
+   * donorStatus now fetches through the explorer pool (src/explorer.js), which
+   * fails over on a rate limit -- so simulating an outage needs one rejection
+   * per host, not one per address. Deriving the count from EXPLORER_HOSTS keeps
+   * these tests correct if a third host is ever added.
+   */
+  function mockAddressUnreachable() {
+    for (let i = 0; i < EXPLORER_HOSTS.length; i++) {
+      global.fetch.mockRejectedValueOnce(new Error('network down'));
+    }
+  }
+
   function mockEmptyOldAddressScan() {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({ pagesTotal: 1, txs: [] }));
   }
@@ -221,9 +235,8 @@ describe('fetch_donor_status', () => {
   });
 
   it('fails soft — not a donor, not a throw — when the explorer is unreachable', async () => {
-    global.fetch
-      .mockRejectedValueOnce(new Error('network down')) // current address
-      .mockRejectedValueOnce(new Error('network down')); // old address
+    // Every host, both addresses: a total outage.
+    global.fetch.mockRejectedValue(new Error('network down'));
 
     await expect(fetch_donor_status(WALLET)).resolves.toEqual(
       expect.objectContaining({ isDonor: false })
@@ -231,16 +244,16 @@ describe('fetch_donor_status', () => {
   });
 
   it('does not cache a result from a failed fetch — retry will re-attempt the network call', async () => {
-    global.fetch
-      .mockRejectedValueOnce(new Error('network down')) // 1st call, current address
-      .mockRejectedValueOnce(new Error('network down')) // 1st call, old address
-      .mockRejectedValueOnce(new Error('network down')) // 2nd call, current address
-      .mockRejectedValueOnce(new Error('network down')); // 2nd call, old address
+    // Every host, both addresses, both calls: a sustained outage.
+    global.fetch.mockRejectedValue(new Error('network down'));
 
     const first = await fetch_donor_status(WALLET);
     const second = await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(4); // both scans, both calls — no cache from failure
+    // 2 fetch_donor_status calls x 2 addresses x every host (the pool tries
+    // each before giving up). The point of the assertion is unchanged: the
+    // second call re-hit the network rather than serving a cached failure.
+    expect(global.fetch).toHaveBeenCalledTimes(2 * 2 * EXPLORER_HOSTS.length);
     expect(first).toEqual(expect.objectContaining({ isDonor: false }));
     expect(second).toEqual(expect.objectContaining({ isDonor: false }));
   });
@@ -259,7 +272,8 @@ describe('fetch_donor_status', () => {
         pagesTotal: 3,
         txs: [realDonationTx({ blockheight: 200, time: nowSec - 5 * 86400, amount: 2 })],
       }))
-      .mockRejectedValueOnce(new Error('network down'));
+      ;
+    mockAddressUnreachable(); // page 2 unreachable on every host
     mockEmptyOldAddressScan();
 
     const first = await fetch_donor_status(WALLET);
@@ -274,12 +288,15 @@ describe('fetch_donor_status', () => {
         pagesTotal: 3,
         txs: [realDonationTx({ blockheight: 200, time: nowSec - 5 * 86400, amount: 2 })],
       }))
-      .mockRejectedValueOnce(new Error('network down'));
+      ;
+    mockAddressUnreachable(); // page 2 unreachable on every host
     mockEmptyOldAddressScan();
 
     await fetch_donor_status(WALLET);
 
-    expect(global.fetch).toHaveBeenCalledTimes(6); // 3 calls per attempt (2 current-address pages + 1 old-address) x 2 attempts
+    // Per attempt: page 1 succeeds (1), page 2 fails on every host
+    // (EXPLORER_HOSTS.length), old-address scan succeeds (1). Twice.
+    expect(global.fetch).toHaveBeenCalledTimes(2 * (1 + EXPLORER_HOSTS.length + 1));
   });
 
   it('counts a donation sent to the OLD donation address toward the threshold', async () => {
@@ -312,7 +329,7 @@ describe('fetch_donor_status', () => {
       pagesTotal: 1,
       txs: [realDonationTx({ blockheight: 500, time: nowSec - 10 * 86400, amount: 15 })],
     }));
-    global.fetch.mockRejectedValueOnce(new Error('network down')); // old address unreachable
+    mockAddressUnreachable(); // old address unreachable on every host
 
     const result = await fetch_donor_status(WALLET);
 
@@ -323,7 +340,10 @@ describe('fetch_donor_status', () => {
     // re-hit the unreachable old address) on every subsequent check.
     const second = await fetch_donor_status(WALLET);
     expect(second).toEqual(result);
-    expect(global.fetch).toHaveBeenCalledTimes(2); // only from the first call
+    // 1 successful current-address fetch + one failed attempt per host for
+    // the unreachable old address, all from the FIRST call -- the second
+    // served from cache and added nothing.
+    expect(global.fetch).toHaveBeenCalledTimes(1 + EXPLORER_HOSTS.length);
   });
 
   it('sums donations split across both the old and new donation address', async () => {
@@ -349,7 +369,7 @@ describe('fetch_donor_status', () => {
 
   it('an unreachable old address alone is enough to make an otherwise-empty result unverified', async () => {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({ pagesTotal: 1, txs: [] })); // current address: clean, empty scan
-    global.fetch.mockRejectedValueOnce(new Error('network down')); // old address: unreachable
+    mockAddressUnreachable(); // old address: unreachable on every host
 
     const result = await fetch_donor_status(WALLET);
 

--- a/client/src/explorer.js
+++ b/client/src/explorer.js
@@ -1,0 +1,154 @@
+/*
+ * Shared, failing-over access to the Flux block explorer.
+ *
+ * WHY THIS EXISTS -- the problem was misdiagnosed for a long time.
+ *
+ * The console fills with:
+ *
+ *   Access to fetch at 'https://explorer.runonflux.io/api/...' has been blocked
+ *   by CORS policy: No 'Access-Control-Allow-Origin' header is present
+ *
+ * That is not a CORS misconfiguration. Measured 2026-09-11:
+ *
+ *   explorer.runonflux.io      -> HTTP 429, Retry-After: 31, NO CORS headers
+ *   explorer.app.runonflux.io  -> HTTP 200, access-control-allow-origin: *
+ *
+ * A rate-limited response omits the CORS headers, so the browser refuses to
+ * surface the 429 to JS and reports a CORS violation instead. Every one of
+ * those errors is a rate limit wearing a CORS costume. Chasing CORS config
+ * would have found nothing, because nothing is misconfigured.
+ *
+ * Both hosts are fallible -- the secondary returned a transient 503 during the
+ * same session -- so this is a POOL with bidirectional failover rather than a
+ * primary with a spare. A failing host is benched; the next healthy host serves
+ * the request; bench windows expire so a recovered host returns to rotation
+ * without needing a reload.
+ *
+ * Benching is the part that actually matters for rate limits. Without it every
+ * call would re-attempt the throttled host first, spending a request to be told
+ * "no" and making the limit worse -- which is precisely how a rate limit turns
+ * into a self-sustaining outage.
+ */
+
+export const EXPLORER_HOSTS = [
+  'https://explorer.runonflux.io/api',
+  'https://explorer.app.runonflux.io/api',
+];
+
+// Used when a host fails without telling us for how long (network error, 5xx,
+// or a 429 with no Retry-After). Long enough to stop hammering, short enough
+// that a blip does not cost minutes of degraded data.
+const DEFAULT_BENCH_MS = 30 * 1000;
+
+// Hard ceiling on anything a server asks for. A hostile or mistaken
+// `Retry-After: 86400` must not bench a host for the rest of the session.
+const MAX_BENCH_MS = 5 * 60 * 1000;
+
+const health = Object.create(null);
+for (const host of EXPLORER_HOSTS) {
+  health[host] = { benchedUntil: 0, lastError: null };
+}
+
+function bench(host, ms, reason) {
+  const duration = Math.min(Math.max(ms, 0), MAX_BENCH_MS);
+  health[host].benchedUntil = Date.now() + duration;
+  health[host].lastError = reason;
+}
+
+/*
+ * `Retry-After` is defined as either delta-seconds or an HTTP-date. Only the
+ * numeric form is honoured: the explorer sends seconds, and mis-parsing a date
+ * into a huge bench would be worse than falling back to the default.
+ */
+function retryAfterMs(response) {
+  try {
+    const raw = response.headers?.get?.('retry-after');
+    if (!raw) return null;
+    const seconds = Number(raw);
+    if (!Number.isFinite(seconds) || seconds <= 0) return null;
+    return seconds * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET `path` from the first healthy explorer, returning parsed JSON.
+ *
+ * Resolves `null` when every host fails. Call sites in this codebase fail soft
+ * (donations resolve 0, chain activity returns empty defaults), so throwing
+ * here would turn a degraded page into a blank one.
+ *
+ * @param {string} path e.g. '/blocks?limit=1' (a leading slash is optional)
+ * @param {{ signal?: AbortSignal }} [options]
+ */
+export async function explorerFetchJson(path, options = {}) {
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  const now = Date.now();
+
+  // Healthy hosts first, in declared order; then benched ones as a last
+  // resort. A benched host is still better than no answer at all when every
+  // host is benched -- but it is never preferred over a healthy one.
+  const healthy = EXPLORER_HOSTS.filter((h) => health[h].benchedUntil <= now);
+  const benched = EXPLORER_HOSTS.filter((h) => health[h].benchedUntil > now);
+  const order = healthy.length > 0 ? healthy : benched;
+
+  for (const host of order) {
+    const url = `${host}${suffix}`;
+    let response;
+    try {
+      response = await fetch(url, { signal: options.signal });
+    } catch (error) {
+      // A rejected fetch is what a blocked-by-CORS 429 looks like from JS:
+      // there is no status to inspect, only a TypeError.
+      bench(host, DEFAULT_BENCH_MS, `network: ${error?.message || error}`);
+      continue;
+    }
+
+    if (response.status === 429) {
+      const wait = retryAfterMs(response) ?? DEFAULT_BENCH_MS;
+      bench(host, wait, 'rate limited (429)');
+      console.log(`[explorer] ${host} rate-limited, benched ${Math.round(wait / 1000)}s`);
+      continue;
+    }
+
+    if (!response.ok) {
+      bench(host, DEFAULT_BENCH_MS, `http ${response.status}`);
+      continue;
+    }
+
+    try {
+      return await response.json();
+    } catch (error) {
+      // The explorer serves `Loading block index...` as text/plain with a 200
+      // while it is starting up. Treat it as a failed host, not as data.
+      bench(host, DEFAULT_BENCH_MS, 'non-JSON body');
+      continue;
+    }
+  }
+
+  console.log(`[explorer] all hosts unavailable for ${suffix}`);
+  return null;
+}
+
+/** Absolute URL on the currently-preferred host, for links and non-JSON uses. */
+export function explorerUrl(path) {
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  const now = Date.now();
+  const host = EXPLORER_HOSTS.find((h) => health[h].benchedUntil <= now) || EXPLORER_HOSTS[0];
+  return `${host}${suffix}`;
+}
+
+// ── test hooks ───────────────────────────────────────────────────────────────
+// Exported so the failover logic is testable without waiting out real bench
+// windows. Not part of the public surface; nothing in src/ should call these.
+
+export function __resetExplorerHealth() {
+  for (const host of EXPLORER_HOSTS) {
+    health[host] = { benchedUntil: 0, lastError: null };
+  }
+}
+
+export function __explorerHealth() {
+  return health;
+}

--- a/client/src/explorer.test.js
+++ b/client/src/explorer.test.js
@@ -1,0 +1,169 @@
+import { explorerFetchJson, EXPLORER_HOSTS, __resetExplorerHealth, __explorerHealth } from './explorer';
+
+/*
+ * Explorer failover.
+ *
+ * The bug this fixes was misdiagnosed for a long time as a CORS
+ * misconfiguration. It is not. Measured 2026-09-11:
+ *
+ *   explorer.runonflux.io      -> HTTP 429, Retry-After: 31, and NO
+ *                                 access-control-allow-origin header
+ *   explorer.app.runonflux.io  -> HTTP 200, access-control-allow-origin: *
+ *
+ * A rate-limited response omits CORS headers, so the browser cannot read the
+ * 429 and reports "blocked by CORS policy" instead. Every one of those console
+ * errors was a rate limit wearing a CORS costume. Nothing was misconfigured.
+ *
+ * Both hosts are fallible -- the secondary returned a transient 503 during the
+ * same testing session -- so this is a POOL with bidirectional failover, not a
+ * primary with a spare. A host that fails is benched and the other is used;
+ * benching expires so a recovered host comes back into rotation.
+ */
+
+function jsonResponse(body, { status = 200, headers = {} } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => headers[name.toLowerCase()] ?? null },
+    json: () => Promise.resolve(body),
+  };
+}
+
+const [PRIMARY, SECONDARY] = EXPLORER_HOSTS;
+
+beforeEach(() => {
+  __resetExplorerHealth();
+  jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('explorerFetchJson', () => {
+  it('uses the primary host when it is healthy', async () => {
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+    await expect(explorerFetchJson('/blocks?limit=1')).resolves.toEqual({ ok: true });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(`${PRIMARY}/blocks?limit=1`);
+  });
+
+  it('falls over to the secondary on a 429', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY)
+          ? jsonResponse('Too Many Requests', { status: 429, headers: { 'retry-after': '31' } })
+          : jsonResponse({ from: 'secondary' })
+      )
+    );
+    await expect(explorerFetchJson('/blocks')).resolves.toEqual({ from: 'secondary' });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('benches a 429ing host for its Retry-After, skipping it on the next call', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY)
+          ? jsonResponse('', { status: 429, headers: { 'retry-after': '31' } })
+          : jsonResponse({ from: 'secondary' })
+      )
+    );
+
+    await explorerFetchJson('/one');
+    expect(global.fetch).toHaveBeenCalledTimes(2); // primary tried, then secondary
+
+    global.fetch.mockClear();
+    await explorerFetchJson('/two');
+    // The whole point: a benched host is not retried on every subsequent call.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(`${SECONDARY}/two`);
+  });
+
+  it('honours Retry-After rather than guessing a cooldown', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY)
+          ? jsonResponse('', { status: 429, headers: { 'retry-after': '31' } })
+          : jsonResponse({})
+      )
+    );
+    await explorerFetchJson('/x');
+    expect(__explorerHealth()[PRIMARY].benchedUntil).toBe(1_000_000 + 31_000);
+  });
+
+  it('brings a host back into rotation once its bench expires', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY)
+          ? jsonResponse('', { status: 429, headers: { 'retry-after': '5' } })
+          : jsonResponse({ from: 'secondary' })
+      )
+    );
+    await explorerFetchJson('/x');
+
+    // Primary recovers, and time moves past the bench.
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse({ from: 'primary-again' })));
+    Date.now.mockReturnValue(1_000_000 + 6_000);
+
+    await expect(explorerFetchJson('/y')).resolves.toEqual({ from: 'primary-again' });
+    expect(global.fetch.mock.calls[0][0]).toBe(`${PRIMARY}/y`);
+  });
+
+  it('falls over on a network error, not only on a 429', async () => {
+    // This is what a blocked-by-CORS failure actually looks like to fetch():
+    // a rejected promise with no status to inspect.
+    global.fetch = jest.fn((url) =>
+      url.startsWith(PRIMARY)
+        ? Promise.reject(new TypeError('Failed to fetch'))
+        : Promise.resolve(jsonResponse({ from: 'secondary' }))
+    );
+    await expect(explorerFetchJson('/x')).resolves.toEqual({ from: 'secondary' });
+  });
+
+  it('falls over on a 5xx', async () => {
+    // The secondary returned a transient 503 during testing; neither host is
+    // assumed reliable.
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY) ? jsonResponse('', { status: 503 }) : jsonResponse({ from: 'secondary' })
+      )
+    );
+    await expect(explorerFetchJson('/x')).resolves.toEqual({ from: 'secondary' });
+  });
+
+  it('falls over when a host returns non-JSON (the "Loading block index..." case)', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve(
+        url.startsWith(PRIMARY)
+          ? { ok: true, status: 200, headers: { get: () => 'text/plain' }, json: () => Promise.reject(new Error('not json')) }
+          : jsonResponse({ from: 'secondary' })
+      )
+    );
+    await expect(explorerFetchJson('/x')).resolves.toEqual({ from: 'secondary' });
+  });
+
+  it('resolves null when every host fails, rather than throwing', async () => {
+    // Call sites across this codebase fail soft (donations resolve 0, chain
+    // activity returns empty defaults). Throwing here would turn a degraded
+    // page into a blank one.
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse('', { status: 429 })));
+    await expect(explorerFetchJson('/x')).resolves.toBeNull();
+  });
+
+  it('does not bench every host permanently when all are failing', async () => {
+    // If a total outage benched both hosts forever, recovery would need a page
+    // reload. Bench windows must still expire.
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse('', { status: 429 })));
+    await explorerFetchJson('/x');
+    for (const host of EXPLORER_HOSTS) {
+      expect(__explorerHealth()[host].benchedUntil).toBeGreaterThan(Date.now());
+      expect(__explorerHealth()[host].benchedUntil).toBeLessThan(Date.now() + 10 * 60 * 1000);
+    }
+  });
+
+  it('accepts a path with or without a leading slash', async () => {
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse({})));
+    await explorerFetchJson('blocks');
+    expect(global.fetch.mock.calls[0][0]).toBe(`${PRIMARY}/blocks`);
+  });
+});

--- a/client/src/live/apidata.js
+++ b/client/src/live/apidata.js
@@ -1,3 +1,5 @@
+import { explorerFetchJson } from 'explorer';
+
 // ── Recent blocks ────────────────────────────────────────────────────────────
 
 /*
@@ -7,13 +9,14 @@
  * chain rail: available immediately on page load, and a plain public HTTPS
  * endpoint with no proxy-mode or arbitrary-node-reachability requirement.
  */
-const RECENT_BLOCKS_ENDPOINT = 'https://explorer.runonflux.io/api/blocks';
-const TXS_BY_BLOCK_ENDPOINT = 'https://explorer.runonflux.io/api/txs/';
+// Paths only: explorerFetchJson picks a healthy host and fails over on a
+// rate limit. See explorer.js -- those 'CORS' errors were 429s in disguise.
+const RECENT_BLOCKS_PATH = '/blocks';
+const TXS_BY_BLOCK_PATH = '/txs/';
 
 export async function fetch_recent_blocks(limit = 6) {
   try {
-    const res = await fetch(`${RECENT_BLOCKS_ENDPOINT}?limit=${limit}`);
-    const json = await res.json();
+    const json = await explorerFetchJson(`${RECENT_BLOCKS_PATH}?limit=${limit}`);
     const blocks = Array.isArray(json?.blocks) ? json.blocks : [];
 
     return blocks.map((b) => ({
@@ -33,8 +36,10 @@ export async function fetch_recent_blocks(limit = 6) {
 // rewards/confirmations and P2P transfers from respectively.
 export async function fetch_block_transactions(blockHash) {
   try {
-    const res = await fetch(`${TXS_BY_BLOCK_ENDPOINT}?block=${blockHash}`);
-    const json = await res.json();
+    const json = await explorerFetchJson(`${TXS_BY_BLOCK_PATH}?block=${blockHash}`);
+    // A null means every explorer host failed. Report that as not-ok rather
+    // than as a block that genuinely had no transactions.
+    if (json === null) return { ok: false, coinbase: null, others: [] };
     const txs = Array.isArray(json?.txs) ? json.txs : [];
     const coinbase = txs.find((t) => t.isCoinBase) || txs[0] || null;
     const others = txs.filter((t) => t !== coinbase);

--- a/client/src/live/apidata.test.js
+++ b/client/src/live/apidata.test.js
@@ -51,7 +51,7 @@ describe('fetch_block_transactions / fetch_block_confirmations ok contract', () 
     });
 
     it('returns ok:true for a valid response that simply has no transactions', async () => {
-      global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ txs: [] }) });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, headers: { get: () => 'application/json' }, json: async () => ({ txs: [] }) });
       await expect(fetch_block_transactions('somehash')).resolves.toEqual({ ok: true, coinbase: null, others: [] });
     });
   });
@@ -63,7 +63,7 @@ describe('fetch_block_transactions / fetch_block_confirmations ok contract', () 
     });
 
     it('returns ok:true for a valid response with no confirming transactions in the block', async () => {
-      global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ data: { tx: [] } }) });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, headers: { get: () => 'application/json' }, json: async () => ({ data: { tx: [] } }) });
       await expect(fetch_block_confirmations('somehash')).resolves.toEqual({ ok: true, confirmingTxs: [] });
     });
   });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -17,6 +17,12 @@
  * silently.
  */
 
+// The explorer pool (explorer.js) benches unhealthy hosts in module-level
+// state. Reset it between tests so one test's simulated outage cannot
+// change which host the next test talks to.
+const { __resetExplorerHealth } = require('explorer');
+beforeEach(() => __resetExplorerHealth());
+
 window.gContent = {
   URL_YOUTUBE: 'https://www.youtube.com/channel/UCO-gfYYQL22oibzOjr1SnHA',
   URL_TWITTER: 'https://twitter.com/2ndTLMining',


### PR DESCRIPTION
Fixes three of the seven items from Docker testing. They are **one root cause**.

## The diagnosis was wrong, and misleadingly so

The console is full of:

```
Access to fetch at 'https://explorer.runonflux.io/api/...' has been blocked
by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

**Nothing is misconfigured.** Measured 2026-09-11:

```
explorer.runonflux.io      -> HTTP 429, Retry-After: 31, NO CORS headers
explorer.app.runonflux.io  -> HTTP 200, access-control-allow-origin: *
```

A rate-limited response omits CORS headers, so the browser can't surface the 429 to JS and reports a CORS violation instead. **Every one of those errors is a rate limit wearing a CORS costume.** The giveaway was already in the report — `/api/currency` logged a `429` *and* a CORS error together.

Chasing CORS configuration would have found nothing, because there is nothing wrong with it.

## The fix: a pool, not a fallback

`client/src/explorer.js` — bidirectional failover across both hosts. Not "primary with a spare": the secondary returned a transient **503** during the same testing session, so neither host is assumed reliable.

A failing host is **benched** (honouring `Retry-After`, capped at 5 min); the other serves the request; bench windows expire so a recovered host returns without a reload.

**Benching is the part that matters.** Without it every call re-attempts the throttled host first, spending a request to be told "no" and making the limit worse — which is how a rate limit becomes a self-sustaining outage.

All 8 client call sites now route through it: `apidata.js` (node list ×2, donations, currency, address balance, rich list), `donorStatus.js`, `topOwners.js`, `live/apidata.js`. The two `<a href>` explorer links are untouched.

## Item 6 — Chain Activity showing nothing

Same root cause, sharper edge. `chain_activity.rs` backed off **up to 62 seconds** on a 429 against a *single* host. A cold start is 23,040 blocks at 2+ requests each, so the backfill never finished — exactly the reported `block 0 of 2939881`.

`explorer_get()` now tries **every host before sleeping**: a 429 on one host says nothing about the other, and switching costs one request versus 62 seconds.

That log line is fixed too — `block 0 of 2939881` reads as a 2.9-million-block sync, when the real work is the difference between the heights, bounded by `RETENTION_BLOCKS` (23,040). It now reports the remaining count.

## Two test-quality problems this surfaced

**`d4TierResolutionAppSide.test.js` (shipped in #217) was not inert without fixtures**, contrary to what that PR claimed. `describe.skip` still *executes* its callback — Jest evaluates it to build the test tree — so the top-level `fs.readFileSync` threw on any clone without fixtures. It passed in #217 only because that worktree had them. **A fresh clone or CI would have failed.** Fixture reads moved inside the tests.

**Several existing mocks returned objects with only `json()`** — no `ok`, `status` or `headers`. A real `Response` always has them, and the pool checks status *before* parsing, correctly, since that's exactly how a 429 is told apart from data. Making those mocks realistic was required, not cosmetic.

`donorStatus`'s "unreachable" tests now fail every host rather than one, and its call-count assertions are expressed via `EXPLORER_HOSTS.length` so they stay correct if a third host is added.

## Honest gaps

- **The Rust change is not compiled.** There is no cargo toolchain on this machine. Reviewed for consistency instead: `get_with_backoff` still serves the app-specs URL (no dead code), all three explorer callers use `explorer_get`, no stale `EXPLORER_BASE` refs. **It needs a real build before merge.**
- A second `API_FLUX_NODES_ALL_URL` use was missed on the first pass and caught by the **build**, not the 482 passing tests. Green tests are not a substitute for a compile — worth remembering given how much of this work is verified by suite alone.

Client: **482 tests / 33 suites pass**, 6 skipped (audit tests, now genuinely inert). Build exit 0.

Remaining items from your report — 2 (donor gating on `/nodes`), 3 & 4 (Apps tab layout + Flux-team tooltip), 5 (world map) — are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)