### PR TITLE
refactor(#147): extract wallet nodes from apidata.js, share REQUEST_OPTIONS_API

### DIFF
--- a/client/src/api/endpoints.js
+++ b/client/src/api/endpoints.js
@@ -1,5 +1,5 @@
 /*
- * Endpoint paths shared by more than one API module.
+ * Endpoint paths and request options shared by more than one API module.
  *
  * Exists so a path used from two places is defined once. Duplicating a URL
  * across modules is exactly the drift issue #147 is about -- it is how the
@@ -10,3 +10,28 @@
  */
 
 export const EXPLORER_FLUX_NODES_PATH = '/status?q=getFluxNodes';
+
+/*
+ * Fetch options for the plain public JSON APIs (api.runonflux.io,
+ * stats.runonflux.io).
+ *
+ * Lives here rather than in either caller because it is genuinely shared:
+ * api/walletNodes.js uses it for the three per-node endpoints and apidata.js
+ * uses it for GPU prices. It was previously declared beside the node code, so
+ * splitting that out broke the GPU-price fetch at build time -- which is the
+ * duplication-and-drift problem issue #147 exists to fix, in miniature.
+ *
+ * `credentials: 'omit'` is deliberate: these are unauthenticated endpoints, and
+ * sending cookies to them would be pointless at best. Callers spread it
+ * (`{ ...REQUEST_OPTIONS_API }`) rather than passing it directly, so nothing can
+ * mutate the shared object.
+ */
+export const REQUEST_OPTIONS_API = {
+  credentials: 'omit',
+  headers: {
+    Accept: 'application/json, text/plain, */*',
+    'Accept-Language': 'en-US,en;q=0.5'
+  },
+  method: 'GET',
+  mode: 'cors'
+};

--- a/client/src/api/walletNodes.js
+++ b/client/src/api/walletNodes.js
@@ -1,0 +1,356 @@
+/*
+ * Wallet nodes: fetching a wallet's nodes and turning raw daemon records into
+ * the shape the node table renders.
+ *
+ * Extracted from apidata.js (issue #147). A MOVE, not a rewrite -- the code
+ * below is unchanged. apidata.js re-exports it, so no call site changes in this
+ * pass.
+ *
+ * This section came out cleanly because it is genuinely self-contained: none of
+ * its ten exported functions is called from anywhere else in apidata.js, and
+ * the four endpoint constants below are referenced nowhere outside it. That is
+ * the test applied before cutting, rather than splitting on where the banner
+ * comments happened to fall.
+ *
+ * It owns:
+ *   getWalletNodes / getEnterpriseNodes   the daemon's node list for a wallet
+ *   transformRawNode / fillPartialNode    raw record -> table row
+ *   fill_health / wallet_health_full      per-wallet health rollup
+ *   normalize_raw_node_tier               tier string normalisation
+ *   calc_mtn_window                       maintenance window from block heights
+ *   validateAddress / getDemoWallet       address check and the demo payload
+ */
+
+import dayjs from 'dayjs';
+
+import { format_minutes } from 'utils';
+import { fluxos_version_desc, fluxos_version_desc_parse } from 'main/flux_version';
+import { explorerFetchJson } from 'explorer';
+import { EXPLORER_FLUX_NODES_PATH, REQUEST_OPTIONS_API } from 'api/endpoints';
+import { FLUXNODE_INFO_API_MODE, FLUXNODE_INFO_API_URL } from 'app-buildinfo';
+
+// Moved with the code that uses them: nothing outside this module reads any of
+// these four.
+const API_FLUX_NODE_URL = 'https://api.runonflux.io/daemon/viewdeterministiczelnodelist?filter=';
+const API_NODE_INFO_ENDPOINT = '/flux/info';
+const API_FLUX_APPLIST_ENDPOINT = '/apps/installedapps';
+const API_FLUX_UPTIME_ENDPOINT = '/flux/systemuptime';
+
+/* ======= node health ======= */
+
+function wallet_health_entry() {
+  return {
+    node_count: 0,
+    projection_daily: { flux: 0, usd: 0 },
+    projection_montly: { flux: 0, usd: 0 }
+  };
+}
+
+export function wallet_health_full() {
+  return {
+    cumulus: wallet_health_entry(),
+    nimbus: wallet_health_entry(),
+    stratus: wallet_health_entry(),
+    //fractus: wallet_health_entry(),
+    total_nodes: 0
+  };
+}
+
+/* ======= nodes overview ======= */
+
+function empty_flux_node() {
+  return {
+    id: 0,
+    maybe_online: false,
+    ip_full: {
+      host: '',
+      port: null,
+
+      active_port_api: null,
+      active_port_os: null
+    },
+    ip_display: false,
+    tier: 'UNKNOWN', // "CUMULUS" | "NIMBUS" | "STRATUS" | "FRACTUS" | "UNKNOWN"
+    rank: -1,
+    last_reward: '-',
+    next_reward: '-',
+    benchmark_status: 'unknown', // 'unknown' | 'failed' | 'passed' | 'offline' | 'running'
+    bench_version: fluxos_version_desc(0, 0, 0),
+    flux_os: fluxos_version_desc(0, 0, 0),
+    cores: 0,
+    threads: 0,
+    eps: 0,
+    ram: 0,
+    dws: 0,
+    total_storage: 0,
+    down_speed: 0,
+    up_speed: 0,
+    last_benchmark: '-',
+    appCount: 0,
+    uptime: 0,
+    score: 0,
+
+    last_confirmed_height: 0
+    // maintenance_win: '-'
+  };
+}
+
+function calc_next_reward(rank) {
+  return format_minutes(rank / 2);
+}
+
+export function calc_mtn_window(last_confirmed_height, current_height) {
+  const BLOCK_RATE = 480;
+  //480 blocks at 30second blocks 240 minutes
+
+  const win = BLOCK_RATE - (current_height - last_confirmed_height);
+
+  if (win <= 0) return 'Closed';
+
+  return format_minutes(win / 2);
+}
+
+export const DISPLAY_DATE_FORMAT = 'DD-MMM-YYYY HH:mm:ss';
+
+const DEFAULT_FLUX_PORT_API = 16127;
+const DEFAULT_FLUX_PORT_OS = 16126;
+
+export function normalize_raw_node_tier(node) {
+  return node['tier'].toUpperCase();
+}
+
+export async function getWalletNodes(walletAddress) {
+  // implement and live in the dark(background) so we can turn it on when ranking feature is fixed
+  let wNodes = [];
+  if (process.env.REACT_APP_ENABLE_FLUX_NODE_API === 'true') {
+    try {
+      const res = await fetch(API_FLUX_NODE_URL + walletAddress);
+      wNodes = (await res.json())?.data;
+    } catch {}
+  } else {
+    // Through the explorer pool: this is the wallet-search path, so a rate
+    // limit here means a user sees no nodes at all.
+    const data = await explorerFetchJson(EXPLORER_FLUX_NODES_PATH);
+    wNodes = Array.isArray(data?.fluxNodes)
+      ? data.fluxNodes.filter((n) => n.payment_address == walletAddress)
+      : [];
+  }
+  return wNodes;
+}
+
+export async function getEnterpriseNodes() {
+  let enterpriseNodes = [];
+  try {
+    const res = await fetch('https://api.runonflux.io/apps/enterprisenodes');
+    enterpriseNodes = (await res.json())?.data;
+    // console.log('getEnterpriseNodes-----', enterpriseNodes);
+  } catch (e) {
+    console.log('getEnterpriseNodes', e);
+  }
+
+  return enterpriseNodes;
+}
+
+export function transformRawNode(node) {
+  let fluxNode = empty_flux_node();
+  const ipRaw = node['ip'];
+  if (ipRaw) {
+    fluxNode.maybe_online = true;
+
+    const ipParts = ipRaw.split(':');
+
+    fluxNode.ip_full.host = ipParts[0];
+    if (ipParts.length > 1) {
+      const portApi = +ipParts[1] || DEFAULT_FLUX_PORT_API;
+
+      fluxNode.ip_full.port = portApi;
+
+      fluxNode.ip_full.active_port_api = portApi;
+      fluxNode.ip_full.active_port_os = portApi - 1;
+    } else {
+      fluxNode.ip_full.port = null;
+
+      fluxNode.ip_full.active_port_api = DEFAULT_FLUX_PORT_API;
+      fluxNode.ip_full.active_port_os = DEFAULT_FLUX_PORT_OS;
+    }
+
+    fluxNode.id = ipRaw;
+    fluxNode.ip_display = ipRaw;
+  } else {
+    fluxNode.id = node['txhash'];
+  }
+
+  fluxNode.tier = normalize_raw_node_tier(node);
+  fluxNode.rank = node['rank'] || 0;
+  fluxNode.last_reward = dayjs.unix(node['lastpaid']).format(DISPLAY_DATE_FORMAT);
+  fluxNode.next_reward = calc_next_reward(node.rank);
+  fluxNode.last_confirmed_height = node['last_confirmed_height'] || 0;
+
+  return fluxNode;
+}
+
+function make_offline(fluxNode) {
+  fluxNode.benchmark_status = 'offline';
+  return undefined;
+}
+
+function _fillPartial_bench_info(fluxNode, bench_info) {
+  if (bench_info !== null) fluxNode.bench_version = fluxos_version_desc_parse(bench_info['version']);
+}
+
+function _fillPartial_benchmarks(fluxNode, benchmarks) {
+  if (benchmarks === null) return make_offline(fluxNode);
+
+  switch (benchmarks['benchmark_status']) {
+    case 'failed':
+      fluxNode.benchmark_status = 'failed';
+      break;
+    case 'running':
+      fluxNode.benchmark_status = 'running';
+      break;
+
+    default:
+      fluxNode.benchmark_status = 'passed';
+  }
+
+  fluxNode.threads = parseInt(benchmarks['cores'] || 0);
+  fluxNode.eps = benchmarks['eps'] || 0;
+  fluxNode.ram = benchmarks['ram'] || 0;
+  fluxNode.dws = benchmarks['ddwrite'] || 0;
+  fluxNode.total_storage = benchmarks['totalstorage'] || 0;
+  fluxNode.down_speed = benchmarks['download_speed'] || 0;
+  fluxNode.up_speed = benchmarks['upload_speed'] || 0;
+  fluxNode.thunder = benchmarks['thunder'] || false;
+
+  fluxNode.last_benchmark = dayjs.unix(benchmarks['time']).format(DISPLAY_DATE_FORMAT);
+}
+function _fillPartial_version(fluxNode, version) {
+  if (version !== null) fluxNode.flux_os = fluxos_version_desc_parse(version);
+}
+function _fillPartial_apps(fluxNode, installedApps) {
+  if (installedApps !== null) {
+    fluxNode.appCount = installedApps?.length;
+    fluxNode.installedApps = installedApps;
+  }
+}
+
+function _fillPartial_uptime(fluxNode, uptime) {
+  if (uptime !== null) fluxNode.uptime = uptime;
+}
+
+const make_node_ip = (fluxNode) => fluxNode.ip_full.host + ':' + fluxNode.ip_full.active_port_api;
+
+let _fetchAndFillNodeInfo;
+if (FLUXNODE_INFO_API_MODE === 'proxy') {
+  _fetchAndFillNodeInfo = async (fluxNode) => {
+    let responseOK = false;
+    let jsonData = {};
+
+    try {
+      const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/node-single/` + make_node_ip(fluxNode), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json'
+        }
+      });
+
+      responseOK = response.status == 200;
+      jsonData = await response.json();
+    } catch {}
+
+    if (!(responseOK && jsonData['success'])) return make_offline(fluxNode);
+
+    let targetNode = jsonData['node']['results'];
+
+    _fillPartial_bench_info(fluxNode, targetNode['node_info'].data?.benchmark?.info);
+    _fillPartial_benchmarks(fluxNode, targetNode['node_info'].data?.benchmark?.bench);
+    _fillPartial_version(fluxNode, targetNode['node_info'].data?.flux?.version);
+    _fillPartial_apps(fluxNode, targetNode['apps'].data);
+    _fillPartial_uptime(fluxNode, targetNode['uptime'].data);
+  };
+}
+// FLUXNODE_INFO_API_MODE == 'debug'
+else {
+  _fetchAndFillNodeInfo = async (fluxNode) => {
+    let server = 'http://' + make_node_ip(fluxNode);
+
+    const promiseNodeInfo = fetch(server + API_NODE_INFO_ENDPOINT, { ...REQUEST_OPTIONS_API });
+    const promiseAppList = fetch(server + API_FLUX_APPLIST_ENDPOINT, { ...REQUEST_OPTIONS_API });
+    const promiseUptimeData = fetch(server + API_FLUX_UPTIME_ENDPOINT, { ...REQUEST_OPTIONS_API });
+
+    let reqSuccess;
+
+    let resultNodeInfo;
+    let resultAppList;
+    let resultUptime;
+
+    try {
+      [resultNodeInfo, resultAppList, resultUptime] = await Promise.all([
+        promiseNodeInfo,
+        promiseAppList,
+        promiseUptimeData
+      ]);
+      reqSuccess = true;
+    } catch {
+      reqSuccess = false;
+    }
+
+    if (reqSuccess) {
+      const nodeInfo = (await resultNodeInfo.json())?.data;
+      _fillPartial_bench_info(fluxNode, nodeInfo?.benchmark?.info);
+      _fillPartial_benchmarks(fluxNode, nodeInfo?.benchmark?.bench);
+      _fillPartial_version(fluxNode, nodeInfo?.flux?.version);
+      _fillPartial_apps(fluxNode, (await resultAppList.json()).data);
+      _fillPartial_uptime(fluxNode, (await resultUptime.json()).data);
+    }
+  };
+}
+
+export async function fillPartialNode(node) {
+  // Do not try to reach servers if they are confirmed to be offline
+  if (!node.maybe_online) return make_offline(node);
+
+  await _fetchAndFillNodeInfo(node);
+}
+
+function fill_tier_health(target, tierRewardProjections, fluxPriceUsd) {
+  target.projection_daily.flux =
+    target.node_count * (tierRewardProjections.payment_amount + tierRewardProjections.pa_amount);
+  target.projection_daily.usd = target.projection_daily.flux * fluxPriceUsd;
+
+  target.projection_montly.flux = target.projection_daily.flux * 30.0;
+  target.projection_montly.usd = target.projection_daily.usd * 30.0;
+}
+
+export function fill_health(health, gstore) {
+  fill_tier_health(health.cumulus, gstore.reward_projections.cumulus, gstore.flux_price_usd);
+  fill_tier_health(health.nimbus, gstore.reward_projections.nimbus, gstore.flux_price_usd);
+  fill_tier_health(health.stratus, gstore.reward_projections.stratus, gstore.flux_price_usd);
+  // Fractus is parts of Cumulus tier
+  //fill_tier_health(health.fractus, gstore.reward_projections.fractus, gstore.flux_price_usd);
+}
+
+export async function validateAddress(address) {
+  try {
+    const res = await fetch('https://api.runonflux.io/explorer/balance?address=' + address);
+    const json = await res.json();
+    return json['data'] !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+export async function getDemoWallet() {
+  try {
+    const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/demo`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+    const jsonData = await response.json();
+    return jsonData;
+  } catch {
+    return null;
+  }
+}

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -1,7 +1,4 @@
-import dayjs from 'dayjs';
-
-import { format_minutes } from 'utils';
-import { fluxos_version_desc, fluxos_version_string, fluxos_version_desc_parse } from 'main/flux_version';
+import { fluxos_version_desc, fluxos_version_desc_parse } from 'main/flux_version';
 import { fetch_fluxinfo_aggregate } from 'fluxinfo';
 import { buildSpecIndex } from 'appSpecs';
 // A real import as well as the re-export below: `export { x } from 'y'` makes
@@ -10,7 +7,7 @@ import { buildSpecIndex } from 'appSpecs';
 import { fetch_global_app_specs_raw } from 'api/specs';
 import { categorizeRunningApps } from 'runningAppsCategorized';
 import { explorerFetchJson } from 'explorer';
-import { EXPLORER_FLUX_NODES_PATH } from 'api/endpoints';
+import { REQUEST_OPTIONS_API } from 'api/endpoints';
 import { OLD_ADDRESS_FLUX } from 'donor/config';
 import {
   fetch_node_benchmarks,
@@ -18,9 +15,6 @@ import {
   fetch_node_geolocation,
   buildWorkhorseNodes
 } from 'networkNodes';
-import { topInGroup } from 'main/Gamification/rankInGroup';
-
-import { FLUXNODE_INFO_API_MODE, FLUXNODE_INFO_API_URL } from 'app-buildinfo';
 
 import {
   CC_BLOCK_REWARD,
@@ -36,18 +30,19 @@ import {
 } from 'content/index';
 import { appStore, StoreKeys } from 'persistance/store';
 
-const API_FLUX_NODE_URL = 'https://api.runonflux.io/daemon/viewdeterministiczelnodelist?filter=';
 const API_DOS_LIST = 'https://api.runonflux.io/daemon/getdoslist';
 const API_NODE_BENCHMARKS = 'https://stats.runonflux.io/fluxinfo?projection=benchmark';
 const API_NODE_GEOLOCATION = 'https://stats.runonflux.io/fluxinfo?projection=geolocation';
 const API_FLUX_NETWORK_UTILISATION = 'https://stats.runonflux.io/fluxinfo?projection=apps.resources';
 const API_FLUX_ARCANE_VERSION = 'https://stats.runonflux.io/fluxinfo?projection=flux';
 
-const API_NODE_INFO_ENDPOINT = '/flux/info';
-const API_FLUX_APPLIST_ENDPOINT = '/apps/installedapps';
-const API_FLUX_UPTIME_ENDPOINT = '/flux/systemuptime';
 
-const FLUX_PER_DAY = (24 * 60) * 2; /* 1 flux every 2 minutes */
+// Blocks per day at the 30-second block target: 1,440 minutes x 2 blocks.
+// The name predates the rename from blocks to flux-per-block accounting;
+// the value is a BLOCK count, which is what the CLC_NETWORK_* lines below
+// multiply a per-block reward by. (issue #204 -- the old comment said
+// '1 flux every 2 minutes', which would be 720, not 2,880.)
+const FLUX_PER_DAY = (24 * 60) * 2;
 
 const CLC_NETWORK_CUMULUS_PER_DAY = FLUX_PER_DAY * ((CC_BLOCK_REWARD * CC_FLUX_REWARD_CUMULUS) / 100.0);
 const CLC_NETWORK_NIMBUS_PER_DAY = FLUX_PER_DAY * ((CC_BLOCK_REWARD * CC_FLUX_REWARD_NIMBUS) / 100.0);
@@ -640,334 +635,6 @@ export async function fetch_global_stats(walletAddress = null) {
   return store;
 }
 
-/* ======= node health ======= */
-
-function wallet_health_entry() {
-  return {
-    node_count: 0,
-    projection_daily: { flux: 0, usd: 0 },
-    projection_montly: { flux: 0, usd: 0 }
-  };
-}
-
-export function wallet_health_full() {
-  return {
-    cumulus: wallet_health_entry(),
-    nimbus: wallet_health_entry(),
-    stratus: wallet_health_entry(),
-    //fractus: wallet_health_entry(),
-    total_nodes: 0
-  };
-}
-
-/* ======= nodes overview ======= */
-
-const REQUEST_OPTIONS_API = {
-  credentials: 'omit',
-  headers: {
-    Accept: 'application/json, text/plain, */*',
-    'Accept-Language': 'en-US,en;q=0.5'
-  },
-  method: 'GET',
-  mode: 'cors'
-};
-
-function empty_flux_node() {
-  return {
-    id: 0,
-    maybe_online: false,
-    ip_full: {
-      host: '',
-      port: null,
-
-      active_port_api: null,
-      active_port_os: null
-    },
-    ip_display: false,
-    tier: 'UNKNOWN', // "CUMULUS" | "NIMBUS" | "STRATUS" | "FRACTUS" | "UNKNOWN"
-    rank: -1,
-    last_reward: '-',
-    next_reward: '-',
-    benchmark_status: 'unknown', // 'unknown' | 'failed' | 'passed' | 'offline' | 'running'
-    bench_version: fluxos_version_desc(0, 0, 0),
-    flux_os: fluxos_version_desc(0, 0, 0),
-    cores: 0,
-    threads: 0,
-    eps: 0,
-    ram: 0,
-    dws: 0,
-    total_storage: 0,
-    down_speed: 0,
-    up_speed: 0,
-    last_benchmark: '-',
-    appCount: 0,
-    uptime: 0,
-    score: 0,
-
-    last_confirmed_height: 0
-    // maintenance_win: '-'
-  };
-}
-
-function calc_next_reward(rank) {
-  return format_minutes(rank / 2);
-}
-
-export function calc_mtn_window(last_confirmed_height, current_height) {
-  const BLOCK_RATE = 480;
-  //480 blocks at 30second blocks 240 minutes
-
-  const win = BLOCK_RATE - (current_height - last_confirmed_height);
-
-  if (win <= 0) return 'Closed';
-
-  return format_minutes(win / 2);
-}
-
-export const DISPLAY_DATE_FORMAT = 'DD-MMM-YYYY HH:mm:ss';
-
-const DEFAULT_FLUX_PORT_API = 16127;
-const DEFAULT_FLUX_PORT_OS = 16126;
-
-export function normalize_raw_node_tier(node) {
-  return node['tier'].toUpperCase();
-}
-
-export async function getWalletNodes(walletAddress) {
-  // implement and live in the dark(background) so we can turn it on when ranking feature is fixed
-  let wNodes = [];
-  if (process.env.REACT_APP_ENABLE_FLUX_NODE_API === 'true') {
-    try {
-      const res = await fetch(API_FLUX_NODE_URL + walletAddress);
-      wNodes = (await res.json())?.data;
-    } catch {}
-  } else {
-    // Through the explorer pool: this is the wallet-search path, so a rate
-    // limit here means a user sees no nodes at all.
-    const data = await explorerFetchJson(EXPLORER_FLUX_NODES_PATH);
-    wNodes = Array.isArray(data?.fluxNodes)
-      ? data.fluxNodes.filter((n) => n.payment_address == walletAddress)
-      : [];
-  }
-  return wNodes;
-}
-
-export async function getEnterpriseNodes() {
-  let enterpriseNodes = [];
-  try {
-    const res = await fetch('https://api.runonflux.io/apps/enterprisenodes');
-    enterpriseNodes = (await res.json())?.data;
-    // console.log('getEnterpriseNodes-----', enterpriseNodes);
-  } catch (e) {
-    console.log('getEnterpriseNodes', e);
-  }
-
-  return enterpriseNodes;
-}
-
-export function transformRawNode(node) {
-  let fluxNode = empty_flux_node();
-  const ipRaw = node['ip'];
-  if (ipRaw) {
-    fluxNode.maybe_online = true;
-
-    const ipParts = ipRaw.split(':');
-
-    fluxNode.ip_full.host = ipParts[0];
-    if (ipParts.length > 1) {
-      const portApi = +ipParts[1] || DEFAULT_FLUX_PORT_API;
-
-      fluxNode.ip_full.port = portApi;
-
-      fluxNode.ip_full.active_port_api = portApi;
-      fluxNode.ip_full.active_port_os = portApi - 1;
-    } else {
-      fluxNode.ip_full.port = null;
-
-      fluxNode.ip_full.active_port_api = DEFAULT_FLUX_PORT_API;
-      fluxNode.ip_full.active_port_os = DEFAULT_FLUX_PORT_OS;
-    }
-
-    fluxNode.id = ipRaw;
-    fluxNode.ip_display = ipRaw;
-  } else {
-    fluxNode.id = node['txhash'];
-  }
-
-  fluxNode.tier = normalize_raw_node_tier(node);
-  fluxNode.rank = node['rank'] || 0;
-  fluxNode.last_reward = dayjs.unix(node['lastpaid']).format(DISPLAY_DATE_FORMAT);
-  fluxNode.next_reward = calc_next_reward(node.rank);
-  fluxNode.last_confirmed_height = node['last_confirmed_height'] || 0;
-
-  return fluxNode;
-}
-
-function make_offline(fluxNode) {
-  fluxNode.benchmark_status = 'offline';
-  return undefined;
-}
-
-function _fillPartial_bench_info(fluxNode, bench_info) {
-  if (bench_info !== null) fluxNode.bench_version = fluxos_version_desc_parse(bench_info['version']);
-}
-
-function _fillPartial_benchmarks(fluxNode, benchmarks) {
-  if (benchmarks === null) return make_offline(fluxNode);
-
-  switch (benchmarks['benchmark_status']) {
-    case 'failed':
-      fluxNode.benchmark_status = 'failed';
-      break;
-    case 'running':
-      fluxNode.benchmark_status = 'running';
-      break;
-
-    default:
-      fluxNode.benchmark_status = 'passed';
-  }
-
-  fluxNode.threads = parseInt(benchmarks['cores'] || 0);
-  fluxNode.eps = benchmarks['eps'] || 0;
-  fluxNode.ram = benchmarks['ram'] || 0;
-  fluxNode.dws = benchmarks['ddwrite'] || 0;
-  fluxNode.total_storage = benchmarks['totalstorage'] || 0;
-  fluxNode.down_speed = benchmarks['download_speed'] || 0;
-  fluxNode.up_speed = benchmarks['upload_speed'] || 0;
-  fluxNode.thunder = benchmarks['thunder'] || false;
-
-  fluxNode.last_benchmark = dayjs.unix(benchmarks['time']).format(DISPLAY_DATE_FORMAT);
-}
-function _fillPartial_version(fluxNode, version) {
-  if (version !== null) fluxNode.flux_os = fluxos_version_desc_parse(version);
-}
-function _fillPartial_apps(fluxNode, installedApps) {
-  if (installedApps !== null) {
-    fluxNode.appCount = installedApps?.length;
-    fluxNode.installedApps = installedApps;
-  }
-}
-
-function _fillPartial_uptime(fluxNode, uptime) {
-  if (uptime !== null) fluxNode.uptime = uptime;
-}
-
-const make_node_ip = (fluxNode) => fluxNode.ip_full.host + ':' + fluxNode.ip_full.active_port_api;
-
-let _fetchAndFillNodeInfo;
-if (FLUXNODE_INFO_API_MODE === 'proxy') {
-  _fetchAndFillNodeInfo = async (fluxNode) => {
-    let responseOK = false;
-    let jsonData = {};
-
-    try {
-      const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/node-single/` + make_node_ip(fluxNode), {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json'
-        }
-      });
-
-      responseOK = response.status == 200;
-      jsonData = await response.json();
-    } catch {}
-
-    if (!(responseOK && jsonData['success'])) return make_offline(fluxNode);
-
-    let targetNode = jsonData['node']['results'];
-
-    _fillPartial_bench_info(fluxNode, targetNode['node_info'].data?.benchmark?.info);
-    _fillPartial_benchmarks(fluxNode, targetNode['node_info'].data?.benchmark?.bench);
-    _fillPartial_version(fluxNode, targetNode['node_info'].data?.flux?.version);
-    _fillPartial_apps(fluxNode, targetNode['apps'].data);
-    _fillPartial_uptime(fluxNode, targetNode['uptime'].data);
-  };
-}
-// FLUXNODE_INFO_API_MODE == 'debug'
-else {
-  _fetchAndFillNodeInfo = async (fluxNode) => {
-    let server = 'http://' + make_node_ip(fluxNode);
-
-    const promiseNodeInfo = fetch(server + API_NODE_INFO_ENDPOINT, { ...REQUEST_OPTIONS_API });
-    const promiseAppList = fetch(server + API_FLUX_APPLIST_ENDPOINT, { ...REQUEST_OPTIONS_API });
-    const promiseUptimeData = fetch(server + API_FLUX_UPTIME_ENDPOINT, { ...REQUEST_OPTIONS_API });
-
-    let reqSuccess;
-
-    let resultNodeInfo;
-    let resultAppList;
-    let resultUptime;
-
-    try {
-      [resultNodeInfo, resultAppList, resultUptime] = await Promise.all([
-        promiseNodeInfo,
-        promiseAppList,
-        promiseUptimeData
-      ]);
-      reqSuccess = true;
-    } catch {
-      reqSuccess = false;
-    }
-
-    if (reqSuccess) {
-      const nodeInfo = (await resultNodeInfo.json())?.data;
-      _fillPartial_bench_info(fluxNode, nodeInfo?.benchmark?.info);
-      _fillPartial_benchmarks(fluxNode, nodeInfo?.benchmark?.bench);
-      _fillPartial_version(fluxNode, nodeInfo?.flux?.version);
-      _fillPartial_apps(fluxNode, (await resultAppList.json()).data);
-      _fillPartial_uptime(fluxNode, (await resultUptime.json()).data);
-    }
-  };
-}
-
-export async function fillPartialNode(node) {
-  // Do not try to reach servers if they are confirmed to be offline
-  if (!node.maybe_online) return make_offline(node);
-
-  await _fetchAndFillNodeInfo(node);
-}
-
-function fill_tier_health(target, tierRewardProjections, fluxPriceUsd) {
-  target.projection_daily.flux =
-    target.node_count * (tierRewardProjections.payment_amount + tierRewardProjections.pa_amount);
-  target.projection_daily.usd = target.projection_daily.flux * fluxPriceUsd;
-
-  target.projection_montly.flux = target.projection_daily.flux * 30.0;
-  target.projection_montly.usd = target.projection_daily.usd * 30.0;
-}
-
-export function fill_health(health, gstore) {
-  fill_tier_health(health.cumulus, gstore.reward_projections.cumulus, gstore.flux_price_usd);
-  fill_tier_health(health.nimbus, gstore.reward_projections.nimbus, gstore.flux_price_usd);
-  fill_tier_health(health.stratus, gstore.reward_projections.stratus, gstore.flux_price_usd);
-  // Fractus is parts of Cumulus tier
-  //fill_tier_health(health.fractus, gstore.reward_projections.fractus, gstore.flux_price_usd);
-}
-
-export async function validateAddress(address) {
-  try {
-    const res = await fetch('https://api.runonflux.io/explorer/balance?address=' + address);
-    const json = await res.json();
-    return json['data'] !== undefined;
-  } catch {
-    return false;
-  }
-}
-
-export async function getDemoWallet() {
-  try {
-    const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/demo`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    });
-    const jsonData = await response.json();
-    return jsonData;
-  } catch {
-    return null;
-  }
-}
 
 // Fetch USD Latest currency rate
 // Currency rates now live in client/src/currency.js so they can be unit
@@ -995,6 +662,25 @@ async function lazy_load_fractus_count(benchmarks) {
 
 /* ======================================================================= */
 /* ======================================================================= */
+/*
+ * Wallet nodes moved to api/walletNodes.js (issue #147). Re-exported here
+ * so no call site changes in this pass; importers migrate to the new path
+ * incrementally, and this barrel goes away once none are left.
+ */
+export {
+  wallet_health_full,
+  calc_mtn_window,
+  DISPLAY_DATE_FORMAT,
+  normalize_raw_node_tier,
+  getWalletNodes,
+  getEnterpriseNodes,
+  transformRawNode,
+  fillPartialNode,
+  fill_health,
+  validateAddress,
+  getDemoWallet
+} from 'api/walletNodes';
+
 export { buildTierResolver, fetch_global_performance_rankings, fetch_country_node_counts, _extract_country_counts } from 'api/rankings';
 export { pa_summary_full, wallet_pas_summary } from 'api/parallelAssets';
 export { fetch_global_app_specs, fetch_global_app_specs_raw } from 'api/specs';


### PR DESCRIPTION
Third pass on #147. **apidata.js: 1,055 → 741 lines** (1,702 when the issue was opened).

## What moved

`client/src/api/walletNodes.js` takes the whole *node health* + *nodes overview* region — `getWalletNodes`, `getEnterpriseNodes`, `transformRawNode`, `fillPartialNode`, `fill_health`, `wallet_health_full`, `normalize_raw_node_tier`, `calc_mtn_window`, `validateAddress`, `getDemoWallet`, `DISPLAY_DATE_FORMAT`.

**The cut was chosen by measuring coupling, not by where the banner comments fell.** Before moving anything:

- none of those ten functions is called from anywhere else in apidata.js
- the four endpoint constants they use are referenced nowhere outside the region, so they moved too

Verified afterwards that the moved block is **byte-identical** to what was on main. This is a move, not a rewrite. apidata.js re-exports everything, so no call site changes in this pass.

## The shared constant — found by the compiler, not by me

`REQUEST_OPTIONS_API` was declared beside the node code but also used by `fetch_gpu_prices`, which stayed behind. Extracting the region broke the build:

```
Line 704:54:  'REQUEST_OPTIONS_API' is not defined  no-undef
```

It now lives in `api/endpoints.js` — the module that already exists for things shared by more than one API module — and both callers import it. A one-constant module would have been over-splitting.

Two things worth drawing out:

1. **This is exactly the failure #147 is about, in miniature.** A value used from two places, declared next to one of them, where moving either half breaks the other.
2. **It's the second time this session a green test run didn't catch a broken build.** All 553 tests pass either way, because none of them exercises `fetch_gpu_prices`. The build is the gate, not the suite.

## Also cleaned up

Four imports orphaned by this move (`dayjs`, `format_minutes`, `EXPLORER_FLUX_NODES_PATH`, `FLUXNODE_INFO_API_MODE`/`URL`) and **two that were already dead before it** — `fluxos_version_string` and `topInGroup`, left behind by the earlier #147 passes.

## Issue #204, folded in

`FLUX_PER_DAY`'s comment said *"1 flux every 2 minutes"*, which would be 720. The value is `(24 * 60) * 2` = **2,880** — blocks per day at the 30-second block target, which is what the `CLC_NETWORK_*` lines multiply a per-block reward by.

The arithmetic was always right; only the comment was wrong. Corrected rather than carried forward, since this pass moves the constant's neighbours out from under it. **No behaviour change**, and unrelated to the whitepaper items the rest of that issue range covers — flagging it explicitly since #204 sits inside the parked #202–#207 block, and I'd rather you push back than have it slip through unnoticed.

## Verification

- 553 tests pass
- Production build clean
- Moved block confirmed byte-identical to main

## What's left in apidata.js

741 lines: the global-stats region (`create_global_store`, `fill_rewards`, `fetch_total_donations`, `fetch_arcane_os_stats`, `fetch_total_network_utils`, `fetch_global_stats`) plus GPU prices and DOS state. `fetch_global_stats` is the orchestrating entry point and touches most of the rest, so it wants its own pass rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)