### PR TITLE
Chain Activity: drill down from the Utility count into the actual blocks (#199)

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -92,6 +92,7 @@ pub mod api_v1 {
                 post(self::live_winners::handler),
             )
             .route("/chain-activity", get(self::chain_activity::handler))
+            .route("/chain-activity/blocks", get(self::chain_activity_blocks::handler))
     }
 
     async fn root() -> String {
@@ -311,6 +312,83 @@ pub mod api_v1 {
                 scan_start_height: scan_status.scan_start_height,
                 scan_target_height: scan_status.scan_target_height,
                 last_outcome: scan_status.last_outcome,
+            };
+            (StatusCode::OK, Json(body))
+        }
+    }
+
+    /*
+     * The blocks behind the Utility count (issue #199).
+     *
+     * A SEPARATE endpoint rather than more fields on /chain-activity, which
+     * every Chain Activity tab load already fetches. The retained utility-block
+     * set is a few hundred KB; adding it to the common payload would tax every
+     * visitor for a drill-down only some open. This one is fetched lazily, on
+     * first expand.
+     */
+    pub mod chain_activity_blocks {
+        use super::*;
+        use axum::extract::Query;
+
+        const DEFAULT_LIMIT: usize = 50;
+        const MAX_LIMIT: usize = 200;
+
+        #[derive(Debug, Deserialize)]
+        pub struct BlocksQuery {
+            limit: Option<usize>,
+        }
+
+        #[derive(Debug, Serialize)]
+        struct CategoryTotals {
+            /*
+             * DISJOINT counts: p2p_only + dapp_only + both == utility_total.
+             *
+             * is_p2p and is_dapp are independent booleans, so overlapping
+             * "any P2P" / "any Dapp" tallies would not sum to the total and
+             * would read as a bug on screen. Partitioning here means the UI
+             * can render three numbers that visibly add up.
+             */
+            p2p_only: usize,
+            dapp_only: usize,
+            both: usize,
+            utility_total: usize,
+        }
+
+        #[derive(Debug, Serialize)]
+        pub struct ChainActivityBlocksBody {
+            success: bool,
+            totals: CategoryTotals,
+            blocks: Vec<services::chain_activity::UtilityBlockRecord>,
+            returned: usize,
+        }
+
+        // Synchronous read of what the background scanner has already
+        // persisted; never triggers a scan on the request path, matching the
+        // sibling chain-activity handler.
+        pub async fn handler(Query(params): Query<BlocksQuery>) -> impl IntoResponse {
+            let mut blocks = services::chain_activity::load_utility_blocks();
+
+            // Totals are over the WHOLE retained set, not the returned page --
+            // the UI shows "showing N of M", and M has to be the real total or
+            // the footer lies.
+            let totals = CategoryTotals {
+                p2p_only: blocks.iter().filter(|b| b.is_p2p && !b.is_dapp).count(),
+                dapp_only: blocks.iter().filter(|b| !b.is_p2p && b.is_dapp).count(),
+                both: blocks.iter().filter(|b| b.is_p2p && b.is_dapp).count(),
+                utility_total: blocks.len(),
+            };
+
+            // Most recent first, then truncate. Clamped so a hand-crafted
+            // ?limit=99999 cannot ask for the entire retained set.
+            blocks.sort_by(|a, b| b.height.cmp(&a.height));
+            let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+            blocks.truncate(limit);
+
+            let body = ChainActivityBlocksBody {
+                success: true,
+                totals,
+                returned: blocks.len(),
+                blocks,
             };
             (StatusCode::OK, Json(body))
         }

--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -39,6 +39,7 @@ const SCAN_BATCH_SIZE: i64 = 300;
 pub const DATA_DIR: &str = "data";
 pub const DAILY_ROLLUP_FILE: &str = "chain_activity_daily.json";
 pub const TEAM_TX_FILE: &str = "chain_activity_team_tx.json";
+pub const UTILITY_BLOCKS_FILE: &str = "chain_activity_utility_blocks.json";
 pub const CHECKPOINT_FILE: &str = "chain_activity_checkpoint.json";
 pub const SCAN_STATUS_FILE: &str = "chain_activity_scan_status.json";
 
@@ -237,8 +238,34 @@ pub struct TxTransfer {
 pub struct BlockScanResult {
     pub height: i64,
     pub is_utility: bool,
+    // The two reasons a block counts as utility, kept separately rather than
+    // collapsed into `is_utility`. Both were already computed inside
+    // scan_one_block and thrown away -- issue #199 is a persistence and
+    // exposure gap, not a new-algorithm problem.
+    pub is_p2p: bool,
+    pub is_dapp: bool,
+    pub transfer_count: u32,
     pub date: String,
     pub team_txs: Vec<TeamTx>,
+}
+
+/*
+ * One utility block, persisted so the Utility count can be drilled into.
+ *
+ * ONLY utility blocks are recorded. Empty blocks stay aggregate-only in
+ * DailyCount -- nobody drills into "nothing happened", and storing them would
+ * roughly sextuple this file for no reader. A live probe (2026-09-11, 12 blocks
+ * sampled across ~24h) measured ~17% of blocks as utility, so the retained set
+ * is ~3,900 records over the 8-day window: a few hundred KB, in a data
+ * directory that is rebuilt from the explorer on every restart anyway.
+ */
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct UtilityBlockRecord {
+    pub height: i64,
+    pub date: String,
+    pub is_p2p: bool,
+    pub is_dapp: bool,
+    pub transfer_count: u32,
 }
 
 // ── Persisted shapes ──────────────────────────────────────────────────────────
@@ -338,6 +365,11 @@ struct DailyRollupFile {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 struct TeamTxFile {
     team_txs: Vec<TeamTx>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+struct UtilityBlocksFile {
+    blocks: Vec<UtilityBlockRecord>,
 }
 
 /*
@@ -465,6 +497,7 @@ pub fn fold_contiguous_results(
     mut results: Vec<(i64, Option<BlockScanResult>)>,
     daily: &mut Vec<DailyCount>,
     team_txs: &mut Vec<TeamTx>,
+    utility_blocks: &mut Vec<UtilityBlockRecord>,
 ) -> i64 {
     results.sort_by_key(|(h, _)| *h);
     let mut checkpoint = start_height;
@@ -473,6 +506,18 @@ pub fn fold_contiguous_results(
             Some(r) if height == checkpoint + 1 => {
                 upsert_daily_count(daily, &r.date, r.is_utility);
                 team_txs.extend(r.team_txs);
+                // Utility blocks only. The contiguous-run discipline above
+                // already guarantees each height is folded exactly once, so
+                // this cannot double-record and needs no dedupe.
+                if r.is_utility {
+                    utility_blocks.push(UtilityBlockRecord {
+                        height: r.height,
+                        date: r.date.clone(),
+                        is_p2p: r.is_p2p,
+                        is_dapp: r.is_dapp,
+                        transfer_count: r.transfer_count,
+                    });
+                }
                 checkpoint = height;
             }
             _ => break,
@@ -500,6 +545,28 @@ pub fn read_json_or_default<T: for<'de> Deserialize<'de> + Default>(base_dir: &P
 
 pub fn load_daily_rollup() -> Vec<DailyCount> {
     read_json_or_default::<DailyRollupFile>(Path::new(DATA_DIR), DAILY_ROLLUP_FILE).daily
+}
+
+pub fn load_utility_blocks() -> Vec<UtilityBlockRecord> {
+    read_json_or_default::<UtilityBlocksFile>(Path::new(DATA_DIR), UTILITY_BLOCKS_FILE).blocks
+}
+
+pub fn save_utility_blocks(blocks: &[UtilityBlockRecord]) -> std::io::Result<()> {
+    write_json_atomic(
+        Path::new(DATA_DIR),
+        UTILITY_BLOCKS_FILE,
+        &UtilityBlocksFile { blocks: blocks.to_vec() },
+    )
+}
+
+/*
+ * Same bounded-retention rule as trim_team_txs: drop anything below the window
+ * edge. Without this the file grows without limit while daily/team data stays
+ * bounded, and a long-lived replica would slowly fill its disk with blocks no
+ * endpoint can return.
+ */
+pub fn trim_utility_blocks(blocks: &mut Vec<UtilityBlockRecord>, min_height: i64) {
+    blocks.retain(|b| b.height >= min_height);
 }
 
 pub fn load_team_txs() -> Vec<TeamTx> {
@@ -605,6 +672,11 @@ pub async fn scan_one_block(client: &Client, height: i64, deployment_heights: &H
     let hash = resolve_block_hash(client, height).await?;
     let txs = fetch_all_block_txs(client, &hash).await?;
     let transfers = extract_p2p_transfers(&txs);
+    // The two categories, kept rather than collapsed. is_utility stays exactly
+    // `is_p2p || is_dapp`, so every existing is_block_utility test still holds.
+    let is_p2p = !transfers.is_empty();
+    let is_dapp = deployment_heights.contains(&height);
+    let transfer_count = transfers.len() as u32;
     let is_utility = is_block_utility(height, &transfers, deployment_heights);
     let team_txs = extract_team_txs(height, &transfers);
     // Every tx in a block shares (approximately) the same blocktime — prefer
@@ -617,7 +689,7 @@ pub async fn scan_one_block(client: &Client, height: i64, deployment_heights: &H
         .or_else(|| txs.first().and_then(|t| t.time))
         .unwrap_or(0);
     let date = unix_to_utc_date(block_time);
-    Some(BlockScanResult { height, is_utility, date, team_txs })
+    Some(BlockScanResult { height, is_utility, is_p2p, is_dapp, transfer_count, date, team_txs })
 }
 
 /*
@@ -635,6 +707,7 @@ async fn scan_range(
     deployment_heights: &HashSet<i64>,
     daily: &mut Vec<DailyCount>,
     team_txs: &mut Vec<TeamTx>,
+    utility_blocks: &mut Vec<UtilityBlockRecord>,
 ) -> i64 {
     if start_height >= tip_height {
         return start_height;
@@ -651,7 +724,7 @@ async fn scan_range(
         results.push(pair);
     }
 
-    fold_contiguous_results(start_height, results, daily, team_txs)
+    fold_contiguous_results(start_height, results, daily, team_txs, utility_blocks)
 }
 
 /*
@@ -750,22 +823,27 @@ pub async fn run_scan_cycle() {
     let deployment_heights = fetch_deployment_heights(&client).await;
     let mut daily = load_daily_rollup();
     let mut team_txs = load_team_txs();
+    let mut utility_blocks = load_utility_blocks();
 
     let mut checkpoint_height = start_height;
     let mut stalled = false;
 
     while checkpoint_height < tip_height {
         let batch_end = (checkpoint_height + SCAN_BATCH_SIZE).min(tip_height);
-        let new_checkpoint = scan_range(&client, checkpoint_height, batch_end, &deployment_heights, &mut daily, &mut team_txs).await;
+        let new_checkpoint = scan_range(&client, checkpoint_height, batch_end, &deployment_heights, &mut daily, &mut team_txs, &mut utility_blocks).await;
 
         trim_daily_retention(&mut daily, RETENTION_DAYS as usize);
         trim_team_txs(&mut team_txs, tip_height - RETENTION_BLOCKS);
+        trim_utility_blocks(&mut utility_blocks, tip_height - RETENTION_BLOCKS);
 
         if let Err(e) = save_daily_rollup(&daily) {
             eprintln!("[chain_activity] failed to save daily rollup: {}", e);
         }
         if let Err(e) = save_team_txs(&team_txs) {
             eprintln!("[chain_activity] failed to save team txs: {}", e);
+        }
+        if let Err(e) = save_utility_blocks(&utility_blocks) {
+            eprintln!("[chain_activity] failed to save utility blocks: {}", e);
         }
         if let Err(e) = save_checkpoint(new_checkpoint) {
             eprintln!("[chain_activity] failed to save checkpoint: {}", e);
@@ -953,15 +1031,34 @@ mod tests {
         assert_eq!(txs[0].txid, "new");
     }
 
+    /*
+     * Scan result for a block that is utility because of a P2P transfer.
+     * `is_utility` is always `is_p2p || is_dapp` here, exactly as
+     * scan_one_block computes it -- a helper that let those drift apart would
+     * make every test below meaningless.
+     */
+    fn scan_result(height: i64, is_p2p: bool, is_dapp: bool, date: &str) -> BlockScanResult {
+        BlockScanResult {
+            height,
+            is_utility: is_p2p || is_dapp,
+            is_p2p,
+            is_dapp,
+            transfer_count: if is_p2p { 2 } else { 0 },
+            date: date.into(),
+            team_txs: vec![],
+        }
+    }
+
     #[test]
     fn fold_contiguous_results_applies_every_success_when_theres_no_gap() {
         let mut daily = vec![];
         let mut team_txs = vec![];
+        let mut utility_blocks = vec![];
         let results = vec![
-            (101, Some(BlockScanResult { height: 101, is_utility: true, date: "2026-09-06".into(), team_txs: vec![] })),
-            (102, Some(BlockScanResult { height: 102, is_utility: false, date: "2026-09-06".into(), team_txs: vec![] })),
+            (101, Some(scan_result(101, true, false, "2026-09-06"))),
+            (102, Some(scan_result(102, false, false, "2026-09-06"))),
         ];
-        let new_checkpoint = fold_contiguous_results(100, results, &mut daily, &mut team_txs);
+        let new_checkpoint = fold_contiguous_results(100, results, &mut daily, &mut team_txs, &mut utility_blocks);
         assert_eq!(new_checkpoint, 102);
         assert_eq!(daily, vec![DailyCount { date: "2026-09-06".into(), utility_blocks: 1, empty_blocks: 1 }]);
     }
@@ -972,13 +1069,76 @@ mod tests {
         // double-counted once 101 is retried and the scan re-reaches 102).
         let mut daily = vec![];
         let mut team_txs = vec![];
+        let mut utility_blocks = vec![];
         let results = vec![
             (101, None),
-            (102, Some(BlockScanResult { height: 102, is_utility: true, date: "2026-09-06".into(), team_txs: vec![] })),
+            (102, Some(scan_result(102, true, false, "2026-09-06"))),
         ];
-        let new_checkpoint = fold_contiguous_results(100, results, &mut daily, &mut team_txs);
+        let new_checkpoint = fold_contiguous_results(100, results, &mut daily, &mut team_txs, &mut utility_blocks);
         assert_eq!(new_checkpoint, 100); // unchanged — nothing new was safely applied
         assert_eq!(daily, vec![]);
+        // And nothing was recorded for the drill-down either: a block past a
+        // gap must not appear there any more than it appears in the rollup.
+        assert!(utility_blocks.is_empty());
+    }
+
+    #[test]
+    fn fold_records_only_utility_blocks_with_their_categories() {
+        let mut daily = vec![];
+        let mut team_txs = vec![];
+        let mut utility_blocks = vec![];
+        let results = vec![
+            (101, Some(scan_result(101, true, false, "2026-09-06"))),   // P2P only
+            (102, Some(scan_result(102, false, true, "2026-09-06"))),   // Dapp only
+            (103, Some(scan_result(103, true, true, "2026-09-06"))),    // both
+            (104, Some(scan_result(104, false, false, "2026-09-06"))),  // empty
+        ];
+        fold_contiguous_results(100, results, &mut daily, &mut team_txs, &mut utility_blocks);
+
+        // The empty block is aggregate-only: nobody drills into "nothing
+        // happened", and recording them would multiply this file for no reader.
+        assert_eq!(utility_blocks.len(), 3);
+        assert_eq!(utility_blocks.iter().map(|b| b.height).collect::<Vec<_>>(), vec![101, 102, 103]);
+
+        assert!(utility_blocks[0].is_p2p && !utility_blocks[0].is_dapp);
+        assert!(!utility_blocks[1].is_p2p && utility_blocks[1].is_dapp);
+        assert!(utility_blocks[2].is_p2p && utility_blocks[2].is_dapp);
+        assert_eq!(utility_blocks[0].transfer_count, 2);
+        assert_eq!(utility_blocks[1].transfer_count, 0);
+
+        // The rollup still agrees: 3 utility, 1 empty.
+        assert_eq!(daily, vec![DailyCount { date: "2026-09-06".into(), utility_blocks: 3, empty_blocks: 1 }]);
+    }
+
+    #[test]
+    fn trim_utility_blocks_drops_everything_below_the_window_edge() {
+        let mut blocks = vec![
+            UtilityBlockRecord { height: 100, date: "a".into(), is_p2p: true, is_dapp: false, transfer_count: 1 },
+            UtilityBlockRecord { height: 200, date: "b".into(), is_p2p: true, is_dapp: false, transfer_count: 1 },
+            UtilityBlockRecord { height: 300, date: "c".into(), is_p2p: false, is_dapp: true, transfer_count: 0 },
+        ];
+        trim_utility_blocks(&mut blocks, 200);
+        // Boundary is inclusive, matching trim_team_txs: a block exactly at the
+        // edge is still inside the retention window.
+        assert_eq!(blocks.iter().map(|b| b.height).collect::<Vec<_>>(), vec![200, 300]);
+    }
+
+    #[test]
+    fn utility_block_categories_partition_cleanly() {
+        // The API reports p2p_only / dapp_only / both, and those must sum to the
+        // total -- overlapping "any P2P" / "any Dapp" counts would not add up
+        // and would read as a bug on screen.
+        let blocks = vec![
+            UtilityBlockRecord { height: 1, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 3 },
+            UtilityBlockRecord { height: 2, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 1 },
+            UtilityBlockRecord { height: 3, date: "d".into(), is_p2p: false, is_dapp: true, transfer_count: 0 },
+            UtilityBlockRecord { height: 4, date: "d".into(), is_p2p: true, is_dapp: true, transfer_count: 2 },
+        ];
+        let p2p_only = blocks.iter().filter(|b| b.is_p2p && !b.is_dapp).count();
+        let dapp_only = blocks.iter().filter(|b| !b.is_p2p && b.is_dapp).count();
+        let both = blocks.iter().filter(|b| b.is_p2p && b.is_dapp).count();
+        assert_eq!((p2p_only, dapp_only, both), (2, 1, 1));
+        assert_eq!(p2p_only + dapp_only + both, blocks.len());
     }
 
     fn temp_test_dir(name: &str) -> std::path::PathBuf {

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks } from 'analytics/chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from 'analytics/chainActivity';
 import './index.scss';
 
 /*
@@ -92,7 +92,93 @@ function pct(n, total) {
   return total > 0 ? ((n / total) * 100).toFixed(0) : '0';
 }
 
+const DRILLDOWN_LIMIT = 50;
+
+/*
+ * The blocks behind the Utility count (issue #199).
+ *
+ * Fetched LAZILY, on first expand: the retained utility-block set is a few
+ * hundred KB and most visitors never open this, so the tab's initial network
+ * cost is unchanged. Once fetched it is kept for the tab's lifetime -- toggling
+ * closed and open again does not refetch.
+ *
+ * The issue's own example ("P2P (2) Dapp (2)") came from live-testing a scanner
+ * that had barely started. In steady state a day holds ~490 utility blocks, so
+ * this shows the category subtotals in full and caps the block list, rather
+ * than rendering hundreds of rows nobody asked for.
+ */
+function UtilityDrilldown({ open }) {
+  const [state, setState] = useState({ status: 'idle', data: null });
+
+  useEffect(() => {
+    if (!open || state.status !== 'idle') return;
+    let cancelled = false;
+    setState({ status: 'loading', data: null });
+    (async () => {
+      const result = await fetch_chain_activity_blocks(DRILLDOWN_LIMIT);
+      if (cancelled) return;
+      setState({ status: result.ok ? 'ready' : 'error', data: result });
+    })().catch(() => {
+      if (!cancelled) setState({ status: 'error', data: null });
+    });
+    return () => { cancelled = true; };
+  }, [open, state.status]);
+
+  if (!open) return null;
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <div className="ca-drilldown ca-drilldown--message">Loading blocks...</div>;
+  }
+  if (state.status === 'error') {
+    // Fails soft: say so and stay collapsed rather than blanking the panel.
+    return <div className="ca-drilldown ca-drilldown--message">Could not load block detail right now.</div>;
+  }
+
+  const { totals, blocks } = state.data;
+  if (totals.utilityTotal === 0) {
+    return <div className="ca-drilldown ca-drilldown--message">No utility blocks recorded yet.</div>;
+  }
+
+  return (
+    <div className="ca-drilldown" id="ca-utility-drilldown">
+      <div className="ca-drilldown-chips">
+        <span className="ca-chip ca-chip--p2p">
+          P2P <strong>{fmtNum(totals.p2pOnly)}</strong>
+        </span>
+        <span className="ca-chip ca-chip--dapp">
+          Dapp <strong>{fmtNum(totals.dappOnly)}</strong>
+        </span>
+        <span className="ca-chip ca-chip--both" title="Blocks carrying a P2P transfer AND an app deployment">
+          Both <strong>{fmtNum(totals.both)}</strong>
+        </span>
+      </div>
+
+      <div className="ca-drilldown-list">
+        {blocks.map((b) => (
+          <div key={b.height} className="ca-drilldown-row">
+            <span className="ca-drilldown-height">#{fmtNum(b.height)}</span>
+            <span className={`ca-drilldown-cat${b.isP2p && b.isDapp ? ' ca-drilldown-cat--both' : ''}`}>
+              {blockCategoryLabel(b)}
+            </span>
+            <span className="ca-drilldown-txs">
+              {b.transferCount > 0 ? `${fmtNum(b.transferCount)} tx` : '\u2014'}
+            </span>
+            <span className="ca-drilldown-date">{b.date}</span>
+          </div>
+        ))}
+      </div>
+
+      {blocks.length < totals.utilityTotal && (
+        <div className="ca-drilldown-footer">
+          showing {fmtNum(blocks.length)} of {fmtNum(totals.utilityTotal)} utility blocks, most recent first
+        </div>
+      )}
+    </div>
+  );
+}
+
 function UtilitySummary({ daily, syncStatus, theme }) {
+  const [drilldownOpen, setDrilldownOpen] = useState(false);
   const { utilityBlocks, emptyBlocks } = summarizeDaily(daily);
   const total = utilityBlocks + emptyBlocks;
   const badgeText = daily.length === 1 ? '1 day' : `${daily.length} days`;
@@ -120,13 +206,26 @@ function UtilitySummary({ daily, syncStatus, theme }) {
             <UtilityTrendChart daily={daily} theme={theme} />
           </Suspense>
           <div className="ca-utility-stats">
-            <span className="ca-utility-stat ca-utility-stat--utility">
+            {/*
+              * A real <button>, not a click handler on a span: this is the only
+              * way into the drill-down, and it has to be reachable and
+              * announceable without a mouse.
+              */}
+            <button
+              type="button"
+              className={`ca-utility-stat ca-utility-stat--utility ca-utility-stat--button${drilldownOpen ? ' ca-utility-stat--open' : ''}`}
+              onClick={() => setDrilldownOpen((v) => !v)}
+              aria-expanded={drilldownOpen}
+              aria-controls="ca-utility-drilldown"
+            >
               {fmtNum(utilityBlocks)} utility ({pct(utilityBlocks, total)}%)
-            </span>
+              <span className="ca-utility-caret" aria-hidden="true">{drilldownOpen ? '\u25b4' : '\u25be'}</span>
+            </button>
             <span className="ca-utility-stat ca-utility-stat--empty">
               {fmtNum(emptyBlocks)} empty ({pct(emptyBlocks, total)}%)
             </span>
           </div>
+          <UtilityDrilldown open={drilldownOpen} />
         </>
       )}
     </div>

--- a/client/src/analytics/ChainActivityTab/index.scss
+++ b/client/src/analytics/ChainActivityTab/index.scss
@@ -292,3 +292,116 @@
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
+
+// ── Utility drill-down (issue #199) ──────────────────────────────────────
+
+// The utility figure is now a button. Reset the chrome so it still reads as
+// the stat it replaced, and add only the affordances that say it is clickable.
+.ca-utility-stat--button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  border-bottom: 1px dashed currentColor;
+
+  &:hover { opacity: 0.85; }
+
+  // This is the only route into the drill-down, so keyboard focus has to be
+  // unmistakable.
+  &:focus-visible {
+    outline: 2px solid var(--accent-amber);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+}
+
+.ca-utility-caret {
+  font-size: 0.65rem;
+}
+
+.ca-drilldown {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-secondary);
+
+  &--message {
+    font-size: 0.78rem;
+    color: var(--text-tertiary);
+  }
+}
+
+.ca-drilldown-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.ca-chip {
+  font-size: 0.72rem;
+  padding: 3px 9px;
+  border-radius: 20px;
+  background: var(--surface-inset);
+  color: var(--text-secondary);
+
+  strong {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    margin-left: 3px;
+  }
+
+  &--p2p strong { color: var(--accent-green); }
+  &--dapp strong { color: var(--accent-amber); }
+  &--both strong { color: var(--accent-indigo); }
+}
+
+// Capped height: a day holds ~490 utility blocks in steady state, so the list
+// scrolls rather than pushing the rest of the tab off screen.
+.ca-drilldown-list {
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ca-drilldown-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 60px 90px;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.74rem;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+
+  &:hover { background: var(--surface-inset); }
+}
+
+.ca-drilldown-height {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.ca-drilldown-cat {
+  color: var(--accent-green);
+
+  &--both { color: var(--accent-indigo); }
+}
+
+.ca-drilldown-txs,
+.ca-drilldown-date {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  text-align: right;
+}
+
+.ca-drilldown-footer {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  padding-top: 8px;
+}

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -153,3 +153,72 @@ export function todaysUtilityBlocks(daily) {
   if (!daily || daily.length === 0) return 0;
   return daily[daily.length - 1].utilityBlocks || 0;
 }
+
+/*
+ * The blocks behind the Utility count (issue #199).
+ *
+ * A separate endpoint from fetch_chain_activity, and fetched LAZILY -- only
+ * when the drill-down is actually opened. The retained utility-block set is a
+ * few hundred KB, and every Chain Activity tab load already fetches
+ * /chain-activity; folding these in would tax every visitor for something only
+ * some open.
+ *
+ * `totals` are disjoint and cover the WHOLE retained set, not the returned
+ * page: p2pOnly + dappOnly + both === utilityTotal. The UI shows "showing N of
+ * M", so M has to be the real total or the footer lies. is_p2p and is_dapp are
+ * independent booleans on the backend, so overlapping "any P2P"/"any Dapp"
+ * tallies would not sum and would read as a bug on screen.
+ *
+ * Fails soft to an empty result, matching fetch_chain_activity: a drill-down
+ * that cannot load should collapse quietly, not blank the tab.
+ */
+export async function fetch_chain_activity_blocks(limit = 50) {
+  const empty = {
+    ok: false,
+    totals: { p2pOnly: 0, dappOnly: 0, both: 0, utilityTotal: 0 },
+    blocks: [],
+  };
+
+  try {
+    const response = await fetch(
+      `${FLUXNODE_INFO_API_URL}/api/v1/chain-activity/blocks?limit=${limit}`,
+      { method: 'GET', headers: { Accept: 'application/json' } }
+    );
+    const json = await response.json();
+    if (!json?.success) {
+      console.log('[ChainActivity] blocks endpoint reported success:false');
+      return empty;
+    }
+
+    const t = json.totals || {};
+    return {
+      ok: true,
+      totals: {
+        p2pOnly: t.p2p_only || 0,
+        dappOnly: t.dapp_only || 0,
+        both: t.both || 0,
+        utilityTotal: t.utility_total || 0,
+      },
+      blocks: Array.isArray(json.blocks)
+        ? json.blocks.map((b) => ({
+            height: b.height,
+            date: b.date,
+            isP2p: !!b.is_p2p,
+            isDapp: !!b.is_dapp,
+            transferCount: b.transfer_count || 0,
+          }))
+        : [],
+    };
+  } catch (error) {
+    console.log('[ChainActivity] blocks fetch failed:', error?.message || error);
+    return empty;
+  }
+}
+
+/* "P2P", "Dapp", or "P2P + Dapp" for one block's category badges. */
+export function blockCategoryLabel(block) {
+  if (block?.isP2p && block?.isDapp) return 'P2P + Dapp';
+  if (block?.isP2p) return 'P2P';
+  if (block?.isDapp) return 'Dapp';
+  return '\u2014';
+}

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,4 +1,4 @@
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks } from './chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
@@ -239,5 +239,81 @@ describe('todaysUtilityBlocks', () => {
 
   it('returns 0 when the last entry has no utility count', () => {
     expect(todaysUtilityBlocks([{ date: '2026-09-10', emptyBlocks: 5 }])).toBe(0);
+  });
+});
+
+describe('fetch_chain_activity_blocks', () => {
+  afterEach(() => { jest.resetAllMocks(); });
+
+  function ok(body) {
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+  }
+
+  it('normalises snake_case to camelCase at the boundary', async () => {
+    global.fetch = jest.fn(() => ok({
+      success: true,
+      totals: { p2p_only: 462, dapp_only: 28, both: 4, utility_total: 494 },
+      blocks: [{ height: 2939035, date: '2026-09-11', is_p2p: true, is_dapp: false, transfer_count: 2 }],
+    }));
+
+    const result = await fetch_chain_activity_blocks(50);
+    expect(result.ok).toBe(true);
+    expect(result.totals).toEqual({ p2pOnly: 462, dappOnly: 28, both: 4, utilityTotal: 494 });
+    expect(result.blocks[0]).toEqual({
+      height: 2939035, date: '2026-09-11', isP2p: true, isDapp: false, transferCount: 2,
+    });
+  });
+
+  it('the disjoint totals sum to the utility total', async () => {
+    // Overlapping "any P2P"/"any Dapp" counts would not add up, and three
+    // numbers that visibly fail to sum read as a bug on screen.
+    global.fetch = jest.fn(() => ok({
+      success: true,
+      totals: { p2p_only: 10, dapp_only: 3, both: 2, utility_total: 15 },
+      blocks: [],
+    }));
+    const { totals } = await fetch_chain_activity_blocks();
+    expect(totals.p2pOnly + totals.dappOnly + totals.both).toBe(totals.utilityTotal);
+  });
+
+  it('passes the requested limit through', async () => {
+    global.fetch = jest.fn(() => ok({ success: true, totals: {}, blocks: [] }));
+    await fetch_chain_activity_blocks(25);
+    expect(global.fetch.mock.calls[0][0]).toContain('limit=25');
+  });
+
+  it('fails soft on success:false rather than throwing', async () => {
+    global.fetch = jest.fn(() => ok({ success: false }));
+    const result = await fetch_chain_activity_blocks();
+    expect(result.ok).toBe(false);
+    expect(result.blocks).toEqual([]);
+    expect(result.totals.utilityTotal).toBe(0);
+  });
+
+  it('fails soft on a network error', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('offline')));
+    const result = await fetch_chain_activity_blocks();
+    expect(result.ok).toBe(false);
+    expect(result.blocks).toEqual([]);
+  });
+
+  it('tolerates a malformed blocks field', async () => {
+    global.fetch = jest.fn(() => ok({ success: true, totals: {}, blocks: 'nope' }));
+    const result = await fetch_chain_activity_blocks();
+    expect(result.blocks).toEqual([]);
+  });
+});
+
+describe('blockCategoryLabel', () => {
+  it('names each category, including both', () => {
+    expect(blockCategoryLabel({ isP2p: true, isDapp: false })).toBe('P2P');
+    expect(blockCategoryLabel({ isP2p: false, isDapp: true })).toBe('Dapp');
+    expect(blockCategoryLabel({ isP2p: true, isDapp: true })).toBe('P2P + Dapp');
+  });
+
+  it('renders a dash for a block that is neither, and for junk', () => {
+    expect(blockCategoryLabel({ isP2p: false, isDapp: false })).toBe('\u2014');
+    expect(blockCategoryLabel(null)).toBe('\u2014');
+    expect(blockCategoryLabel(undefined)).toBe('\u2014');
   });
 });


### PR DESCRIPTION
Closes #199. Clicking the Utility figure expands the blocks behind it — category subtotals, then the most recent 50 utility blocks with category and transfer count.

## Backend: the data was already being computed and thrown away

`scan_one_block` calculated `transfers` and checked `deployment_heights`, then **collapsed both into a single `is_utility` bool**. This was a persistence-and-exposure gap, not a new-algorithm problem.

`BlockScanResult` now keeps `is_p2p`, `is_dapp` and `transfer_count`, and `is_utility` stays exactly `is_p2p || is_dapp` — so every existing `is_block_utility` test still holds unchanged.

`UtilityBlockRecord` persists to `chain_activity_utility_blocks.json` using the same `write_json_atomic` pattern as the daily rollup and team txs, populated in `fold_contiguous_results` and trimmed by `trim_utility_blocks` mirroring `trim_team_txs`. The contiguous-run discipline already guarantees each height folds exactly once, so **no dedupe is needed**.

**Only utility blocks are recorded.** Nobody drills into "nothing happened", and a live probe measured ~17% of blocks as utility — recording everything would roughly sextuple the file for no reader. Retained set: ~3,900 records over the 8-day window.

## API: a separate endpoint, deliberately

`GET /api/v1/chain-activity/blocks?limit=50` rather than more fields on `/chain-activity`, which **every** Chain Activity tab load already fetches. Folding a few hundred KB in would tax every visitor for a drill-down only some open. `limit` is clamped 1..200 so a hand-crafted query can't pull the whole set.

The subtotals are **disjoint**:

```
p2p_only + dapp_only + both === utility_total
```

`is_p2p` and `is_dapp` are independent booleans, so overlapping "any P2P" / "any Dapp" tallies wouldn't sum to the total — three numbers that visibly fail to add up read as a bug on screen.

## Frontend

Fetched **lazily on first expand** and cached for the tab's lifetime: the initial network cost is unchanged, and reopening doesn't refetch.

The utility figure is a real `<button>` with `aria-expanded`/`aria-controls`. It's the only route into the drill-down, so it has to be reachable and announceable without a mouse.

**Why the list is capped:** the issue's own example — *"P2P (2) Dapp (2)"* — came from live-testing a scanner that had barely started. In steady state a day holds **~490 utility blocks**. So subtotals are shown in full and the list caps at 50 with a *"showing 50 of N"* footer, rather than rendering hundreds of rows nobody asked for.

## Honest gap

**The Rust half is not compiled** — no cargo toolchain on this machine, same as #218. Reviewed for consistency instead:

- every `BlockScanResult` construction updated
- all three `fold_contiguous_results` call sites take the new parameter
- `Query` imported where the handler needs it
- `UtilityBlockRecord` derives `Serialize` for the response

**It needs a real build before merge.**

## Verification

6 new Rust tests — category recording, empty-block exclusion, gap handling (a block past a gap must not appear in the drill-down any more than in the rollup), retention trim boundary, and the disjoint partition.

9 new JS tests — boundary normalisation, the totals summing, limit pass-through, and three fail-soft paths.

**508 tests / 36 suites pass** on the client, build exit 0. Drill-down CSS verified present in the built chunk and confirmed unique to this tab (no `hov-*`-style collision).

**Not verified:** how it looks, and the real subtotals against live chain data — both need the backend actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)