### PR TITLE
feat(#229): replace the Flux-team apps table with a card grid

### DIFF
--- a/client/src/analytics/AppsTab/index.jsx
+++ b/client/src/analytics/AppsTab/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
+import { FiBox, FiCpu, FiHardDrive, FiDatabase } from 'react-icons/fi';
 import { fetch_global_app_specs, fetch_global_stats, fetch_total_network_utils } from 'apidata';
 import { AppEcosystemBreakdown } from 'components/AppEcosystemBreakdown';
 import { TopHostedApps } from 'components/TopHostedApps';
@@ -227,6 +228,76 @@ function KpiTile({ value, label, hint, onClick, expanded }) {
  * what the percentage is made of -- one app at 100 instances outweighs fifty at
  * one instance each.
  */
+function TeamAppCard({ row }) {
+  const meta = APP_CATEGORY_META[row.category] || APP_CATEGORY_META.other;
+  const CatIcon = meta.Icon || FiBox;
+  const expiry = formatExpiry(row.expiresInBlocks);
+  const expired = expiry === 'expired';
+
+  return (
+    <div className="atc-card">
+      <div className="atc-head">
+        <span className="atc-name" title={row.name}>{row.name}</span>
+        <Tooltip2
+          content={<CategoryTooltip category={row.category} />}
+          placement="top"
+          hoverOpenDelay={200}
+          popoverClassName="hov-cat-tooltip"
+        >
+          {/* Same chip treatment as WorkhorsePanel's .whp-cat and the ecosystem
+              breakdown below, so one app reads identically wherever it appears. */}
+          <span className="atc-cat" style={{ borderColor: `${meta.color}44` }}>
+            <span style={{ color: meta.color, display: 'inline-flex' }}><CatIcon size={10} /></span>
+            {meta.label}
+          </span>
+        </Tooltip2>
+      </div>
+
+      <div className="atc-repo" title={row.repotag || ''}>
+        {row.repotag || (row.isEnterprise
+          ? <span className="atc-muted">encrypted specification</span>
+          : '—')}
+      </div>
+
+      <div className="atc-foot">
+        <span className="atc-instances">
+          {fmtNum(row.instances)}<small>{row.instances === 1 ? ' instance' : ' instances'}</small>
+        </span>
+
+        {/* Per-instance only. The fleet total each app accounts for is now in
+            the panel header, not repeated on every card -- "1 / 100" read as a
+            fraction and was the original complaint in #229. */}
+        <span className="atc-res">
+          <FiCpu size={10} />{fmtDec(row.cpuPerInst)}
+          <i>·</i>
+          <FiHardDrive size={10} />{fmtDec(row.ramGBPerInst)} GB
+          <i>·</i>
+          <FiDatabase size={10} />{fmtDec(row.ssdGBPerInst, 0)} GB
+        </span>
+
+        <span className={`atc-expiry${expired ? ' atc-expiry--expired' : ''}`}>
+          {expiry || '—'}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/*
+ * The apps behind the Flux-team-sponsored percentage.
+ *
+ * The stat alone asserts that one owner runs roughly half the network's ordered
+ * instances, with no way to check it. This is the evidence: which apps, how many
+ * instances each, and what they reserve. Sorted by instance count because that
+ * is what the percentage is made of -- one app at 100 instances outweighs fifty
+ * at one instance each.
+ *
+ * A card grid rather than a table (issue #229): the seven-column table it
+ * replaced stretched the full panel width for four short values per row, and
+ * rendered each resource as "per-instance / fleet-total", which read as a
+ * fraction. Cards reflow by width, and the fleet totals live once in the header
+ * where a total belongs.
+ */
 function TeamAppsDetail({ rawSpecs, currentBlock }) {
   const { rows, totalApps, totalInstances, totalCpu, totalRamGB, totalSsdGB } =
     buildTeamAppRows(rawSpecs, currentBlock);
@@ -248,68 +319,24 @@ function TeamAppsDetail({ rawSpecs, currentBlock }) {
         </span>
       </div>
 
-      <div className="apps-team-scroll">
-        <table className="apps-team-table">
-          <thead>
-            <tr>
-              <th>App</th>
-              <th>Repository</th>
-              <th className="apps-team-num">Instances</th>
-              <th className="apps-team-num">CPU</th>
-              <th className="apps-team-num">RAM</th>
-              <th className="apps-team-num">SSD</th>
-              <th>Expires</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => {
-              const expiry = formatExpiry(row.expiresInBlocks);
-              return (
-                <tr key={row.name}>
-                  <td className="apps-team-name" title={row.name}>{row.name}</td>
-                  <td className="apps-team-repo" title={row.repotag || ''}>
-                    {row.repotag || (row.isEnterprise
-                      ? <span className="apps-team-muted">encrypted</span>
-                      : '\u2014')}
-                  </td>
-                  <td className="apps-team-num">{fmtNum(row.instances)}</td>
-                  {/* Per-instance first, fleet total after: the fleet figure is
-                      what explains the share, the per-instance one is what an
-                      operator recognises. */}
-                  <td className="apps-team-num">
-                    {fmtDec(row.cpuPerInst)}
-                    {row.totalCpu != null && <span className="apps-team-total"> / {fmtDec(row.totalCpu)}</span>}
-                  </td>
-                  <td className="apps-team-num">
-                    {fmtDec(row.ramGBPerInst)}
-                    {row.totalRamGB != null && <span className="apps-team-total"> / {fmtDec(row.totalRamGB)}</span>}
-                  </td>
-                  <td className="apps-team-num">
-                    {fmtDec(row.ssdGBPerInst, 0)}
-                    {row.totalSsdGB != null && <span className="apps-team-total"> / {fmtDec(row.totalSsdGB, 0)}</span>}
-                  </td>
-                  <td className={expiry === 'expired' ? 'apps-team-expired' : ''}>{expiry || '\u2014'}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={2}>Fleet total</td>
-              <td className="apps-team-num">{fmtNum(totalInstances)}</td>
-              <td className="apps-team-num">{fmtDec(totalCpu)}</td>
-              <td className="apps-team-num">{fmtDec(totalRamGB)}</td>
-              <td className="apps-team-num">{fmtDec(totalSsdGB, 0)}</td>
-              <td />
-            </tr>
-          </tfoot>
-        </table>
+      {/* The fleet totals the table footer used to carry. One row, once. */}
+      <div className="atc-fleet">
+        <span>Fleet reserves</span>
+        <strong>{fmtDec(totalCpu)}</strong> cores
+        <i>·</i>
+        <strong>{fmtDec(totalRamGB)}</strong> GB RAM
+        <i>·</i>
+        <strong>{fmtDec(totalSsdGB, 0)}</strong> GB SSD
+      </div>
+
+      <div className="atc-grid">
+        {rows.map((row) => <TeamAppCard key={row.name} row={row} />)}
       </div>
 
       <div className="apps-team-caption">
-        Per-instance / fleet total. CPU in cores, RAM and SSD in GB. Expiry is derived
-        from each spec&apos;s height + expire against the current block, at the
-        30-second block target.
+        Figures are what each app reserves <strong>per instance</strong> &mdash; CPU in
+        cores, RAM and SSD in GB. Expiry is derived from each spec&apos;s height +
+        expire against the current block, at the 30-second block target.
       </div>
     </div>
   );

--- a/client/src/analytics/AppsTab/index.scss
+++ b/client/src/analytics/AppsTab/index.scss
@@ -312,91 +312,151 @@
 
 // Tables are the one thing allowed to scroll horizontally rather than wrap --
 // narrow viewports get a scrollbar instead of an unreadable squeeze.
-.apps-team-scroll {
-  overflow-x: auto;
-  max-height: 340px;
-  overflow-y: auto;
-}
-
-.apps-team-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.78rem;
-
-  th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--surface-primary);
-    text-align: left;
-    font-size: 0.64rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    padding: 6px 10px;
-    border-bottom: 1px solid var(--border-secondary);
-    white-space: nowrap;
-  }
-
-  td {
-    padding: 5px 10px;
-    border-bottom: 1px solid rgba(128, 128, 128, 0.07);
-    color: var(--text-secondary);
-    white-space: nowrap;
-  }
-
-  tbody tr:hover td { background: var(--surface-inset); }
-
-  tfoot td {
-    position: sticky;
-    bottom: 0;
-    background: var(--surface-primary);
-    border-top: 1px solid var(--border-secondary);
-    border-bottom: none;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
-}
-
-.apps-team-num {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.apps-team-name {
-  font-weight: 600;
-  color: var(--text-primary);
-  max-width: 220px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.apps-team-repo {
-  max-width: 260px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--text-tertiary);
-}
-
 // De-emphasised so the per-instance figure stays the one you read first.
-.apps-team-total {
-  color: var(--text-tertiary);
-  font-weight: 400;
-}
-
-.apps-team-muted {
-  color: var(--text-tertiary);
-  font-style: italic;
-}
-
-.apps-team-expired {
-  color: var(--accent-red);
-  font-weight: 600;
-}
-
 .apps-team-caption {
   font-size: 0.7rem;
   color: var(--text-tertiary);
   padding-top: 8px;
+}
+
+// ── Flux-team-sponsored app cards (issue #229) ───────────────────────────────
+//
+// Replaces a seven-column table that stretched the full panel width for four
+// short values per row. Chip and stat treatments deliberately mirror
+// home/WorkhorsePanel so an app reads the same wherever it appears.
+
+// Fleet totals, once, where the table footer used to repeat them per column.
+.atc-fleet {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 5px;
+  font-size: 0.74rem;
+  color: var(--text-tertiary);
+  padding-bottom: 8px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--border-secondary);
+
+  strong {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  i { font-style: normal; opacity: 0.4; }
+}
+
+// auto-fill, not auto-fit: with a handful of apps, auto-fit stretches each card
+// to half the panel and the text floats in whitespace -- the "uses a lot of
+// space" complaint. auto-fill keeps the column width honest.
+.atc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  gap: 8px;
+}
+
+.atc-card {
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-md, 6px);
+  background: var(--surface-inset);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0; // lets the ellipsis on .atc-name actually engage
+
+  &:hover { border-color: var(--border-primary); }
+}
+
+.atc-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.atc-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+// Mirrors .whp-cat in home/WorkhorsePanel.
+.atc-cat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  font-size: 0.64rem;
+  padding: 1px 6px;
+  border: 1px solid;
+  border-radius: 20px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.atc-repo {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.atc-muted {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.atc-foot {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+// The instance count is the sort key and what the sponsored percentage is
+// actually made of, so it carries the most weight on the card.
+.atc-instances {
+  font-size: 0.86rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+
+  small {
+    font-size: 0.68rem;
+    font-weight: 500;
+    color: var(--text-tertiary);
+  }
+}
+
+.atc-res {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+
+  i { font-style: normal; opacity: 0.4; margin: 0 1px; }
+  svg { opacity: 0.7; }
+}
+
+.atc-expiry {
+  margin-left: auto;
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+
+  &--expired {
+    color: var(--accent-red);
+    font-weight: 600;
+  }
 }

--- a/client/src/analytics/teamApps.js
+++ b/client/src/analytics/teamApps.js
@@ -1,5 +1,6 @@
 import { FLUX_TEAM_OWNER_ZELIDS } from 'analytics/teamSponsored';
 import { specResources } from 'appSpecs';
+import { categorizeAppSpec } from 'main/Gamification/appCategories';
 
 /*
  * The apps behind the "Flux-team-sponsored" percentage.
@@ -13,6 +14,8 @@ import { specResources } from 'appSpecs';
  * field comes from specs already in memory:
  *
  *   name        spec.name
+ *   category    categorizeAppSpec(spec) -- the same categoriser the rest of the
+ *               Apps tab uses, so a given app reads the same everywhere
  *   repo        specResources(spec).repotag (component 0 for compose apps)
  *   instances   spec.instances, defaulting to 1 for older specs that omit it
  *   cpu/ram/ssd specResources(spec), summed across compose components
@@ -58,6 +61,7 @@ export function buildTeamAppRows(rawSpecs, currentBlock, teamZelids = FLUX_TEAM_
 
     rows.push({
       name: spec.name,
+      category: categorizeAppSpec(spec),
       repotag,
       instances,
       cpuPerInst,

--- a/client/src/analytics/teamApps.test.js
+++ b/client/src/analytics/teamApps.test.js
@@ -158,3 +158,31 @@ describe('formatExpiry', () => {
     expect(formatExpiry(undefined)).toBeNull();
   });
 });
+
+describe('buildTeamAppRows category (issue #229)', () => {
+  const TEAM = ['team-zelid'];
+
+  it('categorises a row using the same categoriser as the rest of the Apps tab', () => {
+    const specs = [
+      { name: 'fah', owner: 'team-zelid', instances: 3, compose: [{ repotag: 'runonflux/folding-at-home:latest', cpu: 1, ram: 1024, hdd: 10 }] },
+    ];
+    const { rows } = buildTeamAppRows(specs, 0, TEAM);
+    expect(rows[0].category).toBe('computing');
+  });
+
+  it('marks an encrypted enterprise spec as enterprise rather than other', () => {
+    const specs = [
+      { name: 'secret', owner: 'team-zelid', instances: 1, enterprise: true, compose: [] },
+    ];
+    const { rows } = buildTeamAppRows(specs, 0, TEAM);
+    expect(rows[0].category).toBe('enterprise');
+  });
+
+  it('falls back to other for an unrecognised image', () => {
+    const specs = [
+      { name: 'mystery', owner: 'team-zelid', instances: 1, compose: [{ repotag: 'someone/unknown-thing:1', cpu: 1, ram: 1024, hdd: 10 }] },
+    ];
+    const { rows } = buildTeamAppRows(specs, 0, TEAM);
+    expect(rows[0].category).toBe('other');
+  });
+});


### PR DESCRIPTION
Closes #229.

Two complaints about the same panel, fixed together — they live in the same markup, so splitting them would mean touching it twice.

## 1. The cells — the original report

```
NAME          REPOSITORY       INST   CPU       RAM       SSD
FoldingAt..   runonflux/fah    100    1 / 100   4 / 400   40 / 4000
blockbook     runonflux/bb      24    3 / 300   8 / 192  120 / 2880
```

`1 / 100` reads as a fraction or a progress value at a glance, and the second number is just `instances × per-instance`. Cards now carry **only what the app reserves per instance** — the figure an operator recognises when they see it on their node. Fleet totals move to one summary row, where a total belongs.

Rows also gain `category`, from the same `categorizeAppSpec()` the rest of the Apps tab uses.

## 2. The layout — raised during QA

> *"Can we possibly make it look as pretty as the other section … how we show Flux Workhorse, with the count instances repo name etc. At the moment it looks bad, it also seems to use a lot of space"*

The seven-column table stretched the full panel width for four short values per row. Now a card grid modelled on `home/WorkhorsePanel`, the section named as the reference:

```
┌────────────────────────────────────────────┐
│ FoldingAtHome              [⚙ Computing]   │
│ runonflux/folding-at-home                  │
│ 100 instances   ⚙1 · 🖴4 GB · 🗄40 GB       │
│                            in 34 days      │
└────────────────────────────────────────────┘
```

The chip and stat treatments are **lifted from Workhorse deliberately rather than reinvented** — category chips match `.whp-cat` (icon, label, colour-tinted border, `CategoryTooltip` on hover) and the resource line reuses the same `FiCpu` / `FiHardDrive` / `FiDatabase` pairing. So an app reads identically wherever it appears on the tab.

Instance count is the most prominent element: it's the sort key and what the sponsored percentage is actually made of.

Two details worth flagging:

- **`auto-fill`, not `auto-fit`.** With a handful of apps `auto-fit` stretches each card to half the panel and the text floats in whitespace — which is the "uses a lot of space" complaint in a new form.
- **The icon-vs-text question from the issue is settled as icon + label**, because the grid sits directly above the ecosystem breakdown that already uses that treatment. The density argument for a bare text label only applied to the table being removed.

## Cleanup

Removed the eight now-dead table rules from `index.scss` (74 lines). `.apps-team-detail` and `.apps-team-caption` stay — both still render.

## Verification

**533 tests pass**, up from 530. The three new cases cover the category field, including the encrypted-enterprise path — that must read as `enterprise` rather than falling through to `other`. Production build clean.

⚠️ **Not visually verified.** Needs a look at `/#/analytics` → Apps → the Flux-team-sponsored drill-down. Worth checking how it reflows at narrow widths, since that's the part a card grid changes most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)