### PR TITLE
chore(#236): axum 0.5 -> 0.7, reqwest 0.11 -> 0.12 — Cargo advisories now zero (+ a 502 fix found on the way)

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -23,63 +23,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.5.17"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -358,6 +366,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -370,15 +389,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -395,31 +414,36 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body-util"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -435,14 +459,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -450,24 +474,65 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -648,9 +713,9 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -731,7 +796,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -798,26 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
@@ -885,7 +930,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -919,42 +964,56 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -963,7 +1022,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -971,12 +1030,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
- "base64",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1012,7 +1095,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1073,6 +1156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,16 +1214,6 @@ checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -1143,6 +1227,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1168,9 +1258,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1185,20 +1278,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1211,7 +1304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1239,7 +1332,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1277,6 +1370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,14 +1406,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -1319,21 +1422,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-range-header",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1379,6 +1481,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1491,12 +1599,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1505,7 +1633,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1519,40 +1647,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1562,21 +1669,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1592,21 +1687,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1616,37 +1699,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "writeable"
@@ -1697,6 +1758,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 lazy_static = "1.4.0"
 regex = "1.4"
 tokio-retry = "0.3"
-reqwest = { version = "0.11.11", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = "0.1.9"
 futures = "0.3"
-axum = "0.5.14"
-tower-http = { version = "0.3.0", features = ["cors"] }
+axum = "0.7"
+tower-http = { version = "0.6", features = ["cors"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,9 +4,7 @@ pub mod services;
 #[macro_use]
 extern crate lazy_static;
 
-use axum::{
-    handler::Handler, http::StatusCode, response::IntoResponse, routing::get, Router, Server,
-};
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
@@ -40,7 +38,7 @@ async fn main() {
     });
 
     // 404 handler
-    let app = app.fallback(g_handler_404.into_service());
+    let app = app.fallback(g_handler_404);
 
     // Cors handling
     let cors_layer = CorsLayer::new()
@@ -53,10 +51,12 @@ async fn main() {
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), read_port());
 
     println!("Listening on http://{}", socket);
-    Server::bind(&socket)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(socket)
         .await
-        .unwrap();
+        .expect("failed to bind the API port");
+    axum::serve(listener, app)
+        .await
+        .expect("API server stopped unexpectedly");
 }
 
 async fn g_root() -> String {
@@ -101,7 +101,6 @@ pub mod api_v1 {
 
     pub mod node_demo {
         use super::*;
-        use axum::extract::Path;
 
         // Endpoint's response returned back
         #[derive(Debug, Serialize)]

--- a/api/src/services/bench_version.rs
+++ b/api/src/services/bench_version.rs
@@ -53,7 +53,18 @@ lazy_static! {
     };
 }
 
-async fn get_file_name(client: &Client) -> Result<String, String> {
+/*
+ * The raw body of the fluxbench package index.
+ *
+ * Returns the WHOLE document, not a hand-picked line. This used to do
+ * `body.split("\n").collect()` then `files.get(5).unwrap()`, which assumed a
+ * plain-text listing whose sixth line was a .deb filename. The endpoint serves
+ * an HTML directory listing, so that line is `</head>`: the version regex then
+ * failed to match and the unwrap panicked, killing a tokio worker and turning
+ * /api/v1/bench-version into a 502. Finding the version is the caller's job
+ * now, and it does it by pattern rather than by position.
+ */
+async fn get_index_body(client: &Client) -> Result<String, String> {
     let url = Url::parse(&FLUX_VERSION_ENDPOINT).unwrap();
     let response = match client.get(url).send().await {
         Ok(response) => response,
@@ -68,11 +79,7 @@ async fn get_file_name(client: &Client) -> Result<String, String> {
             .text()
             .await
             .map_err(|e| format!("Error while reading the response: {}", e))?;
-        let files: Vec<&str> = body.split("\n").collect();
-        let first_file = files.get(5).unwrap();
-
-        let file_name_string: String = first_file.to_string();
-        Ok(file_name_string)
+        Ok(body)
     } else {
         let err_string = format!("Request failed with status code: {}", response.status());
         return Err(err_string);
@@ -100,14 +107,91 @@ pub async fn get_bench_version() -> Result<String, String> {
         .map(jitter) // add jitter to delays
         .take(3); // limit to 3 retries
 
-    let file_name = Retry::spawn(retry_strategy.clone(), || async {
-        get_file_name(&client).await
+    let body = Retry::start(retry_strategy.clone(), || async {
+        get_index_body(&client).await
     })
     .await?;
 
-    let regex = Regex::new(r"_([0-9]+\.[0-9]+\.[0-9]+)_").unwrap();
+    // Safe to unwrap: a literal pattern, either valid on every run or none,
+    // and covered by a test.
+    let regex = Regex::new(r"_([0-9]+)\.([0-9]+)\.([0-9]+)_").unwrap();
 
-    // Extract the version number from the file name
-    let version = regex.captures(&file_name).unwrap().get(1).unwrap().as_str();
-    return Ok(String::from(version));
+    // The index lists every published build, so take the HIGHEST version
+    // rather than the first or last match: ordering in the listing is the
+    // server's choice, and amd64/arm64 both appear for each release.
+    let newest = highest_version(&regex, &body);
+
+    match newest {
+        Some((major, minor, patch)) => Ok(format!("{}.{}.{}", major, minor, patch)),
+        // An error, not a panic. This is remote content that can change shape
+        // without warning -- which is exactly how the previous version broke.
+        None => Err(String::from(
+            "No fluxbench version found in the package index",
+        )),
+    }
+}
+
+/// Highest `_x.y.z_` version appearing anywhere in `body`, compared
+/// numerically rather than lexically (so 6.10.0 beats 6.9.0).
+fn highest_version(regex: &Regex, body: &str) -> Option<(u32, u32, u32)> {
+    regex
+        .captures_iter(body)
+        .filter_map(|c| {
+            let part = |i: usize| c.get(i)?.as_str().parse::<u32>().ok();
+            Some((part(1)?, part(2)?, part(3)?))
+        })
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn re() -> Regex {
+        Regex::new(r"_([0-9]+)\.([0-9]+)\.([0-9]+)_").unwrap()
+    }
+
+    /*
+     * The real body served by apt.runonflux.io: an HTML directory listing, not
+     * the plain-text file list the previous implementation assumed.
+     */
+    #[test]
+    fn finds_the_version_in_an_html_directory_listing() {
+        let body = r#"<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Directory listing for /pool/main/f/fluxbench/</title>
+</head>
+<body>
+<h1>Directory listing for /pool/main/f/fluxbench/</h1>
+<ul>
+<li><a href="fluxbench_6.3.1_amd64.deb">fluxbench_6.3.1_amd64.deb</a></li>
+<li><a href="fluxbench_6.3.1_arm64.deb">fluxbench_6.3.1_arm64.deb</a></li>
+</ul>
+</body>
+</html>"#;
+        assert_eq!(highest_version(&re(), body), Some((6, 3, 1)));
+    }
+
+    #[test]
+    fn picks_the_highest_version_not_the_first_or_last() {
+        let body = "fluxbench_6.3.1_amd64.deb fluxbench_5.1.0_amd64.deb fluxbench_6.2.9_arm64.deb";
+        assert_eq!(highest_version(&re(), body), Some((6, 3, 1)));
+    }
+
+    #[test]
+    fn compares_numerically_not_lexically() {
+        // 6.10.0 > 6.9.0, which string ordering gets backwards.
+        let body = "fluxbench_6.9.0_amd64.deb fluxbench_6.10.0_amd64.deb";
+        assert_eq!(highest_version(&re(), body), Some((6, 10, 0)));
+    }
+
+    #[test]
+    fn returns_none_rather_than_panicking_when_nothing_matches() {
+        // The failure that produced the 502: a body with no version in it at
+        // all must be an error the caller can report, not a panic.
+        assert_eq!(highest_version(&re(), "<html><head></head></html>"), None);
+        assert_eq!(highest_version(&re(), ""), None);
+    }
 }

--- a/api/src/services/demo.rs
+++ b/api/src/services/demo.rs
@@ -109,7 +109,7 @@ async fn run_demo_address_request() -> Result<String, reqwest::Error> {
         .map(jitter) // add jitter to delays
         .take(3); // limit to 3 retries
 
-    let result = Retry::spawn(retry_strategy.clone(), || async {
+    let result = Retry::start(retry_strategy.clone(), || async {
         get_demo_address_request(&client).await
     })
     .await?;


### PR DESCRIPTION
Closes #236.

Takes the API from 1 vulnerability to **0**. Combined with #234, that's **16 → 0**.

| crate | before | after | |
|---|---|---|---|
| axum | 0.5.17 | 0.7.9 | |
| hyper | 0.14.32 | 1.11.1 | |
| **h2** | **0.3.27** | **0.4.19** | RUSTSEC-2026-0258 cleared |
| reqwest | 0.11.27 | 0.12.28 | |
| tower-http | 0.3.5 | 0.6.11 | |
| **rustls-pemfile** | 1.0.4 | **gone** | RUSTSEC-2025-0134 cleared |

## reqwest was not optional

#236 framed this as an axum migration. **That alone would not have worked.** `h2` enters the tree through *both* `hyper` (via axum) *and* `reqwest` directly, and reqwest 0.11 pins hyper 0.14:

```
who depends on h2:     ['hyper', 'reqwest']
who depends on hyper:  ['axum', 'hyper-tls', 'reqwest']
```

Upgrading axum by itself would have moved axum to hyper 1.x and left h2 0.3 in place through reqwest — the advisory would have survived a migration done exactly as the issue described it.

`reqwest`'s `blocking` feature is also dropped: `reqwest::blocking` is used nowhere in `api/src`, and it pulls in a second synchronous runtime.

## Four code changes, and that's all

The migration is small because the code only ever used standard extractors:

- `axum::Server` is gone in 0.7 (it went with hyper 0.14) — binding is now the caller's job, so `axum::serve()` takes an already-bound `tokio::net::TcpListener`
- `Handler::into_service()` is gone — `fallback()` takes a handler directly
- the unused `axum::extract::Path` import in `node_demo` removed (a warning on every build)
- `tokio_retry::Retry::spawn` → `start()`

`Path`, `Query` and `Json` extractors, every handler signature, the `CorsLayer` and the router structure are **unchanged**. The build now emits **zero warnings**, down from three.

## Behaviour change worth knowing

axum 0.6 removed automatic trailing-slash redirection, so `GET /api/v1/` now 404s where `GET /api/v1` still returns 200. Only that one informational route is affected — every other endpoint is reached with a path segment, and the client always builds URLs that way, so nothing in this repo calls it.

Deliberately **not** papered over with `NormalizePathLayer`: rewriting the path of every request to protect a route nothing calls is more risk than the problem.

---

## Second commit: a 502 this found

The route smoke test turned up `/api/v1/bench-version` returning **502**, with a panicking tokio worker. **Not caused by this upgrade** — it fails identically on `main`, and has been broken in production.

```
thread 'tokio-rt-worker' panicked at bench_version.rs:111:
called `Option::unwrap()` on a `None` value
```

`get_file_name()` split the fluxbench package index on newlines and took `files.get(5).unwrap()`, assuming a plain-text listing whose sixth line was a `.deb` filename. `apt.runonflux.io` serves an **HTML directory listing**, so that line is `</head>`. The version regex then matched nothing, the unwrap panicked, the worker died, and nginx turned the dropped connection into a 502.

Fixed by finding the version **by pattern rather than by line position** — the brittleness was the positional assumption. Highest match wins, not first or last (the index lists amd64 and arm64 for every release, and ordering is the server's choice), compared numerically so 6.10.0 beats 6.9.0. A body with no version is now an `Err` the handler reports, not a panic.

```
GET /api/v1/bench-version
before: 502 Bad Gateway (worker panic)
after:  200 {"success":true,"version":"6.3.1","error":null}
```

## Verification

43 Rust tests pass (4 new), zero warnings, **`cargo audit` reports 0 vulnerabilities**.

The image was built and **run**, with every route exercised — the server's binding changed, which is exactly the kind of change that compiles and then fails at runtime:

| route | status |
|---|---|
| `GET /` | 200 |
| `GET /api/v1` | 200 |
| `GET /api/v1/demo` | 200 |
| `GET /api/v1/bench-version` | 200 |
| `GET /api/v1/chain-activity` | 200 |
| `GET /api/v1/chain-activity/blocks` | 200 |
| `POST /api/v1/nodes` | 200 |
| `POST /api/v1/live/current-winners` | 200 |

Plus the rejection paths: 422 on a wrong payload shape, 400 on malformed JSON — both correct extractor behaviour. Zero panics in the container log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)