### PR TITLE
Stop duplicating geo records across node rows: cache 63% -> 45% of quota (#153)

### DIFF
--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1146,9 +1146,12 @@ function _flagFromCountryCode(cc) {
   );
 }
 
-const GLOBAL_RANKINGS_CACHE_KEY = 'globalPerfRankings_v4';
+const GLOBAL_RANKINGS_CACHE_KEY = 'globalPerfRankings_v5';
 const GLOBAL_RANKINGS_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
-const GLOBAL_RANKINGS_STALE_KEYS = ['globalPerfRankings_v3'];
+// v4 rows carried a full `geo` object; v5 carries `cc` only (#153). A
+// leftover v4 entry would silently yield zero country ranks, so it is
+// pruned rather than left to expire.
+const GLOBAL_RANKINGS_STALE_KEYS = ['globalPerfRankings_v3', 'globalPerfRankings_v4'];
 
 function _prune_stale_global_rankings_caches() {
   for (const key of GLOBAL_RANKINGS_STALE_KEYS) {
@@ -1344,7 +1347,21 @@ export async function fetch_global_performance_rankings() {
         dws: bench.ddwrite || 0,
         down_speed: bench.download_speed || 0,
         up_speed: bench.upload_speed || 0,
-        geo: nodeGeoMap[host] || null,
+        // Country CODE only -- not the whole geo record.
+        //
+        // This used to inline nodeGeoMap[host], duplicating each host's full
+        // geolocation object (country, countryCode, continent, lat, lon, org,
+        // region, city) once per NODE, while nodeGeoMap already stores the
+        // same records once per HOST. With ~6,200 nodes across ~2,350 hosts
+        // that was ~1 MB of pure duplication in a cache measured at 63% of
+        // the sessionStorage quota (issue #153).
+        //
+        // Every consumer of the inlined object only ever read .countryCode
+        // (achievements.js's two country-rank filters, and countryTierCounts
+        // below). Anything needing the full record has nodeGeoMap, which is
+        // cached alongside this and keyed by the same host -- see
+        // live/apidata.js's lookupNodeInfo, which already works that way.
+        cc: nodeGeoMap[host]?.countryCode || null,
       });
     }
 
@@ -1371,9 +1388,13 @@ export async function fetch_global_performance_rankings() {
 
     const countryTierCounts = {};
     for (const node of nodeData) {
-      if (!node.geo?.countryCode) continue;
-      const cc = node.geo.countryCode;
-      if (!countryTierCounts[cc]) countryTierCounts[cc] = { country: node.geo.country, tiers: {} };
+      if (!node.cc) continue;
+      const cc = node.cc;
+      if (!countryTierCounts[cc]) {
+        // The display name comes from nodeGeoMap rather than the row, which
+        // now carries only the code.
+        countryTierCounts[cc] = { country: nodeGeoMap[node.ip]?.country || cc, tiers: {} };
+      }
       countryTierCounts[cc].tiers[node.tier] = (countryTierCounts[cc].tiers[node.tier] || 0) + 1;
     }
 

--- a/client/src/apidata.test.js
+++ b/client/src/apidata.test.js
@@ -527,15 +527,30 @@ describe('fetch_global_performance_rankings (redesigned shape)', () => {
     expect(result.countryTierCounts.DE.tiers.STRATUS).toBe(1);
   });
 
-  it('bumps the cache key to v4 and prunes the old v3 entry', async () => {
+  it('bumps the cache key to v5 and prunes every older entry', async () => {
+    // v3 held pre-sorted per-metric arrays (#153); v4 inlined a full geo
+    // object on every node row (also #153). Both are pruned rather than left
+    // to expire: a leftover v4 entry would feed consumers rows with no `cc`,
+    // silently yielding zero country ranks.
     sessionStorage.setItem('globalPerfRankings_v3', JSON.stringify({ data: { stale: true }, timestamp: Date.now() }));
+    sessionStorage.setItem('globalPerfRankings_v4', JSON.stringify({ data: { stale: true }, timestamp: Date.now() }));
     await fetch_global_performance_rankings();
     expect(sessionStorage.getItem('globalPerfRankings_v3')).toBeNull();
-    expect(sessionStorage.getItem('globalPerfRankings_v4')).not.toBeNull();
-    const cachedV4 = JSON.parse(sessionStorage.getItem('globalPerfRankings_v4'));
-    expect(cachedV4.data.nodeData).toHaveLength(3);
-    expect(cachedV4.data.tierRankings).toBeUndefined();
-    expect(cachedV4.data.countryRankings).toBeUndefined();
+    expect(sessionStorage.getItem('globalPerfRankings_v4')).toBeNull();
+    expect(sessionStorage.getItem('globalPerfRankings_v5')).not.toBeNull();
+
+    const cached = JSON.parse(sessionStorage.getItem('globalPerfRankings_v5'));
+    expect(cached.data.nodeData).toHaveLength(3);
+    expect(cached.data.tierRankings).toBeUndefined();
+    expect(cached.data.countryRankings).toBeUndefined();
+
+    // The v5 shape change itself: a country CODE on the row, and no
+    // duplicated geo record. The full records live in nodeGeoMap alone.
+    for (const row of cached.data.nodeData) {
+      expect(row).not.toHaveProperty('geo');
+      expect(Object.prototype.hasOwnProperty.call(row, 'cc')).toBe(true);
+    }
+    expect(cached.data.nodeGeoMap).toBeDefined();
   });
 
   afterEach(() => {

--- a/client/src/main/Gamification/achievements.js
+++ b/client/src/main/Gamification/achievements.js
@@ -134,7 +134,8 @@ function _worstRankInTier(walletTierNodes, nodeData, tier, metricKey) {
 
 // Find wallet's best rank in a country for a metric
 function _bestRankInCountry(walletCountryNodes, nodeData, tier, countryCode, metricKey) {
-  const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === countryCode);
+  // `cc` replaced the inlined geo object in v5 of the rankings cache (#153).
+  const groupNodes = nodeData.filter((n) => n.tier === tier && n.cc === countryCode);
   let best = null;
   for (const node of walletCountryNodes) {
     const ip = node.ip_full?.host;
@@ -241,7 +242,7 @@ export function computeCountryPerformanceAchievements(walletNodes, nodeData, nod
     const country = Object.values(nodeGeoMap).find((g) => g.countryCode === cc)?.country;
 
     for (const metric of PERF_METRICS) {
-      const groupNodes = nodeData.filter((n) => n.tier === tier && n.geo?.countryCode === cc);
+      const groupNodes = nodeData.filter((n) => n.tier === tier && n.cc === cc);
       const totalInGroup = groupNodes.length;
       if (totalInGroup === 0) continue;
 

--- a/client/src/main/Gamification/achievements.test.js
+++ b/client/src/main/Gamification/achievements.test.js
@@ -86,7 +86,7 @@ const CUMULUS_NODE_DATA = CUMULUS_EPS_VALUES.map((eps, i) => ({
   dws: 200 - i,
   down_speed: 300 - i,
   up_speed: 400 - i,
-  geo: null,
+  cc: null,
 }));
 // Verified by hand: eps rank for node i (0-indexed) = 1 + count of nodes with
 // strictly greater eps, plus (for a tie) count of earlier-indexed nodes with
@@ -276,9 +276,9 @@ describe('computeCountryPerformanceAchievements (characterization)', () => {
   // Reshaped from the old countryRankings-shaped fixture into flat nodeData:
   // 3 CUMULUS nodes, all geo-tagged US, eps 100/50/10 (ranks 1/2/3).
   const countryNodeData = [
-    { ip: '10.0.0.0', tier: 'CUMULUS', eps: 100, geo: { countryCode: 'US' } },
-    { ip: '10.0.0.1', tier: 'CUMULUS', eps: 50, geo: { countryCode: 'US' } },
-    { ip: '10.0.0.2', tier: 'CUMULUS', eps: 10, geo: { countryCode: 'US' } },
+    { ip: '10.0.0.0', tier: 'CUMULUS', eps: 100, cc: 'US' },
+    { ip: '10.0.0.1', tier: 'CUMULUS', eps: 50, cc: 'US' },
+    { ip: '10.0.0.2', tier: 'CUMULUS', eps: 10, cc: 'US' },
   ];
   // nodeGeoMap must carry `.country` (display name) too — achievements.js's
   // computeCountryPerformanceAchievements looks up the country's display


### PR DESCRIPTION
Addresses the largest remaining piece of #153.

## The duplication

The rankings cache inlined `nodeGeoMap[host]` — the **full** geolocation record (country, countryCode, continent, lat, lon, org, region, city) — **once per node**, while `nodeGeoMap` already stored the same records **once per host**, in the same cached payload.

~6,200 nodes across ~2,350 hosts, so the same data roughly **2.6× over**.

## Only one field was ever read

Every consumer of the inlined object read `.countryCode` and nothing else:

- `achievements.js` — two country-rank filters
- `apidata.js` — `countryTierCounts`

Nothing read `country`, `lat`, `lon`, `org`, `region` or `city` from a node row. Anything needing the full record already goes through `nodeGeoMap` — `live/apidata.js`'s `lookupNodeInfo` works exactly that way today.

So the row now carries `cc`, a two-character string.

## Measured against live data, not estimated

| | | |
|---|---|---|
| `nodeData` (6,194 rows) | v4, geo inlined | **1,826 KB** |
| | v5, `cc` only | **894 KB** |
| | **saved** | **932 KB** — 51% of `nodeData` |

| whole sessionStorage | before | after |
|---|---|---|
| total | 3,233 KB | **2,301 KB** |
| % of ~5,120 KB quota | 63% | **45%** |
| headroom | 1,887 KB | **2,819 KB** |

For context, #153 was filed at **84%** with 795 KB of headroom.

## The cache key bump matters more than usual

Key moves `v4` → `v5`, and **both** older keys are pruned.

A leftover `v4` entry would feed consumers rows carrying a `geo` they no longer read and **no `cc` at all** — so every country rank would silently come back empty. That is precisely the class of quiet wrong answer #153 was filed about, so the old entry is pruned rather than left to expire.

## Test fixtures

Updated to the v5 shape rather than left stale — including one my first regex missed (no `re.MULTILINE`), which was passing only because that fixture drives *tier* ranks, not *country* ranks. Left alone it would have described a shape that no longer exists.

## This does not close #153

Two of the original points still stand:

- Both cached keys **grow with the network** — 45% is a trend, not a resting state.
- Writes are still wrapped in a bare `try {} catch {}`, so a future quota trip produces no error, no log, and no symptom beyond silent refetching.

What it does remove is the single largest waste in the cache.

500 tests / 34 suites pass, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)