### PR TITLE
Donor tab: 7-day categorised transaction view (#211 part 3)

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -9,6 +9,8 @@ import { fetch_donor_nodes, sortByRank, mostRecentPayout } from 'analytics/donor
 import { fetch_donor_utilization } from 'analytics/donorUtilization';
 import { aggregateDonorAppsByCategory } from 'analytics/donorApps';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { fetch_wallet_tx_history } from 'analytics/walletTxFetch';
+import { counterpartyDisplay, WINDOW_DAYS } from 'analytics/walletTxHistory';
 import './index.scss';
 
 function fmtNum(n) {
@@ -18,6 +20,124 @@ function fmtNum(n) {
 
 function fmtPct(n) {
   return `${(n || 0).toFixed(1)}%`;
+}
+
+
+function fmtFlux(n) {
+  if (n == null) return '\u2014';
+  return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function txTime(unixSeconds) {
+  if (!unixSeconds) return '\u2014';
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/*
+ * The wallet's last WINDOW_DAYS of on-chain activity.
+ *
+ * Grouped by DIRECTION first, then type. "Payments sent" and "P2P" overlap --
+ * a payment you send is a P2P transfer -- so a flat list of types would
+ * double-count or need an arbitrary precedence rule. In/out/net is also the
+ * question someone actually has about their own address.
+ *
+ * Counterparties are named from a checked-in address book (exchanges and the
+ * Flux Foundation, from the fluxflow repo). An unknown counterparty shows as a
+ * shortened address rather than being guessed at.
+ */
+function WalletActivityPanel({ walletAddress }) {
+  const [state, setState] = useState({ status: 'loading', summary: null });
+
+  useEffect(() => {
+    if (!walletAddress) return undefined;
+    let cancelled = false;
+    setState({ status: 'loading', summary: null });
+    (async () => {
+      const result = await fetch_wallet_tx_history(walletAddress);
+      if (cancelled) return;
+      setState({ status: result.ok ? 'ready' : 'error', summary: result.summary });
+    })().catch(() => {
+      if (!cancelled) setState({ status: 'error', summary: null });
+    });
+    return () => { cancelled = true; };
+  }, [walletAddress]);
+
+  if (state.status === 'loading') {
+    return (
+      <div className="hov-panel dt-activity-panel">
+        <div className="hov-header"><span className="hov-header-title">RECENT ACTIVITY</span></div>
+        <div className="hov-empty">Loading recent transactions...</div>
+      </div>
+    );
+  }
+
+  if (state.status === 'error' || !state.summary) {
+    return (
+      <div className="hov-panel dt-activity-panel">
+        <div className="hov-header"><span className="hov-header-title">RECENT ACTIVITY</span></div>
+        <div className="hov-empty">Could not load transaction history right now.</div>
+      </div>
+    );
+  }
+
+  const { received, sent, net, rows } = state.summary;
+
+  return (
+    <div className="hov-panel dt-activity-panel">
+      <div className="hov-header">
+        <span className="hov-header-title">RECENT ACTIVITY</span>
+        <span className="hov-header-badge">last {WINDOW_DAYS} days</span>
+      </div>
+
+      <div className="dt-activity-summary">
+        <div className="dt-activity-col">
+          <span className="dt-activity-col-title">Received</span>
+          <div className="dt-activity-line"><span>Node rewards</span><strong>{fmtFlux(received.rewards)}</strong></div>
+          <div className="dt-activity-line"><span>From exchanges</span><strong>{fmtFlux(received.exchange)}</strong></div>
+          <div className="dt-activity-line"><span>From Flux Foundation</span><strong>{fmtFlux(received.foundation)}</strong></div>
+          <div className="dt-activity-line"><span>Transfers in</span><strong>{fmtFlux(received.transfers)}</strong></div>
+          <div className="dt-activity-line dt-activity-line--total"><span>Total in</span><strong>{fmtFlux(received.total)}</strong></div>
+        </div>
+
+        <div className="dt-activity-col">
+          <span className="dt-activity-col-title">Sent</span>
+          <div className="dt-activity-line"><span>To exchanges</span><strong>{fmtFlux(sent.exchange)}</strong></div>
+          <div className="dt-activity-line"><span>To Flux Foundation</span><strong>{fmtFlux(sent.foundation)}</strong></div>
+          <div className="dt-activity-line"><span>Transfers out</span><strong>{fmtFlux(sent.transfers)}</strong></div>
+          <div className="dt-activity-line"><span /><strong /></div>
+          <div className="dt-activity-line dt-activity-line--total"><span>Total out</span><strong>{fmtFlux(sent.total)}</strong></div>
+        </div>
+      </div>
+
+      <div className={`dt-activity-net${net >= 0 ? ' dt-activity-net--up' : ' dt-activity-net--down'}`}>
+        net {net >= 0 ? '+' : '\u2212'}{fmtFlux(Math.abs(net))} FLUX over {WINDOW_DAYS} days
+      </div>
+
+      <div className="dt-activity-list">
+        {rows.length === 0 ? (
+          <div className="hov-empty">No transactions in the last {WINDOW_DAYS} days</div>
+        ) : (
+          rows.map((row) => (
+            <div key={row.txid} className="dt-activity-row">
+              <span className="dt-activity-date">{txTime(row.time)}</span>
+              <span className={`dt-activity-party dt-activity-party--${row.counterpartyKind || 'unknown'}`}>
+                {counterpartyDisplay(row)}
+              </span>
+              <span className={`dt-activity-amount dt-activity-amount--${row.direction}`}>
+                {row.direction === 'in' ? '+' : '\u2212'}{fmtFlux(row.amount)}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="dt-activity-caption">
+        Counterparties are named where the address is known (exchanges, Flux
+        Foundation). Flux app payments go to a Foundation address, so they appear
+        under Flux Foundation rather than as a separate deployment category.
+      </div>
+    </div>
+  );
 }
 
 // ── Payout card ──────────────────────────────────────────────────────────
@@ -262,6 +382,7 @@ export function DonorTab() {
         <DonorNodesList nodes={nodes} />
         <AppsByCategoryPanel categories={appCategories.categories} totalApps={appCategories.totalApps} />
         <UtilizationPanel donorUtil={utilization} networkPct={networkPct} />
+        <WalletActivityPanel walletAddress={donorWallet} />
       </div>
     </div>
   );

--- a/client/src/analytics/DonorTab/index.scss
+++ b/client/src/analytics/DonorTab/index.scss
@@ -376,3 +376,115 @@
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
+
+// ── Recent activity (issue #211) ──────────────────────────────────
+
+// Spans the grid: two summary columns plus a transaction list need more width
+// than a single cell, and squeezing them would defeat the point.
+.dt-activity-panel {
+  grid-column: 1 / -1;
+}
+
+.dt-activity-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+  margin-bottom: 10px;
+}
+
+.dt-activity-col-title {
+  display: block;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+
+.dt-activity-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.78rem;
+  padding: 2px 0;
+  color: var(--text-secondary);
+  min-height: 1.35em;
+
+  strong {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  &--total {
+    border-top: 1px solid var(--border-secondary);
+    margin-top: 4px;
+    padding-top: 5px;
+    font-weight: 600;
+  }
+}
+
+.dt-activity-net {
+  font-size: 0.86rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  padding: 6px 0 10px;
+  border-bottom: 1px solid var(--border-secondary);
+  margin-bottom: 8px;
+
+  &--up { color: var(--accent-green); }
+  &--down { color: var(--accent-red); }
+}
+
+.dt-activity-list {
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dt-activity-row {
+  display: grid;
+  grid-template-columns: 60px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.76rem;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+
+  &:hover { background: var(--surface-inset); }
+}
+
+.dt-activity-date {
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.dt-activity-party {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+
+  // Known counterparties are highlighted; an unknown address stays neutral so
+  // the named ones stand out rather than everything competing.
+  &--exchange { color: var(--accent-amber); font-weight: 600; }
+  &--foundation { color: var(--accent-indigo); font-weight: 600; }
+  &--reward { color: var(--accent-blue); }
+}
+
+.dt-activity-amount {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+
+  &--in { color: var(--accent-green); }
+  &--out { color: var(--accent-red); }
+}
+
+.dt-activity-caption {
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  padding-top: 8px;
+}

--- a/client/src/analytics/walletTxFetch.js
+++ b/client/src/analytics/walletTxFetch.js
@@ -1,0 +1,45 @@
+import { explorerFetchJson } from 'explorer';
+import { buildWalletTxSummary, WINDOW_DAYS } from 'analytics/walletTxHistory';
+
+/*
+ * A wallet's recent transactions, for the Donor tab's activity panel.
+ *
+ * Goes through the explorer POOL (src/explorer.js) rather than a hardcoded
+ * host, so a rate limit on one explorer fails over instead of blanking the
+ * panel -- the same failure that was presenting as a CORS error before #218.
+ *
+ * Pages are walked newest-first and stop as soon as a page is entirely older
+ * than the window. An address with years of history should not cost a full
+ * scan to answer "what happened this week"; MAX_PAGES is a hard backstop for
+ * an address whose pages are not ordered as expected.
+ */
+
+const MAX_PAGES = 10;
+
+export async function fetch_wallet_tx_history(walletAddress, windowDays = WINDOW_DAYS) {
+  const empty = { ok: false, summary: null };
+  if (!walletAddress) return empty;
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const cutoff = nowSec - windowDays * 86400;
+  const basePath = `/txs?address=${walletAddress}`;
+
+  const first = await explorerFetchJson(basePath);
+  if (!first) return empty;
+
+  const txs = Array.isArray(first.txs) ? [...first.txs] : [];
+  const pagesTotal = first.pagesTotal || 1;
+
+  for (let page = 1; page < Math.min(pagesTotal, MAX_PAGES); page += 1) {
+    // Every transaction on the previous page predates the window, so no later
+    // page can contain anything newer.
+    const pageAllOld = txs.length > 0 && txs.every((t) => (t.time || 0) < cutoff);
+    if (pageAllOld) break;
+
+    const json = await explorerFetchJson(`${basePath}&pageNum=${page}`);
+    if (!json) break; // partial history is still worth showing
+    if (Array.isArray(json.txs)) txs.push(...json.txs);
+  }
+
+  return { ok: true, summary: buildWalletTxSummary(txs, walletAddress, nowSec, windowDays) };
+}

--- a/client/src/analytics/walletTxHistory.js
+++ b/client/src/analytics/walletTxHistory.js
@@ -1,0 +1,186 @@
+import { lookupAddress } from 'data/fluxAddressBook';
+
+/*
+ * A wallet's recent on-chain history, grouped the way an address actually
+ * experiences it: what came IN, what went OUT.
+ *
+ * Why direction-first rather than a flat list of types: "payments sent" and
+ * "P2P" overlap -- a payment you send IS a P2P transfer -- so a flat list
+ * double-counts or forces an arbitrary rule about which bucket wins. Splitting
+ * on direction first means every transaction lands in exactly one bucket, and
+ * the summary reads as in/out/net, which is the question someone actually has.
+ *
+ * Amounts are computed from the wallet's own perspective:
+ *
+ *   received  the sum of outputs paid TO the wallet
+ *   sent      the sum of outputs paid to ANYONE ELSE in a transaction the
+ *             wallet funded -- change returning to itself is excluded, or every
+ *             send would look larger than it was
+ *
+ * Counterparty labelling uses the checked-in address book (exchanges, Flux
+ * Foundation). An unknown counterparty is reported as unknown rather than
+ * guessed at: a wrong label is worse than no label.
+ *
+ * On app deployments -- deliberately NOT a separate category. Flux app payments
+ * go to a Foundation address (per the v9 whitepaper: consensus splits the
+ * payment, with the remainder going to "the Foundation address that already
+ * receives application payments today"), so they are indistinguishable on chain
+ * from any other payment to the Foundation without a per-spec payment memo,
+ * which the current app-spec version does not carry. They therefore show as
+ * "Flux Foundation" rather than being asserted as deployments.
+ */
+
+export const WINDOW_DAYS = 7;
+const SECONDS_PER_DAY = 86400;
+
+/** Sum of every output in `tx` paid to `address`. An output can repeat. */
+function paidTo(tx, address) {
+  let total = 0;
+  for (const vout of tx?.vout || []) {
+    const addresses = vout?.scriptPubKey?.addresses || [];
+    if (!addresses.includes(address)) continue;
+    const value = Number(vout.value);
+    if (Number.isFinite(value)) total += value;
+  }
+  return total;
+}
+
+/** Sum of every output paid to someone OTHER than `address` (i.e. not change). */
+function paidToOthers(tx, address) {
+  let total = 0;
+  let counterparty = null;
+  for (const vout of tx?.vout || []) {
+    const addresses = vout?.scriptPubKey?.addresses || [];
+    if (addresses.length === 0 || addresses.includes(address)) continue;
+    const value = Number(vout.value);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    total += value;
+    // First non-self output with a real value is the counterparty shown. A
+    // transaction paying several parties is rare here and the full amount is
+    // still summed, so the total stays correct even when the label is partial.
+    if (counterparty === null) counterparty = addresses[0];
+  }
+  return { total, counterparty };
+}
+
+/**
+ * Classify one transaction from `walletAddress`'s point of view.
+ * Returns null for a transaction that does not touch the wallet at all.
+ */
+export function categorizeWalletTx(tx, walletAddress) {
+  if (!tx || !walletAddress) return null;
+
+  const fundedByWallet = (tx.vin || []).some((v) => v?.addr === walletAddress);
+  const received = paidTo(tx, walletAddress);
+
+  // A coinbase output to the wallet is a node reward. Checked before the
+  // generic incoming case so rewards do not land in "transfers in", which
+  // would make the headline "rewards received" figure meaningless.
+  if (tx.isCoinBase) {
+    if (received <= 0) return null;
+    return {
+      txid: tx.txid,
+      height: tx.blockheight,
+      time: tx.time,
+      direction: 'in',
+      type: 'reward',
+      amount: received,
+      counterparty: null,
+      counterpartyLabel: 'Node reward',
+      counterpartyKind: 'reward',
+    };
+  }
+
+  if (fundedByWallet) {
+    const { total, counterparty } = paidToOthers(tx, walletAddress);
+    // A self-send (consolidation) pays nobody else. Reporting it as an
+    // outgoing payment of 0 would add a meaningless row.
+    if (total <= 0) return null;
+    const known = lookupAddress(counterparty);
+    return {
+      txid: tx.txid,
+      height: tx.blockheight,
+      time: tx.time,
+      direction: 'out',
+      type: known?.kind === 'exchange' ? 'exchange' : known?.kind === 'foundation' ? 'foundation' : 'transfer',
+      amount: total,
+      counterparty,
+      counterpartyLabel: known?.name || null,
+      counterpartyKind: known?.kind || null,
+    };
+  }
+
+  if (received > 0) {
+    const counterparty = (tx.vin || []).find((v) => v?.addr)?.addr || null;
+    const known = lookupAddress(counterparty);
+    return {
+      txid: tx.txid,
+      height: tx.blockheight,
+      time: tx.time,
+      direction: 'in',
+      type: known?.kind === 'exchange' ? 'exchange' : known?.kind === 'foundation' ? 'foundation' : 'transfer',
+      amount: received,
+      counterparty,
+      counterpartyLabel: known?.name || null,
+      counterpartyKind: known?.kind || null,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Roll a wallet's transactions up into the in/out summary and a row list.
+ *
+ * @param {Array} txs explorer transactions (newest first is not required)
+ * @param {string} walletAddress
+ * @param {number} [nowSec] unix seconds; defaults to now. Injectable so tests
+ *        are not time-dependent.
+ * @param {number} [windowDays]
+ */
+export function buildWalletTxSummary(txs, walletAddress, nowSec, windowDays = WINDOW_DAYS) {
+  const now = nowSec || Math.floor(Date.now() / 1000);
+  const cutoff = now - windowDays * SECONDS_PER_DAY;
+
+  const rows = [];
+  for (const tx of Array.isArray(txs) ? txs : []) {
+    // A transaction with no timestamp cannot be placed in the window. Dropping
+    // it is safer than assuming "now" and inflating the totals.
+    if (!tx?.time || tx.time < cutoff) continue;
+    const row = categorizeWalletTx(tx, walletAddress);
+    if (row) rows.push(row);
+  }
+
+  rows.sort((a, b) => (b.time || 0) - (a.time || 0));
+
+  const bucket = () => ({ rewards: 0, exchange: 0, foundation: 0, transfers: 0, total: 0, count: 0 });
+  const received = bucket();
+  const sent = bucket();
+
+  for (const row of rows) {
+    const side = row.direction === 'in' ? received : sent;
+    if (row.type === 'reward') side.rewards += row.amount;
+    else if (row.type === 'exchange') side.exchange += row.amount;
+    else if (row.type === 'foundation') side.foundation += row.amount;
+    else side.transfers += row.amount;
+    side.total += row.amount;
+    side.count += 1;
+  }
+
+  return {
+    windowDays,
+    cutoff,
+    rows,
+    received,
+    sent,
+    net: received.total - sent.total,
+  };
+}
+
+/** "Kucoin", "Flux Foundation", "Node reward", or a shortened raw address. */
+export function counterpartyDisplay(row) {
+  if (!row) return '—';
+  if (row.counterpartyLabel) return row.counterpartyLabel;
+  if (!row.counterparty) return 'Unknown';
+  return `${row.counterparty.slice(0, 8)}…${row.counterparty.slice(-4)}`;
+}

--- a/client/src/analytics/walletTxHistory.test.js
+++ b/client/src/analytics/walletTxHistory.test.js
@@ -1,0 +1,205 @@
+import { categorizeWalletTx, buildWalletTxSummary, counterpartyDisplay, WINDOW_DAYS } from './walletTxHistory';
+import { EXCHANGES, FOUNDATION, lookupAddress } from 'data/fluxAddressBook';
+
+const WALLET = 't1WalletUnderTest0000000000000000000';
+const STRANGER = 't1SomeoneElse00000000000000000000000';
+const KUCOIN = EXCHANGES.find((e) => e.name === 'Kucoin').addresses[0];
+const FOUNDATION_ADDR = FOUNDATION.addresses[0];
+
+const NOW = 1_800_000_000;
+const recent = NOW - 3600;               // an hour ago
+const old = NOW - 30 * 86400;            // 30 days ago, outside the 7-day window
+
+function out(address, value) {
+  return { value: String(value), scriptPubKey: { addresses: [address] } };
+}
+
+function tx({ txid = 'tx', time = recent, vin = [], vout = [], isCoinBase = false, blockheight = 100 }) {
+  return { txid, time, vin, vout, isCoinBase, blockheight };
+}
+
+describe('fluxAddressBook', () => {
+  it('resolves exchange and foundation addresses, and nothing else', () => {
+    expect(lookupAddress(KUCOIN)).toEqual({ kind: 'exchange', name: 'Kucoin' });
+    expect(lookupAddress(FOUNDATION_ADDR)).toEqual({ kind: 'foundation', name: 'Flux Foundation' });
+    expect(lookupAddress(STRANGER)).toBeNull();
+    expect(lookupAddress(null)).toBeNull();
+  });
+
+  it('keeps the exchange and foundation sets disjoint', () => {
+    // An address in both would resolve to whichever loaded last -- a silent,
+    // order-dependent mislabel.
+    const exchangeAddrs = new Set(EXCHANGES.flatMap((e) => e.addresses));
+    const overlap = FOUNDATION.addresses.filter((a) => exchangeAddrs.has(a));
+    expect(overlap).toEqual([]);
+  });
+});
+
+describe('categorizeWalletTx', () => {
+  it('reads a coinbase output to the wallet as a node reward, not a transfer', () => {
+    // Checked before the generic incoming case: rewards landing in "transfers
+    // in" would make the headline rewards figure meaningless.
+    const row = categorizeWalletTx(tx({ isCoinBase: true, vout: [out(WALLET, 2.8125)] }), WALLET);
+    expect(row.type).toBe('reward');
+    expect(row.direction).toBe('in');
+    expect(row.amount).toBeCloseTo(2.8125);
+  });
+
+  it('ignores a coinbase that pays someone else', () => {
+    expect(categorizeWalletTx(tx({ isCoinBase: true, vout: [out(STRANGER, 2.8)] }), WALLET)).toBeNull();
+  });
+
+  it('labels an outgoing payment to a known exchange', () => {
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: WALLET }], vout: [out(KUCOIN, 100)] }), WALLET
+    );
+    expect(row.direction).toBe('out');
+    expect(row.type).toBe('exchange');
+    expect(row.counterpartyLabel).toBe('Kucoin');
+    expect(row.amount).toBe(100);
+  });
+
+  it('labels an outgoing payment to the Flux Foundation', () => {
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: WALLET }], vout: [out(FOUNDATION_ADDR, 10)] }), WALLET
+    );
+    expect(row.type).toBe('foundation');
+    expect(row.counterpartyLabel).toBe('Flux Foundation');
+  });
+
+  it('EXCLUDES change returning to the wallet from a send', () => {
+    // The bug this guards: counting every output would report a 10 FLUX send
+    // as 90, because 80 came straight back as change.
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: WALLET }], vout: [out(STRANGER, 10), out(WALLET, 80)] }), WALLET
+    );
+    expect(row.direction).toBe('out');
+    expect(row.amount).toBe(10);
+  });
+
+  it('sums a send that pays several parties', () => {
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: WALLET }], vout: [out(STRANGER, 10), out(KUCOIN, 5), out(WALLET, 1)] }), WALLET
+    );
+    expect(row.amount).toBe(15);
+    // The label names the first real counterparty; the total still covers all.
+    expect(row.counterparty).toBe(STRANGER);
+  });
+
+  it('ignores a self-send that pays nobody else', () => {
+    // A consolidation would otherwise add a meaningless 0-value outgoing row.
+    expect(categorizeWalletTx(
+      tx({ vin: [{ addr: WALLET }], vout: [out(WALLET, 50)] }), WALLET
+    )).toBeNull();
+  });
+
+  it('reads an incoming transfer from an unknown sender', () => {
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: STRANGER }], vout: [out(WALLET, 7.5)] }), WALLET
+    );
+    expect(row.direction).toBe('in');
+    expect(row.type).toBe('transfer');
+    expect(row.counterpartyLabel).toBeNull();
+    expect(row.amount).toBe(7.5);
+  });
+
+  it('labels an incoming transfer FROM an exchange', () => {
+    const row = categorizeWalletTx(
+      tx({ vin: [{ addr: KUCOIN }], vout: [out(WALLET, 40)] }), WALLET
+    );
+    expect(row.direction).toBe('in');
+    expect(row.type).toBe('exchange');
+    expect(row.counterpartyLabel).toBe('Kucoin');
+  });
+
+  it('returns null for a transaction that does not touch the wallet', () => {
+    expect(categorizeWalletTx(tx({ vin: [{ addr: STRANGER }], vout: [out(KUCOIN, 1)] }), WALLET)).toBeNull();
+  });
+
+  it('survives malformed input', () => {
+    expect(categorizeWalletTx(null, WALLET)).toBeNull();
+    expect(categorizeWalletTx(tx({}), WALLET)).toBeNull();
+    expect(categorizeWalletTx(tx({ vin: [{ addr: WALLET }], vout: [{ value: 'x' }] }), WALLET)).toBeNull();
+  });
+});
+
+describe('buildWalletTxSummary', () => {
+  it('splits totals by direction and type, and nets them', () => {
+    const summary = buildWalletTxSummary([
+      tx({ txid: 'r1', isCoinBase: true, vout: [out(WALLET, 3)] }),
+      tx({ txid: 'r2', isCoinBase: true, vout: [out(WALLET, 2)] }),
+      tx({ txid: 'in', vin: [{ addr: STRANGER }], vout: [out(WALLET, 10)] }),
+      tx({ txid: 'ex', vin: [{ addr: WALLET }], vout: [out(KUCOIN, 4)] }),
+      tx({ txid: 'fo', vin: [{ addr: WALLET }], vout: [out(FOUNDATION_ADDR, 1)] }),
+    ], WALLET, NOW);
+
+    expect(summary.received.rewards).toBe(5);
+    expect(summary.received.transfers).toBe(10);
+    expect(summary.received.total).toBe(15);
+    expect(summary.sent.exchange).toBe(4);
+    expect(summary.sent.foundation).toBe(1);
+    expect(summary.sent.total).toBe(5);
+    expect(summary.net).toBe(10);
+    expect(summary.rows).toHaveLength(5);
+  });
+
+  it('excludes transactions older than the window', () => {
+    const summary = buildWalletTxSummary([
+      tx({ txid: 'recent', isCoinBase: true, time: recent, vout: [out(WALLET, 3)] }),
+      tx({ txid: 'old', isCoinBase: true, time: old, vout: [out(WALLET, 999)] }),
+    ], WALLET, NOW);
+    expect(summary.rows.map((r) => r.txid)).toEqual(['recent']);
+    expect(summary.received.rewards).toBe(3);
+  });
+
+  it('drops a transaction with no timestamp rather than assuming it is recent', () => {
+    // Assuming "now" would silently inflate the window's totals.
+    const summary = buildWalletTxSummary([
+      // NB: null, not undefined -- a destructuring default fires on undefined,
+      // so tx({ time: undefined }) would silently get the helper default and
+      // this test would pass for the wrong reason.
+      tx({ txid: 'notime', time: null, isCoinBase: true, vout: [out(WALLET, 500)] }),
+    ], WALLET, NOW);
+    expect(summary.rows).toEqual([]);
+    expect(summary.received.total).toBe(0);
+  });
+
+  it('honours the window boundary exactly', () => {
+    const onEdge = NOW - WINDOW_DAYS * 86400;
+    const summary = buildWalletTxSummary([
+      tx({ txid: 'edge', time: onEdge, isCoinBase: true, vout: [out(WALLET, 1)] }),
+      tx({ txid: 'past', time: onEdge - 1, isCoinBase: true, vout: [out(WALLET, 1)] }),
+    ], WALLET, NOW);
+    expect(summary.rows.map((r) => r.txid)).toEqual(['edge']);
+  });
+
+  it('sorts rows newest first', () => {
+    const summary = buildWalletTxSummary([
+      tx({ txid: 'older', time: NOW - 7200, isCoinBase: true, vout: [out(WALLET, 1)] }),
+      tx({ txid: 'newer', time: NOW - 60, isCoinBase: true, vout: [out(WALLET, 1)] }),
+    ], WALLET, NOW);
+    expect(summary.rows.map((r) => r.txid)).toEqual(['newer', 'older']);
+  });
+
+  it('handles an empty or missing list', () => {
+    expect(buildWalletTxSummary([], WALLET, NOW).rows).toEqual([]);
+    expect(buildWalletTxSummary(null, WALLET, NOW).net).toBe(0);
+  });
+});
+
+describe('counterpartyDisplay', () => {
+  it('prefers a known name', () => {
+    expect(counterpartyDisplay({ counterpartyLabel: 'Kucoin', counterparty: KUCOIN })).toBe('Kucoin');
+  });
+
+  it('shortens an unknown address rather than showing it whole', () => {
+    const shown = counterpartyDisplay({ counterpartyLabel: null, counterparty: STRANGER });
+    expect(shown).toContain('…');
+    expect(shown.length).toBeLessThan(STRANGER.length);
+  });
+
+  it('says Unknown when there is no counterparty at all', () => {
+    expect(counterpartyDisplay({ counterpartyLabel: null, counterparty: null })).toBe('Unknown');
+    expect(counterpartyDisplay(null)).toBe('—');
+  });
+});

--- a/client/src/data/fluxAddressBook.js
+++ b/client/src/data/fluxAddressBook.js
@@ -1,0 +1,67 @@
+/*
+ * Known Flux addresses: exchange deposit addresses, and the Flux Foundation.
+ *
+ * Source: 2ndtlmining/fluxflow, src/lib/data/exchanges.json, fetched
+ * 2026-09-11. Kept as a checked-in copy rather than fetched at runtime -- it
+ * changes rarely, a network dependency here would mean a rate limit could
+ * silently downgrade every label to "unknown", and a wrong label is worse than
+ * no label.
+ *
+ * Note for whoever updates this: todo.md previously recorded that no reliable
+ * public source of Flux exchange addresses existed. That was wrong -- this
+ * list is maintained in fluxflow. Re-check there before concluding otherwise.
+ *
+ * Verified at import time: the exchange and foundation sets do not overlap, so
+ * an address resolves to exactly one label.
+ */
+
+export const EXCHANGES = [
+  { name: 'Coinex', addresses: ['t1bLYKTWBMUSAhrU2ezDEzC2BXYbafz5L9e'] },
+  { name: 'GateIO', addresses: ['t1YvimnGBmVA7xDiPnqwbKsvujmSJz4X5m2'] },
+  { name: 'Kucoin', addresses: ['t1g7QCktktwReoHgwWtAgNBVvzzboQVZy19', 't1gorwQHhWsvfgSEE3YzBZFnyewfGaimUbF', 't1bVAMF4KUxcyVZa3X3sPB4Tx5jmdgS876X'] },
+  { name: 'NonKYC', addresses: ['t1LXVRNWEugRtoWdNgxnozCBGksGtCvvWsy', 't1eELWS8QBkhRfEF2LBZnxKwCQaWvZ8j8hU'] },
+];
+
+export const FOUNDATION = {
+  name: 'Flux Foundation',
+  addresses: [
+    't3c51GjrkUg7pUiS8bzNdTnW2hD25egWUih',
+    't3ZQQsd8hJNw6UQKYLwfofdL3ntPmgkwofH',
+    't3XjYMBvwxnXVv9jqg4CgokZ3f7kAoXPQL8',
+    't1XWTigDqS5Dy9McwQc752ShtZV1ffTMJB3',
+    't1eabPBaLCqNgttQMnAoohPaQM6u2vFwTNJ',
+    't3PMbbA5YBMrjSD3dD16SSdXKuKovwmj6tS',
+    't1abAp9oZenibGLFuZKyUjmL6FiATTaCYaj',
+    't1cjcLaDHkNcuXh6uoyNL7u1jx7GxvzfYAN',
+    't3ThbWogDoAjGuS6DEnmN1GWJBRbVjSUK4T',
+    't3heoBJT9gn9mne7Q5aynajJo7tReyDv2NV',
+    't1ZLpyVr6hs3vAH7qKujJRpu17G3VdxAkrY',
+    't1SHUuYiE8UT7Hnu9Qr3QcGu3W4L55W98pU',
+    't1Yum7okNzR5kW84dfgwqB23yy1BCcpHFPq',
+    't1Zj9vUsAMoG4M9LSy5ahDzZUmokKGXqwcT',
+    't3c4EfxLoXXSRZCRnPRF3RpjPi9mBzF5yoJ',
+    't1PGMqZxGPzPQcpJKWVyLc4c9D7SvjVe4kq',
+    't1enVJqsiqRxpdnQw3f6Zwp1jAk9e3Wj9n2',
+  ],
+};
+
+// Flat lookup built once at module load: an address history can be thousands
+// of transactions, and a linear scan per output would be needlessly quadratic.
+const ADDRESS_INDEX = new Map();
+for (const exchange of EXCHANGES) {
+  for (const address of exchange.addresses) {
+    ADDRESS_INDEX.set(address, { kind: 'exchange', name: exchange.name });
+  }
+}
+for (const address of FOUNDATION.addresses) {
+  ADDRESS_INDEX.set(address, { kind: 'foundation', name: FOUNDATION.name });
+}
+
+/**
+ * Identify a Flux address, or null when it is not one we know.
+ * @returns {{kind: 'exchange'|'foundation', name: string}|null}
+ */
+export function lookupAddress(address) {
+  if (!address) return null;
+  return ADDRESS_INDEX.get(address) || null;
+}


### PR DESCRIPTION
Part 3 of #211. Parts 1 and 2 shipped in #220.

## I was wrong about exchanges, and the correction matters

When I filed #211 I wrote that *"Sent to Exchanges" is not currently buildable*, citing `todo.md`'s note that no reliable public source of Flux exchange addresses exists.

**That was wrong.** The list is maintained in your own `2ndtlmining/fluxflow` repo (`src/lib/data/exchanges.json`) — 4 exchanges across 7 addresses, plus **17 Flux Foundation addresses**. `todo.md`'s note should be treated as stale, not authoritative.

The address book is **checked in rather than fetched at runtime**: it changes rarely, and a network dependency would mean a rate limit could silently downgrade every label to "unknown". A wrong or missing label is worse than the category not existing.

## Grouped by direction, then type

```
RECEIVED                      SENT
──────────────────            ──────────────────
Node rewards      412.50      To exchanges      80.00
From exchanges      0.00      To Flux Fdn       10.00
From Flux Fdn       0.00      Transfers out     12.50
Transfers in       25.00
──────────────────            ──────────────────
Total in          437.50      Total out        102.50

net +335.00 FLUX over 7 days

12 Sep   Node reward        +2.81
11 Sep   Kucoin            −80.00
11 Sep   Flux Foundation   −10.00
```

"Payments sent" and "P2P" as sibling categories **overlap** — a payment you send *is* a P2P transfer — so a flat list would double-count or need an arbitrary precedence rule. Direction-first puts every transaction in exactly one bucket, and in/out/net is the question someone actually has about their own address.

**Change is excluded from sends.** Counting every output would report a 10 FLUX payment as 90 when 80 came straight back as change. There's a test pinning exactly that.

## Why app deployments aren't a separate category

Flux app payments go to a **Foundation address** — the v9 whitepaper says consensus splits the payment, with the remainder going to *"the Foundation address that already receives application payments today"*.

So on chain they're **indistinguishable** from any other Foundation payment without a per-spec payment memo, which the current app-spec version doesn't carry (that's #206). They show as "Flux Foundation" rather than being asserted as deployments, and the panel says so in a footnote.

I'd rather show a true label than a plausible-looking wrong one.

## Rate-limit resilience

Fetching goes through the **explorer pool from #218**, so a throttled host fails over instead of blanking the panel. Pages are walked newest-first and stop as soon as a page is entirely older than the window — an address with years of history shouldn't cost a full scan to answer "what happened this week".

## Noted, not fixed

`chain_activity.rs`'s `FLUX_TEAM_ADDRESSES` holds **one** address that is **not** in fluxflow's 17-address Foundation list. Two independently-maintained notions of "Flux team addresses" that disagree — worth reconciling, but out of scope here.

## Verification

22 new tests: change-exclusion, coinbase-checked-before-transfer (rewards landing in "transfers in" would make the headline figure meaningless), self-send exclusion, window boundary, missing timestamps, and the exchange/foundation sets being **disjoint** — an address in both would resolve to whichever loaded last, a silent order-dependent mislabel.

**530 tests / 38 suites pass**, build exit 0. Styles confirmed in the built chunk and unique to DonorTab.

**Not verified:** appearance, and the real numbers against a live wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)