### PR TITLE
chore(#167): upgrade rxjs 5 -> 7.8.2

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -38,7 +38,7 @@
         "react-router-dom": "6",
         "react-scripts": "5.0.1",
         "recharts": "^2.12.7",
-        "rxjs": "^5.6.0-forward-compat.5",
+        "rxjs": "^7.8.2",
         "web-vitals": "^2.1.0"
       },
       "devDependencies": {
@@ -14420,14 +14420,12 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "5.6.0-forward-compat.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.6.0-forward-compat.5.tgz",
-      "integrity": "sha512-CJ9UIV5LlcyGhKWOVvZa4PcVbJJbGNcTunG29cflNo+Y2jAZgvMdZVl4xwYNiYK5gmley/0QuAFVJ0M4GO+GNQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "symbol-observable": "1.0.1"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -15407,14 +15405,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -27174,11 +27164,11 @@
       }
     },
     "rxjs": {
-      "version": "5.6.0-forward-compat.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.6.0-forward-compat.5.tgz",
-      "integrity": "sha512-CJ9UIV5LlcyGhKWOVvZa4PcVbJJbGNcTunG29cflNo+Y2jAZgvMdZVl4xwYNiYK5gmley/0QuAFVJ0M4GO+GNQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -27899,11 +27889,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "react-router-dom": "6",
     "react-scripts": "5.0.1",
     "recharts": "^2.12.7",
-    "rxjs": "^5.6.0-forward-compat.5",
+    "rxjs": "^7.8.2",
     "web-vitals": "^2.1.0"
   },
   "overrides": {

--- a/client/src/persistance/observableFactory.test.js
+++ b/client/src/persistance/observableFactory.test.js
@@ -1,0 +1,75 @@
+import { Observable } from 'rxjs';
+
+/*
+ * The rxjs contract that localforage-observable actually depends on (#167).
+ *
+ * rxjs earns its place in this app through exactly one line, repeated in
+ * MainApp.jsx and Home.jsx:
+ *
+ *   appStore.newObservable.factory = function (subscribeFn) {
+ *     return new Observable(subscribeFn);
+ *   };
+ *
+ * localforage-observable declares NO rxjs dependency -- it ships zen-observable
+ * and calls whatever factory it is given. So nothing in the library pins a
+ * version, and nothing else in this repo imports rxjs. That makes the 5 -> 7
+ * upgrade safe, and it also means a break would be completely silent: there are
+ * no render tests over the two components that use it, and the subscription
+ * only fires on a privacy-mode toggle.
+ *
+ * These tests pin the four behaviours the factory relies on, so a future rxjs
+ * bump fails here rather than in a browser.
+ */
+describe('rxjs Observable factory contract', () => {
+  it('constructs from a subscribe function and delivers values to a partial observer', () => {
+    // The object form, not the positional subscribe(next, error, complete):
+    // rxjs 7 deprecates positional arguments and rxjs 8 removes them.
+    const seen = [];
+    const observable = new Observable((subscriber) => {
+      subscriber.next({ newValue: true });
+      subscriber.next({ newValue: false });
+    });
+
+    observable.subscribe({ next: (v) => seen.push(v.newValue) });
+
+    expect(seen).toEqual([true, false]);
+  });
+
+  it('returns a subscription that can be unsubscribed', () => {
+    // Home.jsx keeps the handle and unsubscribes in componentWillUnmount.
+    const observable = new Observable(() => {});
+    const subscription = observable.subscribe({ next: () => {} });
+
+    expect(typeof subscription.unsubscribe).toBe('function');
+    subscription.unsubscribe();
+    expect(subscription.closed).toBe(true);
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    let emit;
+    const seen = [];
+    const observable = new Observable((subscriber) => {
+      emit = (v) => subscriber.next(v);
+    });
+
+    const subscription = observable.subscribe({ next: (v) => seen.push(v) });
+    emit('before');
+    subscription.unsubscribe();
+    emit('after');
+
+    expect(seen).toEqual(['before']);
+  });
+
+  it('runs the teardown function the subscribe function returns', () => {
+    // localforage-observable returns a teardown to detach its store listener;
+    // if this stopped being called the listener would leak on every unmount.
+    const teardown = jest.fn();
+    const observable = new Observable(() => teardown);
+
+    const subscription = observable.subscribe({ next: () => {} });
+    expect(teardown).not.toHaveBeenCalled();
+
+    subscription.unsubscribe();
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8505,12 +8505,12 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^5.6.0-forward-compat.5:
-  version "5.6.0-forward-compat.5"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-5.6.0-forward-compat.5.tgz"
-  integrity sha512-CJ9UIV5LlcyGhKWOVvZa4PcVbJJbGNcTunG29cflNo+Y2jAZgvMdZVl4xwYNiYK5gmley/0QuAFVJ0M4GO+GNQ==
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^2.1.0"
 
 safe-buffer@^5.1.0, safe-buffer@>=5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -9186,11 +9186,6 @@ svgo@^2.7.0:
     sax "^1.5.0"
     stable "^0.1.8"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz"
-  integrity sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==
-
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
@@ -9360,7 +9355,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@~2.5.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@~2.5.0:
   version "2.5.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==


### PR DESCRIPTION
Closes #167.

```diff
- "rxjs": "^5.6.0-forward-compat.5"
+ "rxjs": "^7.8.2"
```

## Why this is genuinely a one-line change

rxjs earns its place in this app through exactly one line, repeated in `MainApp.jsx` and `Home.jsx`:

```js
appStore.newObservable.factory = function (subscribeFn) {
  return new Observable(subscribeFn);
};
```

Nothing else imports it. No operators, no `pipe()`, no `Subject`, no schedulers — the two imports are the entire surface, and `new Observable(fn)` plus `.subscribe({ next })` behave identically in 5, 6 and 7.

The subscribe call already uses the **object form** rather than the positional `subscribe(next, error, complete)` that rxjs 7 deprecates and rxjs 8 removes, so no call site needed changing there either.

## localforage-observable doesn't pin rxjs

Checked before upgrading rather than assumed:

```
dependencies = { localforage: '^1.5.0', 'zen-observable': '^0.2.1' }
devDependencies = { '@reactivex/rxjs': '^5.0.0-beta.7', ... }
```

It declares **no rxjs dependency** — it ships `zen-observable` and calls whatever factory it's handed, listing rxjs only for its own tests. Nothing constrains the version from that side.

## The risk here was silence, so this adds tests

A break would have been invisible: there are **no render tests** over the two components that use it, and the subscription only fires on a privacy-mode toggle. `yarn build` succeeding proves nothing about runtime behaviour.

`persistance/observableFactory.test.js` now pins the four behaviours the factory actually depends on:

- construction from a subscribe function
- delivery to a **partial** observer (`{ next }`)
- unsubscribe
- **the teardown function being run on unsubscribe**

That last one matters most: localforage-observable returns a teardown to detach its store listener. If it stopped being called, the listener would leak on every unmount — silently. A future rxjs bump now fails in CI rather than in a browser.

## Noted, and deliberately not done

localforage-observable already ships `zen-observable` (98K on disk, against rxjs's 9.1M), so the factory *could* drop rxjs entirely.

Not doing it. The bundled `zen-observable` is **0.2.1**, a 2016-era release pulled in transitively. Trading a maintained direct dependency for an unmaintained transitive one to save install size is the wrong trade — and the shipped bundle barely moves either way: `main.js` changed by **−1 B**, since only `Observable` is imported and both tree-shake.

## Verification

- **553 tests pass**, up from 549
- Production build clean, bundle size unchanged
- Image built and **run**: frontend HTTP 200, API 200, no errors in the log
- Both lockfiles updated — the image builds with yarn, so `yarn.lock` is what ships, but a stale `package-lock` would make future audits lie

One thing still worth a click during QA: the privacy-mode toggle on `/nodes` and `/home`, since that's the only path that actually exercises the subscription at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)