### PR TITLE
fix(#166): repair privacy masking and donor pickup drift between /home and /nodes

### DIFF
--- a/client/src/Application.jsx
+++ b/client/src/Application.jsx
@@ -126,8 +126,8 @@ class Application extends React.Component {
                     <ErrorBoundary>
                       <React.Suspense fallback={<PageLoader />}>
                         <DonorContext.Consumer>
-                          {({ setDonorWallet }) => (
-                            <Home theme={darkMode ? 'dark' : 'light'} setDonorWallet={setDonorWallet} />
+                          {({ donorWallet, setDonorWallet }) => (
+                            <Home theme={darkMode ? 'dark' : 'light'} donorWallet={donorWallet} setDonorWallet={setDonorWallet} />
                           )}
                         </DonorContext.Consumer>
                       </React.Suspense>

--- a/client/src/home/Home.jsx
+++ b/client/src/home/Home.jsx
@@ -12,6 +12,7 @@ import { HomeOverview } from 'home/HomeOverview';
 import { DonorBadge } from 'donor/DonorBadge';
 import { runDonorAutoDetect } from 'donor/runDonorAutoDetect';
 import { CHECK_STATUS } from 'donor/donorWalletCheck';
+import { createNewHistoryList, displayedAddress, privacyStatePatch } from 'wallet/addressInput';
 
 import { Button, Icon, InputGroup, Menu, MenuItem, mergeRefs, Switch } from '@blueprintjs/core';
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
@@ -35,7 +36,7 @@ import {
 import { appStore, StoreKeys } from 'persistance/store';
 
 import { LayoutContext } from 'contexts/LayoutContext';
-import { blurAllInputs, hide_sensitive_string } from 'utils';
+import { blurAllInputs } from 'utils';
 import { FaMedal } from 'react-icons/fa';
 
 
@@ -126,17 +127,20 @@ class Home extends React.Component {
     this.setState({ searchHistory }, () => this.hydrateApp());
 
     const hideSensitiveData = (isPrivateModeEnabled) => {
-      this.setState({ privacyMode: isPrivateModeEnabled });
-      if (!this.state.activeAddress) return;
-      if (!isPrivateModeEnabled) {
-        this.setSearch({ wallet: this.state.activeAddress }, { replace: false });
-        if (this.addressInputRef && this.addressInputRef.current)
-          this.addressInputRef.current.value = this.state.activeAddress;
-      } else {
-        this.setSearch({ wallet: hide_sensitive_string(this.state.activeAddress) }, { replace: false });
-        if (this.addressInputRef && this.addressInputRef.current)
-          this.addressInputRef.current.value = hide_sensitive_string(this.state.activeAddress);
+      const { activeAddress } = this.state;
+      if (!activeAddress) {
+        this.setState({ privacyMode: isPrivateModeEnabled });
+        return;
       }
+      /*
+       * The <InputGroup> is controlled by state.inputAddress, so the mask has
+       * to go through setState. Writing addressInputRef.current.value -- what
+       * this did before -- is undone by the very next render, which is why
+       * privacy mode never actually masked the field.
+       */
+      const shown = displayedAddress(isPrivateModeEnabled, activeAddress);
+      this.setState({ privacyMode: isPrivateModeEnabled, inputAddress: shown });
+      this.setSearch({ wallet: shown }, { replace: false });
     };
 
     await appStore.ready(function () {
@@ -160,7 +164,23 @@ class Home extends React.Component {
     if (this.context.autoRefresh) this._startAutoRefresh();
   }
 
+  /*
+   * Keep the address field in step with the privacy toggle (issue #166).
+   *
+   * This is the only thing that masks the field: the <InputGroup> is
+   * controlled by state.inputAddress, so writing addressInputRef.current.value
+   * is reverted by the next render. The URL is masked separately, by
+   * LayoutContext's own effect. privacyStatePatch returns null when nothing
+   * changed, which React treats as a bail-out, so this is safe to call on
+   * every update.
+   */
+  _syncPrivacyMode() {
+    this.setState((prev) => privacyStatePatch(this.context.enablePrivacyMode, prev));
+  }
+
   componentDidUpdate() {
+    this._syncPrivacyMode();
+
     const shouldRefresh = this.context.autoRefresh;
     if (shouldRefresh && !this._autoRefreshActive) {
       this._startAutoRefresh();
@@ -198,22 +218,7 @@ class Home extends React.Component {
   }
 
   _createNewHistoryList(oldValues, newTop) {
-    if (!oldValues || oldValues.constructor !== Array) {
-      if (!newTop) return [];
-      else return [newTop];
-    }
-
-    let _historyClone = [];
-    for (let i = 0; i < oldValues.length; i++) {
-      let val = oldValues[i];
-      if (val != newTop && _historyClone.indexOf(val) == -1)
-        //
-        _historyClone.push(val);
-    }
-
-    if (newTop) _historyClone.push(newTop);
-
-    return _historyClone;
+    return createNewHistoryList(oldValues, newTop);
   }
 
   hydrateApp() {
@@ -228,6 +233,22 @@ class Home extends React.Component {
       const address = wallet.toString();
       this.onProcessAddress(address);
       this.addressInputRef.current.value = address;
+      // The input is controlled: without this it renders blank despite the
+      // ref write above.
+      this.setState({ inputAddress: address });
+    } else if (this.props.donorWallet) {
+      /*
+       * A wallet unlocked as a donor elsewhere (the /live unlock dialog, or
+       * /nodes) but with no ?wallet= param on THIS page yet. /nodes already
+       * did this; /home ignored the unlocked wallet entirely.
+       *
+       * Only engages when no URL wallet is present, so it never overrides an
+       * explicit navigation.
+       */
+      const address = this.props.donorWallet;
+      this.onProcessAddress(address);
+      this.addressInputRef.current.value = address;
+      this.setState({ inputAddress: address });
     } else {
       fetch_global_stats(null)
         .then((gstore) => {
@@ -433,7 +454,7 @@ class Home extends React.Component {
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>
-          {this.state.privacyMode ? hide_sensitive_string(this.state.activeAddress) : this.state.activeAddress}
+          {displayedAddress(this.state.privacyMode, this.state.activeAddress)}
         </a>
       </div>
     );

--- a/client/src/main/MainApp.jsx
+++ b/client/src/main/MainApp.jsx
@@ -12,6 +12,7 @@ import { getEnterpriseNodes } from 'apidata';
 import { AppToaster } from 'components/AppToaster';
 import { runDonorAutoDetect } from 'donor/runDonorAutoDetect';
 import { CHECK_STATUS } from 'donor/donorWalletCheck';
+import { createNewHistoryList, displayedAddress, privacyStatePatch } from 'wallet/addressInput';
 import { DashboardCells } from 'main/Header';
 import { ParallelAssets } from 'main/ParallelAssets';
 import { PayoutTimer } from 'main/PayoutTimer';
@@ -39,7 +40,7 @@ import {
 import { appStore, StoreKeys } from 'persistance/store';
 
 import { LayoutContext } from 'contexts/LayoutContext';
-import { blurAllInputs, hide_sensitive_string } from 'utils';
+import { blurAllInputs } from 'utils';
 import { FaMedal } from 'react-icons/fa';
 import { DonorBadge } from 'donor/DonorBadge';
 //import { setGAEvent } from 'g-analytic';
@@ -138,17 +139,20 @@ class MainApp extends React.Component {
     this.setState({ searchHistory }, () => this.hydrateApp());
 
     const hideSensitiveData = (isPrivateModeEnabled) => {
-      this.setState({ privacyMode: isPrivateModeEnabled });
-      if (!this.state.activeAddress) return;
-      if (!isPrivateModeEnabled) {
-        this.setSearch({ wallet: this.state.activeAddress }, { replace: false });
-        if (this.addressInputRef && this.addressInputRef.current)
-          this.addressInputRef.current.value = this.state.activeAddress;
-      } else {
-        this.setSearch({ wallet: hide_sensitive_string(this.state.activeAddress) }, { replace: false });
-        if (this.addressInputRef && this.addressInputRef.current)
-          this.addressInputRef.current.value = hide_sensitive_string(this.state.activeAddress);
+      const { activeAddress } = this.state;
+      if (!activeAddress) {
+        this.setState({ privacyMode: isPrivateModeEnabled });
+        return;
       }
+      /*
+       * The <InputGroup> is controlled by state.inputAddress, so the mask has
+       * to go through setState. Writing addressInputRef.current.value -- what
+       * this did before -- is undone by the very next render, which is why
+       * privacy mode never actually masked the field.
+       */
+      const shown = displayedAddress(isPrivateModeEnabled, activeAddress);
+      this.setState({ privacyMode: isPrivateModeEnabled, inputAddress: shown });
+      this.setSearch({ wallet: shown }, { replace: false });
     };
 
     await appStore.ready(function () {
@@ -162,6 +166,15 @@ class MainApp extends React.Component {
         changeDetection: false
       });
 
+      /*
+       * Deliberately subscribed and immediately unsubscribed, as it has been
+       * since before #166: the observable is created with changeDetection
+       * false and LayoutContext writes PRIVACY_MODE from its render body, so
+       * this fires on every render of the provider. Input masking is driven
+       * from context in _syncPrivacyMode() instead, which needs no
+       * subscription. Left in place rather than deleted because removing the
+       * observable wiring is a separate change from fixing the mask.
+       */
       var methodCallSubscription = methodCallObservable.subscribe({
         next: function (args) {
           hideSensitiveData(args.newValue);
@@ -203,16 +216,22 @@ class MainApp extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  /*
+   * Keep the address field in step with the privacy toggle (issue #166).
+   *
+   * This is the only thing that masks the field: the <InputGroup> is
+   * controlled by state.inputAddress, so writing addressInputRef.current.value
+   * is reverted by the next render. The URL is masked separately, by
+   * LayoutContext's own effect. privacyStatePatch returns null when nothing
+   * changed, which React treats as a bail-out, so this is safe to call on
+   * every update.
+   */
+  _syncPrivacyMode() {
+    this.setState((prev) => privacyStatePatch(this.context.enablePrivacyMode, prev));
+  }
 
-    let inputField = this.addressInputRef.current.value
-
-    if (prevState.privacyMode !== this.context.enablePrivacyMode) {
-      prevState.privacyMode = this.context.enablePrivacyMode
-
-      this.setState({ inputAddress: !this.state.privacyMode ? this.state.activeAddress : hide_sensitive_string(inputField) });
-
-    }
+  componentDidUpdate() {
+    this._syncPrivacyMode();
 
     const shouldRefresh = this.context.autoRefresh;
     if (shouldRefresh && !this._autoRefreshActive) {
@@ -246,22 +265,7 @@ class MainApp extends React.Component {
   }
 
   _createNewHistoryList(oldValues, newTop) {
-    if (!oldValues || oldValues.constructor !== Array) {
-      if (!newTop) return [];
-      else return [newTop];
-    }
-
-    let _historyClone = [];
-    for (let i = 0; i < oldValues.length; i++) {
-      let val = oldValues[i];
-      if (val != newTop && _historyClone.indexOf(val) == -1)
-        //
-        _historyClone.push(val);
-    }
-
-    if (newTop) _historyClone.push(newTop);
-
-    return _historyClone;
+    return createNewHistoryList(oldValues, newTop);
   }
 
   async hydrateApp() {
@@ -486,7 +490,7 @@ class MainApp extends React.Component {
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>
-          {privacyMode ? hide_sensitive_string(this.state.activeAddress) : this.state.activeAddress}
+          {displayedAddress(privacyMode, this.state.activeAddress)}
         </a>
       </div>
     );

--- a/client/src/wallet/addressInput.js
+++ b/client/src/wallet/addressInput.js
@@ -1,0 +1,75 @@
+/*
+ * Shared state logic for the wallet address input that /home and /nodes both
+ * render (issue #166).
+ *
+ * Both pages grew from the same original component and still carry
+ * near-identical copies of this logic -- 463 identical lines between them. The
+ * copies have since drifted, and the drift caused real bugs rather than merely
+ * offending tidiness:
+ *
+ *   - the privacy-mode toggle masked the address on /nodes but not on /home
+ *   - a ?wallet= link left the input visibly blank on /home
+ *   - /nodes picked up a donor wallet unlocked elsewhere; /home did not
+ *
+ * This module holds the parts that are genuinely shared and provable in
+ * isolation, so the next fix lands in one place instead of one-and-a-half.
+ * The components stay classes: converting them to hooks is a separate, much
+ * larger change, and none of these bugs needed it.
+ */
+
+import { hide_sensitive_string } from 'utils';
+
+/*
+ * The search-history list with `newTop` moved to the end (the UI renders it
+ * most-recent-last), de-duplicated, with any previous occurrence removed.
+ *
+ * Moved verbatim from the two components, which held byte-identical copies.
+ * The loose `!=` and `== -1` are deliberate: history loaded from storage can
+ * hold non-string values, and tightening the comparisons here would silently
+ * change which entries are treated as duplicates.
+ */
+export function createNewHistoryList(oldValues, newTop) {
+  if (!oldValues || oldValues.constructor !== Array) {
+    if (!newTop) return [];
+    else return [newTop];
+  }
+  let _historyClone = [];
+  for (let i = 0; i < oldValues.length; i++) {
+    let val = oldValues[i];
+    if (val != newTop && _historyClone.indexOf(val) == -1) _historyClone.push(val);
+  }
+  if (newTop) _historyClone.push(newTop);
+  return _historyClone;
+}
+
+/*
+ * What the address field and the ?wallet= param should show for a given
+ * privacy-mode setting.
+ *
+ * Falsy addresses pass through untouched so callers can hand this an empty
+ * field without getting a masked empty string back.
+ */
+export function displayedAddress(privacyMode, address) {
+  if (!address) return address;
+  return privacyMode ? hide_sensitive_string(address) : address;
+}
+
+/*
+ * The state patch that brings a page's privacy state in line with the layout
+ * context, or null when nothing needs to change.
+ *
+ * Returning null matters: React treats a null from a setState updater as a
+ * bail-out, so componentDidUpdate can call this unconditionally without
+ * looping. Callers compare against CURRENT state rather than componentDidUpdate's
+ * prevState argument -- comparing prevState is what made the old /nodes
+ * version mask a render late, leaving a frame of unmasked address after every
+ * toggle.
+ *
+ * `inputAddress` is only rewritten when there is an active address to mask, so
+ * a half-typed search the user has not submitted is left alone.
+ */
+export function privacyStatePatch(privacyMode, prev) {
+  if (privacyMode === prev.privacyMode) return null;
+  if (!prev.activeAddress) return { privacyMode };
+  return { privacyMode, inputAddress: displayedAddress(privacyMode, prev.activeAddress) };
+}

--- a/client/src/wallet/addressInput.test.js
+++ b/client/src/wallet/addressInput.test.js
@@ -1,0 +1,92 @@
+import { createNewHistoryList, displayedAddress, privacyStatePatch } from './addressInput';
+
+describe('createNewHistoryList', () => {
+  it('returns an empty list when there is nothing to keep', () => {
+    expect(createNewHistoryList(null, null)).toEqual([]);
+    expect(createNewHistoryList(undefined, null)).toEqual([]);
+  });
+
+  it('seeds the list when there is no prior history', () => {
+    expect(createNewHistoryList(null, 'addr1')).toEqual(['addr1']);
+  });
+
+  it('treats a non-array as absent history rather than throwing', () => {
+    // History comes back from LocalForage, which can hand back whatever was
+    // last written -- including a value from an older schema.
+    expect(createNewHistoryList('not-an-array', 'addr1')).toEqual(['addr1']);
+    expect(createNewHistoryList({ 0: 'addr1' }, 'addr2')).toEqual(['addr2']);
+  });
+
+  it('appends the newest address last', () => {
+    expect(createNewHistoryList(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('moves a repeated address to the end instead of duplicating it', () => {
+    expect(createNewHistoryList(['a', 'b', 'c'], 'b')).toEqual(['a', 'c', 'b']);
+  });
+
+  it('drops duplicates already present in the stored history', () => {
+    expect(createNewHistoryList(['a', 'a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves the existing list when there is no new address', () => {
+    expect(createNewHistoryList(['a', 'b'], null)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the list it was given', () => {
+    const original = ['a', 'b'];
+    createNewHistoryList(original, 'c');
+    expect(original).toEqual(['a', 'b']);
+  });
+});
+
+describe('displayedAddress', () => {
+  const addr = 't1abc123XYZ';
+
+  it('returns the address unchanged when privacy mode is off', () => {
+    expect(displayedAddress(false, addr)).toBe(addr);
+  });
+
+  it('masks every alphanumeric character when privacy mode is on', () => {
+    expect(displayedAddress(true, addr)).toBe('XXXXXXXXXXX');
+  });
+
+  it('passes falsy addresses straight through', () => {
+    // An empty field must stay empty, not become a masked empty string.
+    expect(displayedAddress(true, '')).toBe('');
+    expect(displayedAddress(true, null)).toBe(null);
+    expect(displayedAddress(true, undefined)).toBe(undefined);
+  });
+});
+
+describe('privacyStatePatch', () => {
+  const base = { privacyMode: false, activeAddress: 't1abc', inputAddress: 't1abc' };
+
+  it('bails out when privacy mode already matches', () => {
+    // null is React's setState bail-out, so componentDidUpdate can call this
+    // unconditionally without re-rendering forever.
+    expect(privacyStatePatch(false, base)).toBeNull();
+    expect(privacyStatePatch(true, { ...base, privacyMode: true })).toBeNull();
+  });
+
+  it('masks the input when privacy mode turns on', () => {
+    expect(privacyStatePatch(true, base)).toEqual({ privacyMode: true, inputAddress: 'XXXXX' });
+  });
+
+  it('restores the address when privacy mode turns off', () => {
+    const masked = { privacyMode: true, activeAddress: 't1abc', inputAddress: 'XXXXX' };
+    expect(privacyStatePatch(false, masked)).toEqual({ privacyMode: false, inputAddress: 't1abc' });
+  });
+
+  it('leaves a half-typed search alone when no address is active', () => {
+    const typing = { privacyMode: false, activeAddress: null, inputAddress: 't1part' };
+    expect(privacyStatePatch(true, typing)).toEqual({ privacyMode: true });
+  });
+
+  it('masks from activeAddress, not from whatever is in the field', () => {
+    // The old /nodes code masked the input field's current text, so a toggle
+    // mid-edit masked the draft rather than the real address.
+    const editing = { privacyMode: false, activeAddress: 't1abc', inputAddress: 'zzz' };
+    expect(privacyStatePatch(true, editing)).toEqual({ privacyMode: true, inputAddress: 'XXXXX' });
+  });
+});


### PR DESCRIPTION
Partial progress on #166. The issue proposes extracting a shared `useFluxNodeData()` hook from `MainApp.jsx` and `Home.jsx`. This does something smaller and more urgent first, because measuring the duplication turned up **four user-visible bugs** the drift was already causing — two of them in the donor/privacy area.

### Why not the full hook conversion

I measured the two files before choosing: **463 identical non-blank lines, 263 differing** (~63% duplication) across 14 shared methods. But only **one** shared method is both byte-identical and free of `this` — the rest are bound to class state and lifecycle.

So the hook conversion isn't a refactor with a safe subset to peel off; it's a rewrite of both main routes' data flow. With **zero render tests** in the repo and no browser QA available this session, that's the riskiest change on the board. #166 stays open for it.

What *is* safely extractable is the logic that's shared **and** provable in isolation. That's what this PR moves — and doing so surfaced the bugs below.

### The bugs

All four verified by reading the wiring, not inferred.

**1. Privacy mode never masked the wallet input — on either page.**
Both `<InputGroup>`s are controlled (`value={this.state.inputAddress}`), but the toggle handler masked by writing `addressInputRef.current.value`. React reverts that on the very next render — which the handler's own `setState` triggers. `/nodes` papered over it in `componentDidUpdate`; `/home` had no compensation, so the address stayed in the clear.

**2. `/nodes` masked a render late.**
Its `componentDidUpdate` compared the `prevState` argument, then built the masked value from a stale `this.state.privacyMode` — one frame of unmasked address after every toggle. It also masked *the input field's current text* rather than `activeAddress`, so toggling mid-edit masked the draft instead of the real address. It also mutated `prevState`, which does nothing.

**3. `/home` ignored a donor wallet unlocked elsewhere.**
`Application.jsx` destructured only `setDonorWallet` for the `/home` route. A wallet unlocked via `/live` or `/nodes` auto-loaded on `/nodes` and was silently dropped on `/home`.

**4. `/home` rendered a blank field for a `?wallet=` link.**
`hydrateApp` set the ref but never `inputAddress`, so the controlled input showed nothing.

### The fix

New `client/src/wallet/addressInput.js` holds `createNewHistoryList`, `displayedAddress`, and `privacyStatePatch`. Masking is now driven from `LayoutContext` through `privacyStatePatch()`, which returns `null` when nothing changed — React's `setState` bail-out — so `componentDidUpdate` can call it unconditionally. Comparing against *current* state rather than `prevState` converges after exactly one extra render, with no unmasked frame.

### Deliberately not changed

MainApp's `PRIVACY_MODE` observable subscription is created and **unsubscribed on the next line**. It's dead, and its `componentWillUnmount` cleanup has always been a no-op (the handle is a local `var`, never assigned to the instance).

Re-enabling it looked like the obvious fix, and I did — then reverted it. The observable is built with `changeDetection: false` while `LayoutContext` writes the key **from its render body**, so it fires on every provider render; the handler calls `setSearch`, which changes the URL, which re-renders the provider. That's a plausible feedback loop I can't rule out without a browser, and it's most likely why someone disabled it in the first place. Masking no longer depends on it either way. Left in place with a comment; removing the observable wiring is its own change.

### Known gap, not widened blind

`LayoutContext`'s URL-masking effect is gated to `/nodes` (`if (location.pathname !== '/nodes') return;`), so `/home`'s `?wallet=` param is still unmasked. Flagging rather than fixing — it's URL-level and separate from the input-field bugs here.

### Verification

- **546 tests pass**, up from 530 — 16 new, covering the extracted logic including the two behaviours the old code got wrong (bail-out on no-op; masking from `activeAddress`, not the field)
- Production build clean; the two remaining warnings are pre-existing in files this PR doesn't touch
- Both classes stay classes — no paradigm change

⚠️ **Not visually verified.** No browser QA has been possible this session. The privacy toggle on both `/home` and `/nodes`, and a donor unlock landing on `/home`, are the three things worth clicking before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)