### PR TITLE
Wave 2: footer, Apps panel layout, team badge, and Expiring/Deployed filtering

### DIFF
--- a/client/src/analytics/AppsTab/index.jsx
+++ b/client/src/analytics/AppsTab/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { FiBox, FiCpu, FiHardDrive, FiDatabase } from 'react-icons/fi';
@@ -10,6 +10,7 @@ import { CategoryTooltip } from 'components/CategoryTooltip';
 import { WorkhorsePanel } from 'home/WorkhorsePanel';
 import { rankNodeOperators, aggregateOwnerTotals, DEFAULT_TOP_N } from 'analytics/topOwners';
 import { FLUX_TEAM_OWNER_ZELIDS, computeTeamSponsoredShare } from 'analytics/teamSponsored';
+import { filterAndSortSpecs, nextSortState } from 'analytics/AppsTab/specFilter';
 import { buildTeamAppRows, formatExpiry } from 'analytics/teamApps';
 import { PanelGate } from 'analytics/PanelGate';
 import './index.scss';
@@ -45,16 +46,42 @@ function fmtSpecVal(value, suffix) {
   return `${value.toFixed(2)}${suffix}`;
 }
 
-function SpecHeader() {
+/*
+ * Column headers double as sort controls (issue #247). Real <button>s, not
+ * click handlers on spans, so the panels stay keyboard-reachable and announce
+ * their sort state -- the same reasoning as the Chain Activity drill-down.
+ */
+const SPEC_COLUMNS = [
+  { key: 'name', label: 'Name', cls: 'hov-spec-header__name' },
+  { key: 'category', label: 'Cat', cls: 'hov-spec-header__cat' },
+  { key: 'instances', label: 'Inst', cls: 'hov-spec-header__inst' },
+  { key: 'cpuPerInst', label: 'CPU', cls: 'hov-spec-header__val' },
+  { key: 'ramGBPerInst', label: 'RAM', cls: 'hov-spec-header__val' },
+  { key: 'ssdGBPerInst', label: 'SSD', cls: 'hov-spec-header__val' },
+  { key: 'timeBlocks', label: 'Time', cls: 'hov-spec-header__time' }
+];
+
+function SpecHeader({ sortKey, sortDir, onSort }) {
   return (
     <div className="hov-spec-header">
-      <span className="hov-spec-header__name">Name</span>
-      <span className="hov-spec-header__cat">Cat</span>
-      <span className="hov-spec-header__inst">Inst</span>
-      <span className="hov-spec-header__val">CPU</span>
-      <span className="hov-spec-header__val">RAM</span>
-      <span className="hov-spec-header__val">SSD</span>
-      <span className="hov-spec-header__time">Time</span>
+      {SPEC_COLUMNS.map(({ key, label, cls }) => {
+        const active = sortKey === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            className={`${cls} hov-spec-header__btn${active ? ' hov-spec-header__btn--active' : ''}`}
+            onClick={() => onSort(key)}
+            aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+            title={`Sort by ${label}`}
+          >
+            {label}
+            <span className="hov-spec-sort" aria-hidden="true">
+              {active ? (sortDir === 'asc' ? '▴' : '▾') : '⇅'}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -72,37 +99,81 @@ function SpecCategoryIcon({ category }) {
   );
 }
 
-function ExpiringTodayPanel({ appSpecs }) {
-  if (!appSpecs) {
-    return (
-      <div className="hov-panel hov-panel-center">
-        <Spinner size={24} />
-      </div>
-    );
-  }
+/*
+ * One component for both panels (issue #247).
+ *
+ * These were two near-identical copies differing only in title, tone class and
+ * how the time column reads. That is the same duplication pattern that put the
+ * same bug in Home.jsx and MainApp.jsx twice over (#249/#251), so the filter
+ * and sort controls are added ONCE here rather than to two copies that would
+ * immediately start drifting.
+ *
+ * `timeBlocks` is normalised on the way in so specFilter can sort the time
+ * column without caring which panel it came from.
+ */
+function SpecPanel({ title, items, modifier, tone, emptyText, renderTime }) {
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState({ sortKey: null, sortDir: null });
 
-  const items = appSpecs.expiringToday || [];
+  const visible = useMemo(
+    () => filterAndSortSpecs(items, { query, ...sort }),
+    [items, query, sort]
+  );
+
+  const onSort = (key) => setSort((prev) => nextSortState(prev, key));
+  const filtering = query.trim().length > 0;
 
   return (
-    <div className="hov-panel hov-panel--expiring">
+    <div className={`hov-panel ${modifier}`}>
       <div className="hov-header">
-        <span className="hov-header-title">EXPIRING TODAY</span>
-        {items.length > 0 && <span className="hov-header-badge">{items.length}</span>}
+        <span className="hov-header-title">{title}</span>
+        {items.length > 0 && (
+          <span className="hov-header-badge">
+            {filtering ? `${visible.length}/${items.length}` : items.length}
+          </span>
+        )}
       </div>
-      {items.length > 0 && <SpecHeader />}
+
+      {items.length > 0 && (
+        <div className="hov-spec-filter">
+          <input
+            type="text"
+            className="hov-spec-filter__input"
+            placeholder="Filter by name or category…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label={`Filter ${title}`}
+          />
+          {filtering && (
+            <button
+              type="button"
+              className="hov-spec-filter__clear"
+              onClick={() => setQuery('')}
+              aria-label="Clear filter"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      )}
+
+      {items.length > 0 && <SpecHeader sortKey={sort.sortKey} sortDir={sort.sortDir} onSort={onSort} />}
+
       <div className="hov-list">
         {items.length === 0 ? (
-          <div className="hov-empty">None expiring today</div>
+          <div className="hov-empty">{emptyText}</div>
+        ) : visible.length === 0 ? (
+          <div className="hov-empty">No apps match “{query.trim()}”</div>
         ) : (
-          items.map((spec, i) => (
+          visible.map((spec, i) => (
             <div key={spec.name + i} className="hov-spec-row">
-              <span className="hov-list-name">{spec.name}</span>
+              <span className="hov-list-name" title={spec.name}>{spec.name}</span>
               <SpecCategoryIcon category={spec.category} />
-              <span className="hov-badge hov-badge--warn">{spec.instances}×</span>
+              <span className={`hov-badge hov-badge--${tone}`}>{spec.instances}×</span>
               <span className="hov-spec-val">{fmtSpecVal(spec.cpuPerInst, 'c')}</span>
               <span className="hov-spec-val">{fmtSpecVal(spec.ramGBPerInst, 'GB')}</span>
               <span className="hov-spec-val">{fmtSpecVal(spec.ssdGBPerInst, 'GB')}</span>
-              <span className="hov-time hov-time--warn">in {blocksToHuman(spec.expiresInBlocks)}</span>
+              <span className={`hov-time hov-time--${tone}`}>{renderTime(spec)}</span>
             </div>
           ))
         )}
@@ -111,7 +182,12 @@ function ExpiringTodayPanel({ appSpecs }) {
   );
 }
 
-function DeployedTodayPanel({ appSpecs }) {
+function ExpiringTodayPanel({ appSpecs }) {
+  const items = useMemo(
+    () => (appSpecs?.expiringToday || []).map((s) => ({ ...s, timeBlocks: s.expiresInBlocks })),
+    [appSpecs]
+  );
+
   if (!appSpecs) {
     return (
       <div className="hov-panel hov-panel-center">
@@ -120,33 +196,41 @@ function DeployedTodayPanel({ appSpecs }) {
     );
   }
 
-  const items = appSpecs.deployedToday || [];
+  return (
+    <SpecPanel
+      title="EXPIRING TODAY"
+      items={items}
+      modifier="hov-panel--expiring"
+      tone="warn"
+      emptyText="None expiring today"
+      renderTime={(spec) => `in ${blocksToHuman(spec.expiresInBlocks)}`}
+    />
+  );
+}
+
+function DeployedTodayPanel({ appSpecs }) {
+  const items = useMemo(
+    () => (appSpecs?.deployedToday || []).map((s) => ({ ...s, timeBlocks: s.deployedAgeBlocks })),
+    [appSpecs]
+  );
+
+  if (!appSpecs) {
+    return (
+      <div className="hov-panel hov-panel-center">
+        <Spinner size={24} />
+      </div>
+    );
+  }
 
   return (
-    <div className="hov-panel hov-panel--deployed">
-      <div className="hov-header">
-        <span className="hov-header-title">DEPLOYED TODAY</span>
-        {items.length > 0 && <span className="hov-header-badge">{items.length}</span>}
-      </div>
-      {items.length > 0 && <SpecHeader />}
-      <div className="hov-list">
-        {items.length === 0 ? (
-          <div className="hov-empty">None deployed today</div>
-        ) : (
-          items.map((spec, i) => (
-            <div key={spec.name + i} className="hov-spec-row">
-              <span className="hov-list-name">{spec.name}</span>
-              <SpecCategoryIcon category={spec.category} />
-              <span className="hov-badge hov-badge--green">{spec.instances}×</span>
-              <span className="hov-spec-val">{fmtSpecVal(spec.cpuPerInst, 'c')}</span>
-              <span className="hov-spec-val">{fmtSpecVal(spec.ramGBPerInst, 'GB')}</span>
-              <span className="hov-spec-val">{fmtSpecVal(spec.ssdGBPerInst, 'GB')}</span>
-              <span className="hov-time hov-time--green">{blocksToHuman(spec.deployedAgeBlocks)} ago</span>
-            </div>
-          ))
-        )}
-      </div>
-    </div>
+    <SpecPanel
+      title="DEPLOYED TODAY"
+      items={items}
+      modifier="hov-panel--deployed"
+      tone="green"
+      emptyText="None deployed today"
+      renderTime={(spec) => `${blocksToHuman(spec.deployedAgeBlocks)} ago`}
+    />
   );
 }
 

--- a/client/src/analytics/AppsTab/index.jsx
+++ b/client/src/analytics/AppsTab/index.jsx
@@ -164,8 +164,8 @@ function RankedAddressList({ title, rows, valueLabel, teamZelids = [] }) {
           rows.map(({ key, value }, i) => (
             <div key={key} className="hov-ranked-row">
               <span className={`hov-rank${i === 0 ? ' hov-rank--gold' : i === 1 ? ' hov-rank--silver' : i === 2 ? ' hov-rank--bronze' : ''}`}>#{i + 1}</span>
-              <span className="hov-ranked-name" title={key}>
-                {truncateAddr(key)}
+              <span className="hov-ranked-name apps-tab-owner-name" title={key}>
+                <span className="apps-tab-owner-id">{truncateAddr(key)}</span>
                 {teamZelids.includes(key) && <span className="apps-tab-team-flag">Flux team</span>}
               </span>
               <div className="hov-ranked-bar-wrap">

--- a/client/src/analytics/AppsTab/index.scss
+++ b/client/src/analytics/AppsTab/index.scss
@@ -514,3 +514,84 @@
     font-weight: 600;
   }
 }
+
+/*
+ * Filter + sort controls for the EXPIRING TODAY / DEPLOYED TODAY panels
+ * (issue #247).
+ */
+.hov-spec-filter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 2px 6px;
+}
+
+.hov-spec-filter__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.72rem;
+  padding: 3px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  background: var(--surface-inset);
+  color: inherit;
+
+  &::placeholder {
+    color: rgba(128, 128, 128, 0.75);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(43, 97, 209, 0.6);
+  }
+}
+
+.hov-spec-filter__clear {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.6;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 2px 5px;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+/*
+ * Header cells are buttons now, so the browser's default button chrome has to
+ * be stripped back to what the spans looked like before.
+ */
+.hov-spec-header__btn {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity var(--transition-fast);
+
+  &:hover,
+  &--active {
+    opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: 1px solid rgba(43, 97, 209, 0.7);
+    outline-offset: 2px;
+  }
+}
+
+.hov-spec-sort {
+  font-size: 0.6em;
+  opacity: 0.7;
+}

--- a/client/src/analytics/AppsTab/index.scss
+++ b/client/src/analytics/AppsTab/index.scss
@@ -6,17 +6,71 @@
   gap: 20px;
 }
 
+/*
+ * Six panels, so only a column count that DIVIDES six leaves a full last row
+ * (issue #248).
+ *
+ * This was `repeat(auto-fit, minmax(340px, 1fr))`, which resolves to 4 or 5
+ * columns at ordinary desktop widths -- 6 mod 5 = 1, 6 mod 4 = 2 -- stranding
+ * DEPLOYED TODAY alone on a second row at a third the width and two thirds the
+ * height of its siblings. It only looked correct on a very wide display, where
+ * auto-fit happened to give 6+ tracks and collapse the empties.
+ *
+ * Fixed counts rather than auto-fit because the constraint here is divisibility,
+ * which auto-fit cannot express.
+ */
 .apps-tab-panel-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
+
+  @media (min-width: 720px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1100px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  // Below this the six tracks would each fall under the ~340px these panels
+  // need for their name + bar + value rows.
+  @media (min-width: 2200px) {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
 }
 
 .apps-tab-ranked-panel {
   min-width: 0;
 }
 
+/*
+ * The team badge sits INSIDE .hov-ranked-name, which truncates with an
+ * ellipsis -- so the badge was being cut mid-word to "Flux tea..." (issue
+ * #255). Splitting the cell into a flex row lets the ADDRESS absorb the
+ * truncation while the badge keeps its full width.
+ *
+ * Scoped to .apps-tab-owner-name rather than changing .hov-ranked-name, which
+ * is shared with the Network and Donor tabs and has no badge to protect.
+ */
+.apps-tab-owner-name {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  // The shared rule sets these for the whole cell; the inner id owns them now.
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.apps-tab-owner-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .apps-tab-team-flag {
+  flex-shrink: 0;
+  white-space: nowrap;
   margin-left: 6px;
   padding: 1px 6px;
   border-radius: 999px;

--- a/client/src/analytics/AppsTab/specFilter.js
+++ b/client/src/analytics/AppsTab/specFilter.js
@@ -1,0 +1,62 @@
+/*
+ * Filtering and ordering for the EXPIRING TODAY / DEPLOYED TODAY panels
+ * (issue #247).
+ *
+ * Both panels were static lists. DEPLOYED TODAY routinely carries 80+ rows, so
+ * finding a particular app meant scrolling and reading every line.
+ *
+ * Kept out of the component deliberately: ordering rules are exactly the kind
+ * of thing that looks right in a screenshot and is wrong on the data (a string
+ * sort putting 11.72 GB below 3.91 GB, for instance), and here they are
+ * provable without mounting the Analytics page.
+ */
+
+// Fields the user can order by. `timeBlocks` is normalised by the caller from
+// expiresInBlocks / deployedAgeBlocks so both panels share one implementation.
+const NUMERIC_KEYS = new Set(['instances', 'cpuPerInst', 'ramGBPerInst', 'ssdGBPerInst', 'timeBlocks']);
+
+/*
+ * The query matches name OR category, so typing "gaming" narrows to a category
+ * without needing a second control. Case-insensitive because the real data
+ * mixes cases freely -- "PALWORLD178" and "palworld178" are both live app names.
+ */
+function matches(spec, needle) {
+  const name = String(spec?.name ?? '').toLowerCase();
+  const category = String(spec?.category ?? '').toLowerCase();
+  return name.includes(needle) || category.includes(needle);
+}
+
+function compare(a, b, sortKey) {
+  if (NUMERIC_KEYS.has(sortKey)) {
+    // A missing measurement sorts as lowest rather than throwing. Specs really
+    // do arrive without cpu/ram/ssd -- the panels already render those as "—".
+    const av = typeof a?.[sortKey] === 'number' ? a[sortKey] : -Infinity;
+    const bv = typeof b?.[sortKey] === 'number' ? b[sortKey] : -Infinity;
+    return av - bv;
+  }
+  return String(a?.[sortKey] ?? '').localeCompare(String(b?.[sortKey] ?? ''), undefined, { sensitivity: 'base' });
+}
+
+export function filterAndSortSpecs(specs, { query, sortKey, sortDir } = {}) {
+  if (!Array.isArray(specs)) return [];
+
+  const needle = String(query ?? '').trim().toLowerCase();
+  const filtered = needle ? specs.filter((s) => matches(s, needle)) : specs;
+
+  if (!sortKey || !sortDir) return filtered === specs ? specs.slice() : filtered;
+
+  // slice() first: this must never reorder the caller's array, which is state.
+  const sorted = filtered.slice().sort((a, b) => compare(a, b, sortKey));
+  return sortDir === 'desc' ? sorted.reverse() : sorted;
+}
+
+/*
+ * Header clicks cycle asc -> desc -> unsorted. The third state matters: the
+ * panels' natural order is meaningful (soonest to expire, most recently
+ * deployed), so there has to be a way back to it without reloading.
+ */
+export function nextSortState({ sortKey, sortDir } = {}, clickedKey) {
+  if (sortKey !== clickedKey) return { sortKey: clickedKey, sortDir: 'asc' };
+  if (sortDir === 'asc') return { sortKey: clickedKey, sortDir: 'desc' };
+  return { sortKey: null, sortDir: null };
+}

--- a/client/src/analytics/AppsTab/specFilter.test.js
+++ b/client/src/analytics/AppsTab/specFilter.test.js
@@ -1,0 +1,107 @@
+import { filterAndSortSpecs, nextSortState } from './specFilter';
+
+/*
+ * Issue #247 -- EXPIRING TODAY and DEPLOYED TODAY were static lists with no way
+ * to narrow or reorder them. DEPLOYED TODAY routinely carries 80+ rows, so
+ * finding one app meant scrolling and reading.
+ *
+ * The logic lives here rather than in the component so the ordering rules are
+ * provable without mounting the Analytics page.
+ */
+const SPECS = [
+  { name: 'valheim178', category: 'gaming', instances: 2, cpuPerInst: 4, ramGBPerInst: 11.72, ssdGBPerInst: 35, timeBlocks: 900 },
+  { name: 'minecraftj17', category: 'gaming', instances: 2, cpuPerInst: 2, ramGBPerInst: 3.91, ssdGBPerInst: 30, timeBlocks: 120 },
+  { name: 'logcursortest', category: 'other', instances: 1, cpuPerInst: 0.1, ramGBPerInst: 0.1, ssdGBPerInst: 1, timeBlocks: 450 },
+  { name: 'PALWORLD178', category: 'gaming', instances: 6, cpuPerInst: 6, ramGBPerInst: 15.63, ssdGBPerInst: 40, timeBlocks: 300 },
+];
+
+describe('filterAndSortSpecs', () => {
+  it('returns everything untouched with no query and no sort', () => {
+    expect(filterAndSortSpecs(SPECS, {}).map((s) => s.name)).toEqual([
+      'valheim178', 'minecraftj17', 'logcursortest', 'PALWORLD178',
+    ]);
+  });
+
+  it('filters by name, case-insensitively', () => {
+    // The real data mixes cases -- "PALWORLD178" and "palworld178" both occur.
+    expect(filterAndSortSpecs(SPECS, { query: 'palworld' }).map((s) => s.name)).toEqual(['PALWORLD178']);
+    expect(filterAndSortSpecs(SPECS, { query: 'VALHEIM' }).map((s) => s.name)).toEqual(['valheim178']);
+  });
+
+  it('matches on a substring anywhere in the name', () => {
+    expect(filterAndSortSpecs(SPECS, { query: '178' }).map((s) => s.name)).toEqual(['valheim178', 'PALWORLD178']);
+  });
+
+  it('also matches the category, so a category can be used as a filter', () => {
+    expect(filterAndSortSpecs(SPECS, { query: 'gaming' }).length).toBe(3);
+  });
+
+  it('returns nothing when the query matches nothing', () => {
+    expect(filterAndSortSpecs(SPECS, { query: 'nosuchapp' })).toEqual([]);
+  });
+
+  it('ignores surrounding whitespace in the query', () => {
+    expect(filterAndSortSpecs(SPECS, { query: '  palworld  ' }).map((s) => s.name)).toEqual(['PALWORLD178']);
+  });
+
+  it('sorts numerically, not lexicographically, on numeric columns', () => {
+    // A string sort would put 11.72 before 3.91.
+    expect(filterAndSortSpecs(SPECS, { sortKey: 'ramGBPerInst', sortDir: 'asc' }).map((s) => s.ramGBPerInst))
+      .toEqual([0.1, 3.91, 11.72, 15.63]);
+  });
+
+  it('sorts descending when asked', () => {
+    expect(filterAndSortSpecs(SPECS, { sortKey: 'instances', sortDir: 'desc' }).map((s) => s.instances))
+      .toEqual([6, 2, 2, 1]);
+  });
+
+  it('sorts names case-insensitively so PALWORLD does not jump above valheim', () => {
+    expect(filterAndSortSpecs(SPECS, { sortKey: 'name', sortDir: 'asc' }).map((s) => s.name))
+      .toEqual(['logcursortest', 'minecraftj17', 'PALWORLD178', 'valheim178']);
+  });
+
+  it('sorts by time, which is the column users actually care about', () => {
+    expect(filterAndSortSpecs(SPECS, { sortKey: 'timeBlocks', sortDir: 'asc' }).map((s) => s.timeBlocks))
+      .toEqual([120, 300, 450, 900]);
+  });
+
+  it('filters first, then sorts the survivors', () => {
+    expect(filterAndSortSpecs(SPECS, { query: 'gaming', sortKey: 'instances', sortDir: 'desc' }).map((s) => s.instances))
+      .toEqual([6, 2, 2]);
+  });
+
+  it('does not mutate the array it was given', () => {
+    const before = SPECS.map((s) => s.name);
+    filterAndSortSpecs(SPECS, { sortKey: 'instances', sortDir: 'desc' });
+    expect(SPECS.map((s) => s.name)).toEqual(before);
+  });
+
+  it('survives a missing or non-array input', () => {
+    expect(filterAndSortSpecs(null, { query: 'x' })).toEqual([]);
+    expect(filterAndSortSpecs(undefined, {})).toEqual([]);
+  });
+
+  it('treats a missing numeric field as lowest rather than throwing', () => {
+    const withGap = [{ name: 'a', instances: 2 }, { name: 'b' }];
+    expect(filterAndSortSpecs(withGap, { sortKey: 'instances', sortDir: 'desc' }).map((s) => s.name))
+      .toEqual(['a', 'b']);
+  });
+});
+
+describe('nextSortState', () => {
+  it('starts a fresh column ascending', () => {
+    expect(nextSortState({ sortKey: null, sortDir: null }, 'instances')).toEqual({ sortKey: 'instances', sortDir: 'asc' });
+  });
+
+  it('toggles asc to desc on the same column', () => {
+    expect(nextSortState({ sortKey: 'instances', sortDir: 'asc' }, 'instances')).toEqual({ sortKey: 'instances', sortDir: 'desc' });
+  });
+
+  it('clears the sort on the third click, restoring the original order', () => {
+    expect(nextSortState({ sortKey: 'instances', sortDir: 'desc' }, 'instances')).toEqual({ sortKey: null, sortDir: null });
+  });
+
+  it('switching columns starts the new one ascending', () => {
+    expect(nextSortState({ sortKey: 'instances', sortDir: 'desc' }, 'name')).toEqual({ sortKey: 'name', sortDir: 'asc' });
+  });
+});

--- a/client/src/components/Footer/index.scss
+++ b/client/src/components/Footer/index.scss
@@ -10,6 +10,19 @@
   margin: 0;
   overflow: hidden;
 
+  // The footer is a flex CHILD of .App, which is a fixed-height (100vh) flex
+  // column with `overflow: auto`. A flex item defaults to `flex-shrink: 1`, so
+  // on any route whose content overflows that height the footer was squeezed
+  // from its natural 62px down to 0.67px and clipped to nothing by the
+  // overflow: hidden above -- present in the DOM, invisible on screen, and
+  // positioned past the end of the scrollable area so it could not be reached
+  // by scrolling either (issue #246).
+  //
+  // /live is where this showed up because it is the tallest page; shorter
+  // routes never overflowed enough to trigger the shrink, which is why the
+  // footer looked fine everywhere else.
+  flex-shrink: 0;
+
   @include rule-mode-dark() {
     background-color: #101823;
     border-top-color: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
Wave 2. Closes #246. Closes #248. Closes #255. Closes #247.

Two commits — three visual fixes, then the filtering feature. Each visual bug had a root cause that wasn't what the symptom suggested.

## #246 — the footer was never missing

It was in the DOM on `/live` the whole time, rendered globally from `Application.jsx:193`, text intact. It had been squeezed to **0.67px**.

`.App` is a fixed-height (100vh) flex column with `overflow: auto`. A flex item defaults to `flex-shrink: 1`, so on any route whose content overflows that height the footer compressed from its natural 62px to nothing, then got clipped by its own `overflow: hidden`. It also sat at y=1913 while the scroll area ended at 1070 — so scrolling couldn't reach it either.

`flex-shrink: 0` fixes it. `/live` is just the tallest page; the bug was latent on every route.

**Before:** height 1px, top 1913, scrollable to 1914. **After:** height 63px, reachable, icons + version + donation address all visible.

## #248 — six panels, five columns

`.apps-tab-panel-grid` used `repeat(auto-fit, minmax(340px, 1fr))` → **4 or 5 columns** at ordinary desktop widths. Six panels; neither 4 nor 5 divides six. DEPLOYED TODAY was stranded alone on row two at 393×472 against its siblings' 393×738.

It looked fine only on a very wide display, where auto-fit gave 6+ tracks and collapsed the empties — which is why it reads as intermittent.

Now explicit counts that all divide six: 1 / 2 / 3 / 6 at 0 / 720 / 1100 / 2200px. Divisibility is the real constraint and `auto-fit` can't express it. At 2087px: a uniform **665×738, two rows of three**.

## #255 — badge clipped mid-word

The "Flux team" badge is a *child* of `.hov-ranked-name`, which truncates with `text-overflow: ellipsis` — so it cut to "Flux tea…". The cell is now a flex row with the **address** absorbing truncation and the badge at `flex-shrink: 0`. Scoped to a new `.apps-tab-owner-name`, leaving `.hov-ranked-name` (shared with Network and Donor tabs) alone.

## #247 — filter and sort

Both panels were static lists; DEPLOYED TODAY routinely carries ~80 rows.

- **Filter box** matching name **or** category, case-insensitive — the live data mixes cases ("PALWORLD178" and "palworld178" both exist), and matching category means typing "gaming" narrows by category without a second control.
- **Sortable headers**, cycling asc → desc → unsorted. The third state is deliberate: natural order is meaningful (soonest to expire, most recently deployed) and needs a way back without reloading.
- **"N/total" badge** while filtering.

The two panels were near-identical copies differing only in title, tone and time wording. Rather than add controls twice to copies that would drift — the exact pattern that put the same bug in `Home.jsx` and `MainApp.jsx` twice over — they now share one `SpecPanel`.

Ordering lives in `specFilter.js`, not the component, because sort rules look right in a screenshot and are wrong on the data: a string sort puts 11.72 GB below 3.91 GB and 8.30 GB above 15.63 GB. **18 unit tests** cover numeric-vs-lexical ordering, case-insensitive names, missing measurements, filter-then-sort, and non-mutation of the caller's array.

Headers are real `<button>`s with `aria-sort`, not click handlers on spans.

## Verification

- **645 tests pass, 44 suites** (594/39 at the start of this work). Production build clean.
- **D1 calculation audit** agrees, `compare.py` exit 0, after both commits.
- **Node page re-checked** after commit 1 because the footer rule is global: settles at **127 rows, all NIMBUS**, matching the deterministic node list and the Wave 1 baseline.
- Browser-verified: DEPLOYED TODAY 79 → 25 rows on "valheim", badge "25/79"; RAM descending → 15.63 / 11.72 / 8.30 / 7.81; third click restores natural order and `aria-sort` returns to `none`.

## One thing left deliberately alone

#248 is titled "Size alignment" and the orphaned panel is the objective bug, but there's a softer raggedness I did **not** change: **TOP HOSTED APPS shows 10 rows while TOP NODE OPERATORS and TOP APP OWNERS show 20**, so it still carries a blank area even with uniform panels. That looked like a possible editorial choice ("top 10 apps" vs "top 20 operators") rather than a bug. Harmonising the three ranked lists is a two-line change if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9