### PR TITLE
Blur /nodes Achievements and Apps behind the donor gate (item 2)

### DIFF
--- a/client/src/analytics/panelAccess.js
+++ b/client/src/analytics/panelAccess.js
@@ -29,6 +29,14 @@ export const PANEL_ACCESS = {
   donorTab: 'donor',
   // Chain Activity tab (whole tab, one unit)
   chainActivity: 'donor',
+  // /nodes page tabs. Gated so a visitor can SEE that achievements and a
+  // per-wallet app breakdown exist behind the wall, rather than not knowing
+  // they are there at all -- which is the whole point of preview="blur".
+  // Both are derived from public, unauthenticated Flux APIs (node benchmarks,
+  // running-app lists), so mounting them blurred is a paywall choice, not a
+  // data-exposure one. See PanelGate's own note on that distinction.
+  nodesAchievements: 'donor',
+  nodesApps: 'donor',
   // Moving from /home in Session 2 — public per explicit user direction
   topDogs: 'public',
   expiringToday: 'public',

--- a/client/src/analytics/panelAccess.test.js
+++ b/client/src/analytics/panelAccess.test.js
@@ -18,6 +18,19 @@ describe('getPanelAccess', () => {
     expect(getPanelAccess('somethingNotInTheConfig', false)).toBe(false);
   });
 
+  it('the /nodes achievement and app tabs are donor-gated', () => {
+    // These gate a searched wallet's own achievements and app breakdown behind
+    // the donation threshold, blurred rather than hidden so a visitor can see
+    // the feature exists. Pinned here because silently flipping either to
+    // 'public' would give away the premium tier with no other test failing.
+    for (const key of ['nodesAchievements', 'nodesApps']) {
+      expect(PANEL_ACCESS).toHaveProperty(key);
+      expect(PANEL_ACCESS[key]).toBe('donor');
+      expect(getPanelAccess(key, false)).toBe(false);
+      expect(getPanelAccess(key, true)).toBe(true);
+    }
+  });
+
   it('every currently-rendered Analytics panel has an explicit entry', () => {
     const required = [
       'appsTeamSponsoredStat', 'appEcosystem', 'topHostedApps',

--- a/client/src/components/NodeGridTable/index.jsx
+++ b/client/src/components/NodeGridTable/index.jsx
@@ -19,6 +19,10 @@ import { FiServer, FiPackage } from 'react-icons/fi';
 import { LayoutContext } from 'contexts/LayoutContext';
 import { GamificationSection } from 'main/Gamification';
 import { AppsSection } from 'main/AppsSection';
+// Lives under analytics/ for historical reasons -- it is a donor-gating
+// component, not an analytics-specific one, and panelAccess.js is the
+// single place that decides which panels are gated.
+import { PanelGate } from 'analytics/PanelGate';
 import { computeAchievements } from 'main/Gamification/achievements';
 
 export const NodeGridTable = ({
@@ -304,17 +308,21 @@ export const NodeGridTable = ({
 
       {activeTab === 'achievements' ? (
         <div className='gami-panel-scroll'>
-          <GamificationSection
-            gstore={gstore}
-            walletNodes={data}
-            walletPASummary={walletPASummary}
-            totalDonations={totalDonations}
-            globalRankings={globalRankings}
-          />
+          <PanelGate panelKey='nodesAchievements' feature='Achievements' preview='blur'>
+            <GamificationSection
+              gstore={gstore}
+              walletNodes={data}
+              walletPASummary={walletPASummary}
+              totalDonations={totalDonations}
+              globalRankings={globalRankings}
+            />
+          </PanelGate>
         </div>
       ) : activeTab === 'apps' ? (
         <div className='gami-panel-scroll'>
-          <AppsSection walletNodes={data} gstore={gstore} />
+          <PanelGate panelKey='nodesApps' feature='Your apps breakdown' preview='blur'>
+            <AppsSection walletNodes={data} gstore={gstore} />
+          </PanelGate>
         </div>
       ) : (
         <div className={appTheme === 'dark' ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'} style={{ height: '100%' }}>


### PR DESCRIPTION
Item 2 of the Docker testing report.

When a wallet is entered on `/nodes`, its **Achievements** and **Apps** tabs now render normally for qualifying donors, and blurred behind the donation threshold for everyone else.

## Mostly wiring — the pieces already existed

| Piece | Status |
|---|---|
| `PanelGate` `preview="blur"` — real content, blurred + scrimmed under an unlock card | shipped in #201 |
| `PremiumUnlock` copy: *"Send at least {DONOR_THRESHOLD_FLUX} FLUX … within the year"* | already reads from `donor/config.js` |
| `runDonorAutoDetect` firing on wallet entry | already wired into `MainApp` |

So this is two `panelAccess.js` keys plus two wrapped sections. **The threshold text is config-driven** — change `DONOR_THRESHOLD_FLUX` and every gate updates; nothing is hardcoded.

## Two deliberate choices

**Blurred, not hidden.** A visitor should be able to see that achievements and a per-wallet app breakdown exist behind the wall. Hiding them tells nobody there's anything to unlock — which defeats the point.

**The tabs stay visible and clickable**; only their content is gated.

## On the DOM-exposure question

`preview="blur"` deliberately mounts the real content into the DOM, CSS-blurred rather than omitted — so the values are readable in devtools. That's worth being explicit about.

It's the right call here: both sections derive from **public, unauthenticated Flux APIs** (node benchmarks, running-app lists), so blurring is a paywall choice, not a data-exposure one. `PanelGate`'s own comment draws exactly that line. A section showing genuinely private data would want `preview="plain"` instead.

## Verification

483 tests / 33 suites pass, build exit 0. The new `panelAccess` test pins both keys as `'donor'` — flipping either to `'public'` would give the premium tier away with nothing else failing.

**Not verified:** the actual blur rendering. Needs a look in a browser with and without a qualifying donor wallet.

Related: #211, which covers the wider donor-value feature including the 7-day transaction view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)