### PR TITLE
Rebuild the Apps tab top section, make Flux-team-sponsored inspectable (items 3 & 4)

### DIFF
--- a/client/src/analytics/AppsTab/index.jsx
+++ b/client/src/analytics/AppsTab/index.jsx
@@ -9,6 +9,7 @@ import { CategoryTooltip } from 'components/CategoryTooltip';
 import { WorkhorsePanel } from 'home/WorkhorsePanel';
 import { rankNodeOperators, aggregateOwnerTotals, DEFAULT_TOP_N } from 'analytics/topOwners';
 import { FLUX_TEAM_OWNER_ZELIDS, computeTeamSponsoredShare } from 'analytics/teamSponsored';
+import { buildTeamAppRows, formatExpiry } from 'analytics/teamApps';
 import { PanelGate } from 'analytics/PanelGate';
 import './index.scss';
 
@@ -178,8 +179,145 @@ function RankedAddressList({ title, rows, valueLabel, teamZelids = [] }) {
   );
 }
 
+function fmtDec(n, digits = 1) {
+  if (n == null) return '\u2014';
+  return n.toLocaleString(undefined, { maximumFractionDigits: digits });
+}
+
+/* One cell of the KPI strip. Passing `onClick` turns it into a real button. */
+function KpiTile({ value, label, hint, onClick, expanded }) {
+  const body = (
+    <>
+      <span className="apps-kpi-value">{value}</span>
+      <span className="apps-kpi-label">
+        {label}
+        {hint && <span className="apps-kpi-hint" aria-hidden="true">{'\u24d8'}</span>}
+      </span>
+    </>
+  );
+
+  const tile = onClick ? (
+    <button
+      type="button"
+      className={`hov-panel apps-kpi apps-kpi--interactive${expanded ? ' apps-kpi--expanded' : ''}`}
+      onClick={onClick}
+      aria-expanded={expanded}
+      aria-controls="apps-team-detail"
+    >
+      {body}
+      <span className="apps-kpi-chevron" aria-hidden="true">{expanded ? '\u25b4' : '\u25be'}</span>
+    </button>
+  ) : (
+    <div className="hov-panel apps-kpi">{body}</div>
+  );
+
+  return hint ? (
+    <Tooltip2 content={hint} placement="bottom" hoverOpenDelay={200} transitionDuration={80}>
+      {tile}
+    </Tooltip2>
+  ) : tile;
+}
+
+/*
+ * The apps behind the Flux-team-sponsored percentage.
+ *
+ * The stat alone asserts that one owner runs roughly half the network's ordered
+ * instances, with no way to check it. This is the evidence: which apps, how many
+ * instances each, and what they cost. Sorted by instance count because that is
+ * what the percentage is made of -- one app at 100 instances outweighs fifty at
+ * one instance each.
+ */
+function TeamAppsDetail({ rawSpecs, currentBlock }) {
+  const { rows, totalApps, totalInstances, totalCpu, totalRamGB, totalSsdGB } =
+    buildTeamAppRows(rawSpecs, currentBlock);
+
+  if (rows.length === 0) {
+    return (
+      <div className="hov-panel apps-team-detail" id="apps-team-detail">
+        <div className="hov-empty">No Flux-team-owned apps found in the current spec set</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hov-panel apps-team-detail" id="apps-team-detail">
+      <div className="hov-header">
+        <span className="hov-header-title">FLUX-TEAM-SPONSORED APPS</span>
+        <span className="hov-header-badge">
+          {fmtNum(totalApps)} apps &middot; {fmtNum(totalInstances)} instances
+        </span>
+      </div>
+
+      <div className="apps-team-scroll">
+        <table className="apps-team-table">
+          <thead>
+            <tr>
+              <th>App</th>
+              <th>Repository</th>
+              <th className="apps-team-num">Instances</th>
+              <th className="apps-team-num">CPU</th>
+              <th className="apps-team-num">RAM</th>
+              <th className="apps-team-num">SSD</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const expiry = formatExpiry(row.expiresInBlocks);
+              return (
+                <tr key={row.name}>
+                  <td className="apps-team-name" title={row.name}>{row.name}</td>
+                  <td className="apps-team-repo" title={row.repotag || ''}>
+                    {row.repotag || (row.isEnterprise
+                      ? <span className="apps-team-muted">encrypted</span>
+                      : '\u2014')}
+                  </td>
+                  <td className="apps-team-num">{fmtNum(row.instances)}</td>
+                  {/* Per-instance first, fleet total after: the fleet figure is
+                      what explains the share, the per-instance one is what an
+                      operator recognises. */}
+                  <td className="apps-team-num">
+                    {fmtDec(row.cpuPerInst)}
+                    {row.totalCpu != null && <span className="apps-team-total"> / {fmtDec(row.totalCpu)}</span>}
+                  </td>
+                  <td className="apps-team-num">
+                    {fmtDec(row.ramGBPerInst)}
+                    {row.totalRamGB != null && <span className="apps-team-total"> / {fmtDec(row.totalRamGB)}</span>}
+                  </td>
+                  <td className="apps-team-num">
+                    {fmtDec(row.ssdGBPerInst, 0)}
+                    {row.totalSsdGB != null && <span className="apps-team-total"> / {fmtDec(row.totalSsdGB, 0)}</span>}
+                  </td>
+                  <td className={expiry === 'expired' ? 'apps-team-expired' : ''}>{expiry || '\u2014'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={2}>Fleet total</td>
+              <td className="apps-team-num">{fmtNum(totalInstances)}</td>
+              <td className="apps-team-num">{fmtDec(totalCpu)}</td>
+              <td className="apps-team-num">{fmtDec(totalRamGB)}</td>
+              <td className="apps-team-num">{fmtDec(totalSsdGB, 0)}</td>
+              <td />
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <div className="apps-team-caption">
+        Per-instance / fleet total. CPU in cores, RAM and SSD in GB. Expiry is derived
+        from each spec&apos;s height + expire against the current block, at the
+        30-second block target.
+      </div>
+    </div>
+  );
+}
+
 export function AppsTab() {
   const [gstore, setGstore] = useState(null);
+  const [teamOpen, setTeamOpen] = useState(false);
   const [appSpecs, setAppSpecs] = useState(null);
   const [nodeOperators, setNodeOperators] = useState([]);
   const [ownerTotals, setOwnerTotals] = useState({ owners: [], networkTotalInstances: 0 });
@@ -221,6 +359,8 @@ export function AppsTab() {
   }
 
   const { owners, networkTotalInstances } = ownerTotals;
+  const distinctApps = Array.isArray(appSpecs?.rawSpecs) ? appSpecs.rawSpecs.length : 0;
+  const appOwners = owners.length;
   const { sharePct } = computeTeamSponsoredShare(owners, networkTotalInstances);
 
   const nodeOperatorRows = nodeOperators.map((o) => ({ key: o.address, value: o.nodeCount }));
@@ -228,22 +368,32 @@ export function AppsTab() {
 
   return (
     <div className="apps-tab">
-      <div className="apps-tab-hero">
-        <span className="apps-tab-hero-value">{fmtNum(networkTotalInstances)}</span>
-        <span className="apps-tab-hero-label">Ordered app instances</span>
-      </div>
-
-      <div className="apps-tab-stat-row">
+      {/*
+        * One KPI strip, replacing a hero row and a stat row that each sat
+        * almost entirely empty. The team-sponsored tile is a button: clicking
+        * it expands the apps behind the percentage at full width, because a
+        * seven-column table cannot live in a grid cell.
+        */}
+      <div className="apps-kpi-strip">
+        <KpiTile value={fmtNum(networkTotalInstances)} label="Ordered app instances" />
+        <KpiTile value={fmtNum(distinctApps)} label="Distinct apps" />
+        <KpiTile value={fmtNum(appOwners)} label="App owners" />
         <PanelGate panelKey="appsTeamSponsoredStat" feature="Flux-team-sponsored stat" preview="blur">
-          <div className="hov-panel apps-tab-stat-card">
-            <span className="hov-header-title">FLUX-TEAM-SPONSORED</span>
-            <span className="apps-tab-stat-value">{sharePct.toFixed(1)}%</span>
-            <span className="apps-tab-stat-caption">
-              of {fmtNum(networkTotalInstances)} ordered app instances run under the Flux team's own owner ID
-            </span>
-          </div>
+          <KpiTile
+            value={`${sharePct.toFixed(1)}%`}
+            label="Flux-team-sponsored"
+            hint={`Share of all ${fmtNum(networkTotalInstances)} ordered app instances whose spec owner is the Flux team's own ZelID (${FLUX_TEAM_OWNER_ZELIDS.join(', ')}). Owner IDs are ZelIDs, not payment addresses. Click to see the apps.`}
+            onClick={() => setTeamOpen((open) => !open)}
+            expanded={teamOpen}
+          />
         </PanelGate>
       </div>
+
+      {teamOpen && (
+        <PanelGate panelKey="appsTeamSponsoredStat" feature="Flux-team-sponsored apps" preview="blur">
+          <TeamAppsDetail rawSpecs={appSpecs.rawSpecs} currentBlock={gstore?.fluxBlockHeight || 0} />
+        </PanelGate>
+      )}
 
       <div className="apps-tab-panel-grid">
         <PanelGate panelKey="appEcosystem" feature="App Ecosystem" preview="blur">

--- a/client/src/analytics/AppsTab/index.scss
+++ b/client/src/analytics/AppsTab/index.scss
@@ -6,29 +6,6 @@
   gap: 20px;
 }
 
-.apps-tab-stat-row {
-  display: flex;
-}
-
-.apps-tab-stat-card {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 16px;
-}
-
-.apps-tab-stat-value {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
-}
-
-.apps-tab-stat-caption {
-  font-size: 0.78rem;
-  color: var(--text-tertiary);
-}
-
 .apps-tab-panel-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
@@ -240,20 +217,38 @@
 // plain-color-in-light-mode fallback) to a real page-level headline
 // instead of an in-panel accent.
 
-.apps-tab-hero {
+// ── KPI strip ────────────────────────────────────────────────────────────
+// Replaces .apps-tab-hero and .apps-tab-stat-row, which each occupied a full
+// row to show one figure. auto-fit keeps the tiles readable when the viewport
+// cannot hold four across, rather than crushing them.
+
+.apps-kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.apps-kpi {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin-bottom: 4px;
+  position: relative;
+  // Reset button chrome for the interactive variant, so a <button> and a <div>
+  // tile are visually identical apart from the affordances added below.
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  width: 100%;
 }
 
-.apps-tab-hero-value {
-  font-size: 2.75rem;
+.apps-kpi-value {
+  font-size: 1.85rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
+  line-height: 1.15;
   color: var(--text-primary);
-  line-height: 1.1;
 
   @include rule-mode-dark() {
     background: linear-gradient(135deg, var(--accent-blue), var(--accent-indigo));
@@ -263,10 +258,145 @@
   }
 }
 
-.apps-tab-hero-label {
-  font-size: 0.68rem;
+.apps-kpi-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.66rem;
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
   color: var(--text-tertiary);
+}
+
+.apps-kpi-hint {
+  font-size: 0.72rem;
+  opacity: 0.75;
+}
+
+.apps-kpi--interactive {
+  cursor: pointer;
+  border-color: var(--border-hover);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+  &:hover { box-shadow: var(--shadow-hover); }
+
+  // Keyboard focus must stay obvious -- this is a real button and the only
+  // way into the team-apps table without a mouse.
+  &:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
+  }
+}
+
+.apps-kpi--expanded {
+  border-color: var(--accent-blue);
+}
+
+.apps-kpi-chevron {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+}
+
+// ── Flux-team apps table ─────────────────────────────────────────────────
+// Full width by design: seven columns do not fit in a grid cell, which is why
+// this expands below the strip instead of living in the panel grid.
+
+.apps-team-detail {
+  margin-bottom: 16px;
+  border-left: 2px solid var(--accent-blue);
+}
+
+// Tables are the one thing allowed to scroll horizontally rather than wrap --
+// narrow viewports get a scrollbar instead of an unreadable squeeze.
+.apps-team-scroll {
+  overflow-x: auto;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.apps-team-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--surface-primary);
+    text-align: left;
+    font-size: 0.64rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-secondary);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 5px 10px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.07);
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  tbody tr:hover td { background: var(--surface-inset); }
+
+  tfoot td {
+    position: sticky;
+    bottom: 0;
+    background: var(--surface-primary);
+    border-top: 1px solid var(--border-secondary);
+    border-bottom: none;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+}
+
+.apps-team-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.apps-team-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.apps-team-repo {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-tertiary);
+}
+
+// De-emphasised so the per-instance figure stays the one you read first.
+.apps-team-total {
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+.apps-team-muted {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.apps-team-expired {
+  color: var(--accent-red);
+  font-weight: 600;
+}
+
+.apps-team-caption {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  padding-top: 8px;
 }

--- a/client/src/analytics/teamApps.js
+++ b/client/src/analytics/teamApps.js
@@ -1,0 +1,105 @@
+import { FLUX_TEAM_OWNER_ZELIDS } from 'analytics/teamSponsored';
+import { specResources } from 'appSpecs';
+
+/*
+ * The apps behind the "Flux-team-sponsored" percentage.
+ *
+ * That stat says roughly half of all ordered app instances run under one owner
+ * ID, which is a striking claim to make with no way to check it. This turns it
+ * into something inspectable: the actual apps, what they are, and what they
+ * cost.
+ *
+ * Kept as a pure function over data the tab already has -- no new fetch. Every
+ * field comes from specs already in memory:
+ *
+ *   name        spec.name
+ *   repo        specResources(spec).repotag (component 0 for compose apps)
+ *   instances   spec.instances, defaulting to 1 for older specs that omit it
+ *   cpu/ram/ssd specResources(spec), summed across compose components
+ *   expiry      spec.height + spec.expire, converted to a date via the 30s
+ *               block target
+ *
+ * Expiry is a BLOCK HEIGHT on chain, not a timestamp. Converting it to a date
+ * needs the current height, so callers that do not have one get null rather
+ * than a date computed from a zero height -- which would read as 1970 and look
+ * like real data.
+ */
+
+const SECONDS_PER_BLOCK = 30;
+const MS_PER_BLOCK = SECONDS_PER_BLOCK * 1000;
+
+/**
+ * @param {Array} rawSpecs   every global app spec
+ * @param {number} currentBlock  chain height; 0/undefined disables expiry dates
+ * @param {Array<string>} [teamZelids]  owner IDs treated as the Flux team
+ * @returns {{ rows: Array, totalInstances: number, totalApps: number,
+ *             totalCpu: number, totalRamGB: number, totalSsdGB: number }}
+ */
+export function buildTeamAppRows(rawSpecs, currentBlock, teamZelids = FLUX_TEAM_OWNER_ZELIDS) {
+  const team = new Set(teamZelids || []);
+  const specs = Array.isArray(rawSpecs) ? rawSpecs : [];
+
+  const rows = [];
+  for (const spec of specs) {
+    if (!spec?.owner || !team.has(spec.owner)) continue;
+
+    const { cpuPerInst, ramGBPerInst, ssdGBPerInst, repotag, isEnterprise } = specResources(spec);
+    const instances = spec.instances || 1;
+
+    // Height + expire is the expiry BLOCK. Without a current height there is
+    // no honest way to turn that into a date.
+    let expiresInBlocks = null;
+    let expiresAt = null;
+    if (spec.expire && currentBlock > 0) {
+      const expiryBlock = (spec.height || 0) + spec.expire;
+      expiresInBlocks = expiryBlock - currentBlock;
+      expiresAt = Date.now() + expiresInBlocks * MS_PER_BLOCK;
+    }
+
+    rows.push({
+      name: spec.name,
+      repotag,
+      instances,
+      cpuPerInst,
+      ramGBPerInst,
+      ssdGBPerInst,
+      // Fleet-wide cost, which is the figure that actually explains the
+      // percentage -- one app at 100 instances dominates fifty at one each.
+      totalCpu: cpuPerInst == null ? null : cpuPerInst * instances,
+      totalRamGB: ramGBPerInst == null ? null : ramGBPerInst * instances,
+      totalSsdGB: ssdGBPerInst == null ? null : ssdGBPerInst * instances,
+      expiresInBlocks,
+      expiresAt,
+      isEnterprise,
+    });
+  }
+
+  // Biggest fleets first: the point of the table is explaining where the
+  // instance share comes from, and that is dominated by instance count.
+  rows.sort((a, b) => b.instances - a.instances || String(a.name).localeCompare(String(b.name)));
+
+  const sum = (key) => rows.reduce((total, row) => total + (row[key] || 0), 0);
+
+  return {
+    rows,
+    totalApps: rows.length,
+    totalInstances: sum('instances'),
+    totalCpu: sum('totalCpu'),
+    totalRamGB: sum('totalRamGB'),
+    totalSsdGB: sum('totalSsdGB'),
+  };
+}
+
+/** "in 34 days" / "in 6 hours" / "expired" — null when the height is unknown. */
+export function formatExpiry(expiresInBlocks) {
+  if (expiresInBlocks == null) return null;
+  if (expiresInBlocks <= 0) return 'expired';
+
+  const hours = (expiresInBlocks * SECONDS_PER_BLOCK) / 3600;
+  if (hours < 24) {
+    const rounded = Math.max(1, Math.round(hours));
+    return `in ${rounded} ${rounded === 1 ? 'hour' : 'hours'}`;
+  }
+  const days = Math.round(hours / 24);
+  return `in ${days} ${days === 1 ? 'day' : 'days'}`;
+}

--- a/client/src/analytics/teamApps.test.js
+++ b/client/src/analytics/teamApps.test.js
@@ -1,0 +1,160 @@
+import { buildTeamAppRows, formatExpiry } from './teamApps';
+
+const TEAM = ['196GJWyLxzAw3MirTT7Bqs2iGpUQio29GH'];
+const OTHER = '164ubcHD6ERRkhg22qsSrvu7fHjdryJWUs';
+
+function spec(overrides = {}) {
+  return {
+    name: 'app',
+    owner: TEAM[0],
+    instances: 1,
+    cpu: 1,
+    ram: 1024, // MB -- specResources divides by 1024 for GB
+    hdd: 10,
+    repotag: 'runonflux/thing:latest',
+    height: 1000,
+    expire: 22000,
+    ...overrides,
+  };
+}
+
+describe('buildTeamAppRows', () => {
+  it('includes only specs owned by the team', () => {
+    const result = buildTeamAppRows(
+      [spec({ name: 'ours' }), spec({ name: 'theirs', owner: OTHER })],
+      5000,
+      TEAM
+    );
+    expect(result.rows.map((r) => r.name)).toEqual(['ours']);
+  });
+
+  it('sorts by instance count, biggest fleet first', () => {
+    const result = buildTeamAppRows(
+      [spec({ name: 'small', instances: 2 }), spec({ name: 'huge', instances: 100 }), spec({ name: 'mid', instances: 20 })],
+      5000,
+      TEAM
+    );
+    expect(result.rows.map((r) => r.name)).toEqual(['huge', 'mid', 'small']);
+  });
+
+  it('breaks an instance-count tie by name, so ordering is stable', () => {
+    const result = buildTeamAppRows(
+      [spec({ name: 'beta', instances: 5 }), spec({ name: 'alpha', instances: 5 })],
+      5000,
+      TEAM
+    );
+    expect(result.rows.map((r) => r.name)).toEqual(['alpha', 'beta']);
+  });
+
+  it('reports per-instance AND fleet-wide resources', () => {
+    // The fleet figure is the one that explains the percentage: one app at 100
+    // instances dominates fifty apps at one instance each.
+    const [row] = buildTeamAppRows([spec({ instances: 10, cpu: 2, ram: 2048, hdd: 40 })], 5000, TEAM).rows;
+    expect(row.cpuPerInst).toBe(2);
+    expect(row.ramGBPerInst).toBe(2);
+    expect(row.ssdGBPerInst).toBe(40);
+    expect(row.totalCpu).toBe(20);
+    expect(row.totalRamGB).toBe(20);
+    expect(row.totalSsdGB).toBe(400);
+  });
+
+  it('defaults a missing instances field to 1 rather than 0', () => {
+    // Older specs omit `instances`. Treating that as 0 would silently erase the
+    // app from every total.
+    const [row] = buildTeamAppRows([spec({ instances: undefined })], 5000, TEAM).rows;
+    expect(row.instances).toBe(1);
+  });
+
+  it('sums compose components into one per-instance figure', () => {
+    const [row] = buildTeamAppRows([
+      spec({
+        cpu: undefined, ram: undefined, hdd: undefined, repotag: undefined,
+        compose: [
+          { cpu: 1, ram: 1024, hdd: 10, repotag: 'runonflux/a:1' },
+          { cpu: 3, ram: 3072, hdd: 20, repotag: 'runonflux/b:1' },
+        ],
+      }),
+    ], 5000, TEAM).rows;
+    expect(row.cpuPerInst).toBe(4);
+    expect(row.ramGBPerInst).toBe(4);
+    expect(row.ssdGBPerInst).toBe(30);
+    expect(row.repotag).toBe('runonflux/a:1'); // component 0, per specResources
+  });
+
+  it('computes expiry from height + expire against the current block', () => {
+    // height 1000 + expire 22000 = expiry block 23000; at block 5000 that is
+    // 18000 blocks away.
+    const [row] = buildTeamAppRows([spec({ height: 1000, expire: 22000 })], 5000, TEAM).rows;
+    expect(row.expiresInBlocks).toBe(18000);
+    expect(row.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('reports a past expiry as negative rather than clamping it', () => {
+    const [row] = buildTeamAppRows([spec({ height: 1000, expire: 1000 })], 5000, TEAM).rows;
+    expect(row.expiresInBlocks).toBe(-3000);
+  });
+
+  it('returns null expiry when the current block is unknown', () => {
+    // Deriving a date from height 0 would render as 1970 and look like data.
+    const [row] = buildTeamAppRows([spec()], 0, TEAM).rows;
+    expect(row.expiresInBlocks).toBeNull();
+    expect(row.expiresAt).toBeNull();
+  });
+
+  it('carries enterprise specs with null resources instead of dropping them', () => {
+    // Enterprise specs ship an encrypted compose, so there is nothing to sum --
+    // but the app still exists and still counts toward the instance share.
+    const [row] = buildTeamAppRows([spec({ compose: [], enterprise: 'blob', cpu: undefined })], 5000, TEAM).rows;
+    expect(row.isEnterprise).toBe(true);
+    expect(row.cpuPerInst).toBeNull();
+    expect(row.totalCpu).toBeNull();
+    expect(row.instances).toBe(1);
+  });
+
+  it('totals across the fleet', () => {
+    const result = buildTeamAppRows(
+      [spec({ name: 'a', instances: 2, cpu: 1, ram: 1024, hdd: 10 }),
+       spec({ name: 'b', instances: 3, cpu: 2, ram: 2048, hdd: 20 })],
+      5000, TEAM
+    );
+    expect(result.totalApps).toBe(2);
+    expect(result.totalInstances).toBe(5);
+    expect(result.totalCpu).toBe(2 * 1 + 3 * 2);
+    expect(result.totalRamGB).toBe(2 * 1 + 3 * 2);
+    expect(result.totalSsdGB).toBe(2 * 10 + 3 * 20);
+  });
+
+  it('handles missing, empty and malformed input without throwing', () => {
+    expect(buildTeamAppRows(null, 5000, TEAM).rows).toEqual([]);
+    expect(buildTeamAppRows([], 5000, TEAM).rows).toEqual([]);
+    expect(buildTeamAppRows([null, {}, { owner: null }], 5000, TEAM).rows).toEqual([]);
+  });
+});
+
+describe('formatExpiry', () => {
+  it('renders days beyond a day out', () => {
+    expect(formatExpiry(2880 * 34)).toBe('in 34 days');
+    expect(formatExpiry(2880)).toBe('in 1 day');
+  });
+
+  it('renders hours within a day', () => {
+    expect(formatExpiry(120 * 6)).toBe('in 6 hours'); // 120 blocks = 1 hour
+    expect(formatExpiry(120)).toBe('in 1 hour');
+  });
+
+  it('never renders "in 0 hours" for an imminent expiry', () => {
+    // Rounding 4 blocks (2 minutes) down to zero would read as "in 0 hours",
+    // which says nothing useful.
+    expect(formatExpiry(4)).toBe('in 1 hour');
+  });
+
+  it('says expired rather than a negative duration', () => {
+    expect(formatExpiry(0)).toBe('expired');
+    expect(formatExpiry(-500)).toBe('expired');
+  });
+
+  it('returns null when expiry is unknown', () => {
+    expect(formatExpiry(null)).toBeNull();
+    expect(formatExpiry(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Items 3 and 4 of the Docker testing report.

## Item 3 — the wasted space

The tab opened with a hero row showing **one number**, then a stat row showing **one card** — each occupying a full width before any content began.

**Before**
```
[ 7,716  ORDERED INSTANCES ]                     <- full row, one figure
[ 51.2%  FLUX-TEAM-SPONSORED ]                   <- full row, one card
[ 6 panels ]
```

**After**
```
┌──────────┬──────────┬──────────┬──────────────┐
│  7,716   │  1,412   │   605    │   51.2%  ▾   │
│ ORDERED  │ DISTINCT │   APP    │ FLUX-TEAM  ⓘ │
│INSTANCES │  APPS    │  OWNERS  │ SPONSORED    │
└──────────┴──────────┴──────────┴──────────────┘
```

`auto-fit` keeps the tiles readable on narrow viewports rather than crushing four across.

## Item 4 — making the stat checkable

The Flux-team-sponsored figure asserted that **one owner runs roughly half the network's ordered instances**, with no way to verify it and no explanation of where it came from. Now it has both:

**A tooltip stating the derivation** — including the ZelID it matches on, and the reminder that owner IDs are **ZelIDs, not payment addresses** (a distinction this repo has gotten wrong before).

**The tile is a real `<button>`** that expands the apps behind the percentage:

```
NAME          REPOSITORY        INST   CPU      RAM       SSD        EXPIRES
FoldingAt..   runonflux/fah     100    2 / 200  4 / 400   40 / 4000  in 34 days
blockbook     runonflux/bb       24    4 / 96   8 / 192  120 / 2880  in 6 days
⋮
Fleet total                     3,486  …        …         …
```

Full width **below** the strip rather than inside the panel grid, because seven columns cannot fit a grid cell. Collapsed by default so the tab still opens compact.

Two deliberate presentation choices:

- **Sorted by instance count**, because that's what the percentage is made of — one app at 100 instances outweighs fifty at one each.
- **Per-instance / fleet total** for each resource: the per-instance figure is what an operator recognises; the fleet figure is what actually explains the share.

## No new data fetch

Every field already existed. `specResources` gives cpu/ram/ssd/repotag, `buildSpecIndex` gives instances, and expiry is `spec.height + spec.expire` against `gstore.fluxBlockHeight` at the 30s block target. `buildTeamAppRows` is a pure function over data the tab already holds.

Two edge cases worth calling out:

- **Expiry returns `null`, not a date, when the block height is unknown.** Deriving one from height 0 renders as *1970* and looks like real data.
- **Enterprise specs are carried with null resources, not dropped.** Their compose is encrypted so there's nothing to sum — but the app exists and still counts toward the share.

## Dead CSS removed

The layout change orphaned 7 rules (`.apps-tab-hero*`, `.apps-tab-stat*`). Removed and **verified absent from the built chunk**, not just the source. Leaving them is the same defect the final review caught on the Donor tab.

## Verification

17 new tests on `buildTeamAppRows` / `formatExpiry`, covering the compose sum, the **missing-`instances` default** (treating it as 0 would silently erase an app from every total), negative expiry, unknown block height, and the *"in 0 hours"* rounding trap.

**499 tests / 34 suites pass**, build exit 0. Built CSS confirms `apps-kpi` present and the old classes gone.

**Not verified:** how it looks. The layout, tile proportions and table density need your eyes — particularly whether four KPIs across reads well at your usual window width.

Completes items 1–7 from the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)