### PR TITLE
fix(#231, #219): backfill missing utility blocks, build the frontend in-image, persist chain-activity state

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,20 @@
 !/service/*
 !/redirect-page/*
 
-!/client/build/*
+# Frontend SOURCE, not the host's build output (issue #219). The image now runs
+# `yarn build` itself, so client/build is no longer copied in -- and must not be,
+# or a stale host bundle would shadow the freshly built one.
+#
+# ** rather than *: these are directory trees, and a single * does not cross a
+# path separator, so `!/client/src/*` would admit src/App.jsx while still
+# excluding src/analytics/ChainActivityTab/index.jsx.
+!/client/package.json
+!/client/yarn.lock
+!/client/jsconfig.json
+!/client/.env
+!/client/.env.production
+!/client/src/**
+!/client/public/**
 
 !/api/src/*
 !/api/Cargo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,34 @@
 # name of the rust crate
 ARG RUST_APP_PACKAGE_NAME=fluxnode_api_mask
 
+# ==========================================================
+# ================== FRONTEND BUILD STAGE ==================
+# ==========================================================
+
+# Issue #219: the image used to COPY a client/build produced on the host, so
+# `docker build` on a clean checkout silently shipped either a stale bundle or
+# no bundle at all, depending on what happened to be lying around. Building it
+# here makes the image reproducible from source alone.
+#
+# Node 20 (LTS). react-scripts 5.0.1 builds on it, and pinning the major keeps
+# a new Node release from changing the bundle underneath us.
+FROM node:20-bookworm-slim as frontend-build
+
+WORKDIR /client
+
+# Manifests first so the dependency layer is cached independently of source
+# edits -- without this split, every source change reinstalls the whole tree.
+COPY client/package.json client/yarn.lock ./
+RUN yarn install --frozen-lockfile --network-timeout 600000
+
+COPY client/ ./
+
+# NOT `CI=true`: react-scripts promotes warnings to errors under CI, and the
+# repo carries two long-standing lint warnings (a missing alt prop, an
+# exhaustive-deps hint). Failing the image build on those would be a change to
+# the lint policy smuggled in through the Dockerfile.
+RUN yarn build
+
 FROM rust:1.67.1 as build
 USER root
 
@@ -73,8 +101,24 @@ WORKDIR /app
 # Copy over API build files from the previous stage
 COPY --from=build /app-build/target/release/${RUST_APP_PACKAGE_NAME} ./main
 
+# Chain-activity state lives here (issue #231).
+#
+# services::chain_activity::DATA_DIR is the relative path "data" and the API
+# runs with WORKDIR /app, so this is where the scanner's checkpoint, daily
+# rollup, team txs and utility blocks land. Without a declared volume the whole
+# set is lost on every container restart, which meant re-fetching 8 days of
+# history from an explorer that rate-limits us -- and made the #231 drill-down
+# bug intermittent, since a fresh container backfills and a long-lived one
+# never does.
+#
+# Declared AFTER the directory is created and chowned so the image carries an
+# empty data dir with the right ownership for the volume to inherit.
+RUN mkdir -p /app/data
+
 # Change ownership of the application files to the new user
 RUN chown -R myuser:myuser /app
+
+VOLUME /app/data
 
 # switch to the new user
 USER myuser
@@ -83,9 +127,9 @@ USER myuser
 
 ## Static frontend files
 
-ARG FRONTED_SRC=./client
-# Copy build files. Also, as mentioned as above, don't add a trailing slash
-COPY ${FRONTED_SRC}/build /usr/share/nginx/html
+# Built by the frontend-build stage above rather than copied from the host
+# (issue #219).
+COPY --from=frontend-build /client/build /usr/share/nginx/html
 
 # --------------------
 

--- a/README.md
+++ b/README.md
@@ -356,15 +356,12 @@ When Privacy Mode is enabled (toggle in the top navigation), the Network Footpri
 
 - First, [enable BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds).
 
-- Build the frontend
-
-  ```sh
-  # This assumes your working directory is the repository's root
-  cd client
-  yarn build
-  ```
-
 - Build the docker image
+
+  The image builds the frontend itself (issue #219) — there is no longer a
+  separate `yarn build` step, and `client/build` is deliberately excluded from
+  the build context so a stale local bundle cannot shadow the one the image
+  produces.
 
   ```sh
   # This assumes your working directory is the repository's root
@@ -383,7 +380,17 @@ When Privacy Mode is enabled (toggle in the top navigation), the Network Footpri
 - Run the container locally (maps container port 80 → host port 9000):
 
   ```sh
-  docker run --rm --name="flux-node-web" -it -p 9000:80 <USERNAME>/<REPOSITORY>:<TAG>
+  docker run --rm --name="flux-node-web" -it -p 9000:80 -v fluxnode-data:/app/data <USERNAME>/<REPOSITORY>:<TAG>
   ```
 
   The app is then available at [http://localhost:9000](http://localhost:9000)
+
+  **Mount `/app/data`.** It holds the Chain Activity scanner's state: its
+  checkpoint, the daily rollup, team transactions and utility blocks. The image
+  declares `VOLUME /app/data`, but that only creates an *anonymous* volume,
+  which `--rm` discards along with the container — so without the explicit
+  `-v` above, every run re-scans eight days of chain history from an explorer
+  that rate-limits us, and the Chain Activity tab restarts from empty each
+  time.
+
+  Omit the `-v` only when you deliberately want a cold start.

--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -289,6 +289,35 @@ pub struct TeamTx {
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct Checkpoint {
     pub last_scanned_height: i64,
+    /*
+     * Whether the one-time utility-block repair has run (issue #231).
+     *
+     * #[serde(default)] is load-bearing, not boilerplate: every checkpoint
+     * file written before this field existed deserializes to `false`, which is
+     * exactly the deployments that need the repair. Adding the field without a
+     * default would instead fail to parse those files and silently reset the
+     * scanner to a cold start.
+     */
+    #[serde(default)]
+    pub utility_backfill_done: bool,
+}
+
+/*
+ * Whether this cycle should rewind to repopulate utility blocks (issue #231).
+ *
+ * Utility blocks arrived with #199, but they are only ever recorded inside the
+ * scan loop. A deployment whose scanner had already reached the tip under the
+ * previous code has a checkpoint sitting at the tip, so every later cycle takes
+ * the "already caught up" early return and never records a single one. The
+ * daily rollup still reports real utility COUNTS from those earlier scans, so
+ * the Chain Activity tab shows a non-zero figure whose drill-down is empty.
+ *
+ * Gated on the checkpoint flag rather than purely on emptiness so that a
+ * retention window genuinely containing no utility blocks does not re-trigger a
+ * full 23,040-block rescan on every cycle, forever.
+ */
+pub fn should_backfill_utility_blocks(checkpoint: &Checkpoint, utility_blocks_empty: bool) -> bool {
+    !checkpoint.utility_backfill_done && utility_blocks_empty
 }
 
 /*
@@ -585,8 +614,12 @@ pub fn save_team_txs(team_txs: &[TeamTx]) -> std::io::Result<()> {
     write_json_atomic(Path::new(DATA_DIR), TEAM_TX_FILE, &TeamTxFile { team_txs: team_txs.to_vec() })
 }
 
-pub fn save_checkpoint(last_scanned_height: i64) -> std::io::Result<()> {
-    write_json_atomic(Path::new(DATA_DIR), CHECKPOINT_FILE, &Checkpoint { last_scanned_height })
+pub fn save_checkpoint(last_scanned_height: i64, utility_backfill_done: bool) -> std::io::Result<()> {
+    write_json_atomic(
+        Path::new(DATA_DIR),
+        CHECKPOINT_FILE,
+        &Checkpoint { last_scanned_height, utility_backfill_done },
+    )
 }
 
 pub fn load_scan_status() -> ScanStatus {
@@ -796,7 +829,19 @@ pub async fn run_scan_cycle() {
     // Bounded catch-up: never scan further back than the retention window,
     // whether this is a genuine cold start (checkpoint 0) or a replica that's
     // been down long enough to fall behind the window entirely.
-    let start_height = checkpoint.last_scanned_height.max(earliest_allowed);
+    let mut start_height = checkpoint.last_scanned_height.max(earliest_allowed);
+
+    // One-time repair for deployments that caught up before utility blocks
+    // existed. Rewinding to the window edge is the same range a cold start
+    // would scan, so this costs one backfill and then never fires again.
+    let backfilling_utility = should_backfill_utility_blocks(&checkpoint, load_utility_blocks().is_empty());
+    if backfilling_utility && start_height > earliest_allowed {
+        println!(
+            "[chain_activity] utility blocks missing at checkpoint {} -- rewinding to {} to backfill (issue #231)",
+            start_height, earliest_allowed
+        );
+        start_height = earliest_allowed;
+    }
 
     if start_height >= tip_height {
         // already caught up to the tip — nothing to scan is itself success
@@ -845,7 +890,10 @@ pub async fn run_scan_cycle() {
         if let Err(e) = save_utility_blocks(&utility_blocks) {
             eprintln!("[chain_activity] failed to save utility blocks: {}", e);
         }
-        if let Err(e) = save_checkpoint(new_checkpoint) {
+        // Writes the flag UNCHANGED mid-scan: promoting it here would mark the
+        // repair done on the first batch, so a cycle that stalls halfway would
+        // never retry it.
+        if let Err(e) = save_checkpoint(new_checkpoint, checkpoint.utility_backfill_done) {
             eprintln!("[chain_activity] failed to save checkpoint: {}", e);
         }
 
@@ -876,6 +924,19 @@ pub async fn run_scan_cycle() {
         }
     }
 
+    // The backfill only counts as done once the cycle reached the tip without
+    // stalling; a partial pass leaves the flag clear so the next cycle retries.
+    if backfilling_utility && !stalled {
+        if let Err(e) = save_checkpoint(checkpoint_height, true) {
+            eprintln!("[chain_activity] failed to mark utility backfill done: {}", e);
+        } else {
+            println!(
+                "[chain_activity] utility block backfill complete ({} blocks retained)",
+                load_utility_blocks().len()
+            );
+        }
+    }
+
     let outcome = if stalled { ScanOutcome::Stalled } else { ScanOutcome::CaughtUp };
     persist_scan_status(next_scan_status(previous_status, attempt_at, outcome));
 
@@ -888,6 +949,51 @@ pub async fn run_scan_cycle() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /*
+     * Issue #231: the drill-down was empty on a deployment whose checkpoint had
+     * already reached the tip before utility blocks existed.
+     */
+    #[test]
+    fn backfills_when_utility_blocks_are_missing_and_repair_has_not_run() {
+        let cp = Checkpoint { last_scanned_height: 3_000_000, utility_backfill_done: false };
+        assert!(should_backfill_utility_blocks(&cp, true));
+    }
+
+    #[test]
+    fn does_not_backfill_once_the_repair_has_run() {
+        // A window that genuinely holds no utility blocks must not re-trigger a
+        // full rescan on every cycle.
+        let cp = Checkpoint { last_scanned_height: 3_000_000, utility_backfill_done: true };
+        assert!(!should_backfill_utility_blocks(&cp, true));
+    }
+
+    #[test]
+    fn does_not_backfill_when_utility_blocks_are_already_present() {
+        let cp = Checkpoint { last_scanned_height: 3_000_000, utility_backfill_done: false };
+        assert!(!should_backfill_utility_blocks(&cp, false));
+    }
+
+    /*
+     * The serde default is what makes the repair reach existing deployments:
+     * their checkpoint files predate the field entirely.
+     */
+    #[test]
+    fn checkpoint_without_the_flag_parses_as_needing_the_backfill() {
+        let old_file = r#"{"last_scanned_height": 3000000}"#;
+        let cp: Checkpoint = serde_json::from_str(old_file).expect("old checkpoint must still parse");
+        assert_eq!(cp.last_scanned_height, 3_000_000);
+        assert!(!cp.utility_backfill_done);
+        assert!(should_backfill_utility_blocks(&cp, true));
+    }
+
+    #[test]
+    fn checkpoint_round_trips_the_flag() {
+        let cp = Checkpoint { last_scanned_height: 42, utility_backfill_done: true };
+        let encoded = serde_json::to_string(&cp).unwrap();
+        let decoded: Checkpoint = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(cp, decoded);
+    }
 
     #[test]
     fn unix_to_utc_date_epoch() {

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -107,7 +107,7 @@ const DRILLDOWN_LIMIT = 50;
  * this shows the category subtotals in full and caps the block list, rather
  * than rendering hundreds of rows nobody asked for.
  */
-function UtilityDrilldown({ open }) {
+function UtilityDrilldown({ open, expectedTotal }) {
   const [state, setState] = useState({ status: 'idle', data: null });
 
   useEffect(() => {
@@ -136,7 +136,23 @@ function UtilityDrilldown({ open }) {
 
   const { totals, blocks } = state.data;
   if (totals.utilityTotal === 0) {
-    return <div className="ca-drilldown ca-drilldown--message">No utility blocks recorded yet.</div>;
+    /*
+     * Two very different situations reach here, and saying "none recorded" for
+     * both is what made issue #231 read as a broken panel.
+     *
+     * The count above this drill-down comes from the daily rollup; the blocks
+     * come from a separate file the scanner only writes while it is actually
+     * scanning. A deployment that caught up before utility blocks existed has
+     * the former and not the latter, so the panel claimed there was nothing
+     * there directly underneath a non-zero figure. The API now backfills that
+     * case, but the scan takes a while, so say so instead of contradicting the
+     * number the user just clicked.
+     */
+    const message =
+      expectedTotal > 0
+        ? 'Block detail is still being built for this window. It appears once the scanner finishes its next pass.'
+        : 'No utility blocks recorded yet.';
+    return <div className="ca-drilldown ca-drilldown--message">{message}</div>;
   }
 
   return (
@@ -225,7 +241,7 @@ function UtilitySummary({ daily, syncStatus, theme }) {
               {fmtNum(emptyBlocks)} empty ({pct(emptyBlocks, total)}%)
             </span>
           </div>
-          <UtilityDrilldown open={drilldownOpen} />
+          <UtilityDrilldown open={drilldownOpen} expectedTotal={utilityBlocks} />
         </>
       )}
     </div>


### PR DESCRIPTION
Closes #231. Closes #219.

Two issues that turned out to be one piece of work: **#231's secondary cause is a Dockerfile gap, and #219 is a Dockerfile change.**

---

## #231 — the Utility drill-down showed no detail

The Chain Activity tab displayed a real, non-zero Utility count whose drill-down was empty. The two numbers come from **different files, written by different code versions**:

| Shown | Source file | Populated by |
|---|---|---|
| Utility **count** (the number you click) | `chain_activity_daily.json` | scans predating #199 — already present |
| Utility **blocks** (the drill-down) | `chain_activity_utility_blocks.json` | scans after #199 — never ran |

`run_scan_cycle()` returns early once the checkpoint reaches the tip, and **that return happens before `utility_blocks` is ever loaded or saved** — blocks are recorded only inside the scan loop:

```rust
let start_height = checkpoint.last_scanned_height.max(earliest_allowed);

if start_height >= tip_height {
    persist_scan_status(/* CaughtUp */);
    return;                          // <-- utility_blocks never touched
}

let mut utility_blocks = load_utility_blocks();   // only reached with a range to scan
```

So a deployment that caught up under the pre-#199 code sits at the tip, takes that early return every cycle, and never records a single utility block — while the daily rollup keeps reporting counts from those earlier scans. **The checkpoint is precisely what prevents the rescan that would reconcile them.**

### The fix

A one-time repair. `Checkpoint` gains `utility_backfill_done`; a cycle that finds no utility blocks with the flag clear rewinds `start_height` to the retention-window edge — the same range a cold start would scan.

Three details that are deliberate, not incidental:

- **`#[serde(default)]` is load-bearing.** Every checkpoint file written before the field existed deserializes to `false` — exactly the deployments needing repair. Without the default, those files would fail to parse and silently reset the scanner to a cold start.
- **The flag is promoted only after the cycle reaches the tip without stalling.** Writing it mid-loop would mark the repair done on the first batch, so a cycle that stalled halfway would never retry.
- **Gated on the flag, not purely on emptiness.** A retention window that genuinely holds no utility blocks must not re-trigger a 23,040-block rescan every cycle, forever.

### UI

The panel said *"No utility blocks recorded yet"* directly beneath a non-zero figure — which is what made this read as broken rather than pending. It now distinguishes "nothing there" from "detail still being built", using the daily count it is drilling into.

---

## #219 — the frontend is now built in the image

The image `COPY`d a `client/build` produced on the host, so `docker build` on a clean checkout shipped a stale bundle or none at all, depending on what happened to be lying around. A `node:20` stage now runs `yarn build` itself, with manifests copied ahead of sources so the dependency layer caches independently of source edits.

This needed `.dockerignore` work. It excludes everything with `*` then whitelists, and only `/client/build/*` was listed. The client source is now whitelisted with `**` — **a single `*` does not cross a path separator**, so `!/client/src/*` would admit `src/App.jsx` while still excluding `src/analytics/ChainActivityTab/index.jsx`. `client/build` is deliberately no longer whitelisted, so a stale host bundle cannot shadow the freshly built one.

**Not `CI=true`** for the build step: react-scripts promotes warnings to errors under CI, and the repo carries two long-standing lint warnings (a missing `alt` prop, an exhaustive-deps hint). Failing the image build on those would be a lint-policy change smuggled in through the Dockerfile.

---

## Persistence

`VOLUME /app/data` is declared — but that alone only creates an **anonymous** volume, which `docker run --rm` discards along with the container, and `--rm` is exactly what the README documents. So the README now documents `-v fluxnode-data:/app/data` and explains why: without it, every run re-scans eight days of chain history from an explorer that rate-limits us (#218), and Chain Activity restarts from empty each time.

---

## Verification

Beyond unit tests, **both #231 paths were exercised end to end in a built container** by seeding the data volume:

```
checkpoint at tip, no flag, no blocks
  -> [chain_activity] utility blocks missing at checkpoint 2940423 --
     rewinding to 2917385 to backfill (issue #231)
  -> [chain_activity] scan starting: 23040 blocks remaining

checkpoint at tip, flag set, no blocks
  -> (no scan lines — took the caught-up early return, no rescan loop)
```

Also verified on the built image:
- frontend served — HTTP 200, `<title>Fluxnode Application</title>` (so the in-image build is what ships)
- `GET /api/v1/chain-activity/blocks` — HTTP 200
- `/app/data` present, correct ownership, writable

Plus: **39 Rust tests pass** (5 new), **530 client tests pass**, full `docker build` succeeds, client production build clean.

## What still needs a human

The repair triggers on the next scan cycle after deploy and then runs a full 23,040-block backfill, which takes a while against a rate-limited explorer. Worth watching `docker logs` for the `rewinding to ... to backfill` line on first deploy to confirm it fired on the real instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)