### PR TITLE
feat(#258): community donation totals on Home, and tell every wallet where it stands

### DIFF
--- a/client/src/api/__fixtures__/apidataBaseline.json
+++ b/client/src/api/__fixtures__/apidataBaseline.json
@@ -599,6 +599,11 @@
       "name": "fetch_country_node_counts",
       "type": "function"
     },
+    "fetch_donation_totals": {
+      "type": "function",
+      "length": 0,
+      "name": "fetch_donation_totals"
+    },
     "fetch_global_app_specs": {
       "length": 1,
       "name": "fetch_global_app_specs",
@@ -633,6 +638,11 @@
       "length": 1,
       "name": "fetch_total_network_utils",
       "type": "function"
+    },
+    "fetch_wallet_donation_summary": {
+      "type": "function",
+      "length": 1,
+      "name": "fetch_wallet_donation_summary"
     },
     "fillPartialNode": {
       "length": 1,

--- a/client/src/api/globalStats.js
+++ b/client/src/api/globalStats.js
@@ -30,6 +30,7 @@ import { fetch_global_app_specs_raw } from 'api/specs';
 import { categorizeRunningApps } from 'runningAppsCategorized';
 import { explorerFetchJson } from 'explorer';
 import { OLD_ADDRESS_FLUX } from 'donor/config';
+import { aggregateDonations } from 'donor/donationTotals';
 import {
   fetch_node_benchmarks,
   fetch_node_resources,
@@ -226,40 +227,96 @@ export function fill_rewards(gstore) {
  * Results are de-duplicated by txid, because a single transaction paying both
  * addresses would otherwise be counted twice.
  */
+/*
+ * Every transaction touching one donation address, across all its pages.
+ *
+ * Returns null (not []) when the address could not be read at all, so
+ * "explorer unreachable" stays distinguishable from "this address has no
+ * donations" -- a distinction both callers below depend on.
+ *
+ * Routed through the explorer pool (explorer.js) rather than one hardcoded
+ * host: a 429 on the primary fails over instead of ending the scan.
+ * explorerFetchJson already rejects non-2xx and non-JSON bodies -- the
+ * "Loading block index..." text/plain case this used to handle by hand.
+ */
+async function scanDonationAddress(address) {
+  const basePath = '/txs?address=' + address;
+  const firstPage = await explorerFetchJson(basePath);
+  if (!firstPage) return null;
+
+  const { pagesTotal } = firstPage;
+  const pageNums = pagesTotal <= 1 ? [] : new Array(pagesTotal - 1).fill(0).map((_v, i) => i + 1);
+
+  // Sequentially rather than all at once, to stay under the explorer's limits.
+  const pages = [firstPage];
+  for (const page of pageNums) {
+    const json = await explorerFetchJson(`${basePath}&pageNum=${page}`);
+    if (json) pages.push(json);
+  }
+
+  return pages.reduce((prev, current) => prev.concat(current.txs || []), []);
+}
+
+/** Both donation addresses, scanned independently. One failing does not erase the other. */
+async function scanBothDonationAddresses() {
+  const scans = [];
+  for (const address of [window.gContent.ADDRESS_FLUX, OLD_ADDRESS_FLUX]) {
+    scans.push(await scanDonationAddress(address));
+  }
+  return scans;
+}
+
+/*
+ * Network-wide donation totals for Home's transparency panel (issue #258).
+ *
+ * Shares scanBothDonationAddresses with fetch_total_donations below rather than
+ * repeating the pagination, failover and null-vs-empty handling -- the two ask
+ * different questions of the same bytes.
+ *
+ * Resolves { ok: false } when BOTH addresses were unreadable, so the panel can
+ * say "could not load" instead of rendering a confident and wrong zero.
+ */
+export async function fetch_donation_totals() {
+  const scans = await scanBothDonationAddresses();
+  if (scans.every((txs) => txs === null)) return { ok: false, totals: null };
+
+  const txs = scans.filter(Boolean).flat();
+  return { ok: true, totals: aggregateDonations(txs) };
+}
+
+/*
+ * The same per-wallet donation count as fetch_total_donations, but able to say
+ * whether the chain could actually be READ (issue #258).
+ *
+ * fetch_total_donations resolves 0 when both addresses are unreachable, which
+ * is correct for the achievement gates it feeds -- an unverifiable donation
+ * should not unlock anything. It is wrong for the donation chip, where 0 and
+ * "could not check" must render differently: asking a real supporter to donate
+ * because the explorer returned 429 is the one outcome worth engineering
+ * against.
+ *
+ * Shares one scan, so the pages calling this instead of fetch_total_donations
+ * pay no extra requests.
+ */
+export async function fetch_wallet_donation_summary(walletAddress) {
+  const scans = await scanBothDonationAddresses();
+  if (scans.every((txs) => txs === null)) return { ok: false, donationCount: 0 };
+
+  const countedTxids = new Set();
+  for (const txs of scans) {
+    if (!txs) continue;
+    for (const tx of txs) {
+      if (!tx.vin?.some((v) => v.addr === walletAddress)) continue;
+      countedTxids.add(tx.txid);
+    }
+  }
+  return { ok: true, donationCount: countedTxids.size };
+}
+
 export function fetch_total_donations(walletAddress) {
   return new Promise((resolve) => {
-    // Routed through the explorer pool (explorer.js) rather than one hardcoded
-    // host: a 429 on the primary now fails over instead of ending the scan.
-    // explorerFetchJson already rejects non-2xx and non-JSON bodies -- the
-    // "Loading block index..." text/plain case this used to handle by hand.
-    const safeFetchJson = (path) => explorerFetchJson(path);
-
-    // Every page for one address. Returns null (not []) when the address could
-    // not be read at all, so "explorer unreachable" stays distinguishable from
-    // "this address has no donations".
-    const scanAddress = async (address) => {
-      const basePath = '/txs?address=' + address;
-      const firstPage = await safeFetchJson(basePath);
-      if (!firstPage) return null;
-
-      const { pagesTotal } = firstPage;
-      const pageNums = pagesTotal <= 1 ? [] : new Array(pagesTotal - 1).fill(0).map((_v, i) => i + 1);
-
-      // fetch pages sequentially (or in small batches) instead of all at once
-      const pages = [firstPage];
-      for (const page of pageNums) {
-        const json = await safeFetchJson(`${basePath}&pageNum=${page}`);
-        if (json) pages.push(json);
-      }
-
-      return pages.reduce((prev, current) => prev.concat(current.txs || []), []);
-    };
-
     (async () => {
-      const scans = [];
-      for (const address of [window.gContent.ADDRESS_FLUX, OLD_ADDRESS_FLUX]) {
-        scans.push(await scanAddress(address));
-      }
+      const scans = await scanBothDonationAddresses();
 
       if (scans.every((txs) => txs === null)) {
         resolve(0); // explorer unavailable - fail gracefully instead of crashing

--- a/client/src/apidata.js
+++ b/client/src/apidata.js
@@ -31,6 +31,8 @@ export {
   create_global_store,
   fill_rewards,
   fetch_total_donations,
+  fetch_donation_totals,
+  fetch_wallet_donation_summary,
   fetch_arcane_os_stats,
   fetch_total_network_utils,
   fetch_global_stats

--- a/client/src/donor/WalletDonationChip/index.jsx
+++ b/client/src/donor/WalletDonationChip/index.jsx
@@ -1,0 +1,57 @@
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
+import { Tooltip2 } from '@blueprintjs/popover2';
+import { walletDonationState } from 'donor/walletDonationState';
+import './index.scss';
+
+/*
+ * Says something about the wallet currently being viewed, in both directions
+ * (issue #258).
+ *
+ * Before this there were two gold medals side by side next to the wallet
+ * address -- DonorBadge (premium unlocked) and a second medal counting this
+ * wallet's donations -- which looked identical and meant different things, and
+ * nothing at all for a wallet that had never donated. That silence was the gap:
+ * most people arrive, paste a wallet, watch their nodes, and are never told
+ * the site is worth supporting.
+ *
+ * A heart rather than another medal, so it cannot be confused with the premium
+ * badge sitting beside it.
+ */
+export function WalletDonationChip({ address, donationCount, settled, failed, donationAddress }) {
+  const state = walletDonationState({ address, donationCount, settled, failed });
+  if (state === 'hidden') return null;
+
+  if (state === 'supporter') {
+    const plural = donationCount === 1 ? 'donation' : 'donations';
+    return (
+      <Tooltip2
+        content={`${donationCount} ${plural} from this wallet. Thank you for keeping FluxNode running.`}
+        placement="bottom"
+        hoverOpenDelay={60}
+      >
+        <span className="wdc wdc--supporter">
+          <FaHeart size={12} aria-hidden="true" />
+          Supporter
+        </span>
+      </Tooltip2>
+    );
+  }
+
+  return (
+    <Tooltip2
+      content={
+        <span>
+          FluxNode is free and unfunded. If it saves you time, a donation to{' '}
+          <strong>{donationAddress}</strong> keeps it running.
+        </span>
+      }
+      placement="bottom"
+      hoverOpenDelay={60}
+    >
+      <span className="wdc wdc--ask">
+        <FaRegHeart size={12} aria-hidden="true" />
+        Support development
+      </span>
+    </Tooltip2>
+  );
+}

--- a/client/src/donor/WalletDonationChip/index.scss
+++ b/client/src/donor/WalletDonationChip/index.scss
@@ -1,0 +1,50 @@
+/*
+ * Two states, deliberately unequal in weight. The supporter chip is an
+ * acknowledgement and can carry colour; the ask is shown to almost every
+ * visitor on almost every visit, so it stays quiet enough to live beside the
+ * wallet address indefinitely without becoming something people resent.
+ */
+.wdc {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.wdc--supporter {
+  color: #b4315f;
+  background: rgba(214, 51, 108, 0.12);
+
+  :global(.app-mode-dark) &,
+  .app-mode-dark & {
+    color: #ff8fb1;
+    background: rgba(255, 143, 177, 0.16);
+  }
+}
+
+.wdc--ask {
+  color: rgba(90, 96, 106, 0.95);
+  background: rgba(128, 128, 128, 0.1);
+  font-weight: 500;
+  transition: background 120ms ease, color 120ms ease;
+
+  &:hover {
+    color: #b4315f;
+    background: rgba(214, 51, 108, 0.1);
+  }
+
+  .app-mode-dark & {
+    color: rgba(168, 176, 190, 0.95);
+    background: rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      color: #ff8fb1;
+      background: rgba(255, 143, 177, 0.12);
+    }
+  }
+}

--- a/client/src/donor/config.js
+++ b/client/src/donor/config.js
@@ -37,6 +37,22 @@ export const DONOR_MAX_PAGES_FETCHED = 20;
 export const OLD_ADDRESS_FLUX = 't1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG';
 
 /*
+ * Addresses whose transfers to the donation address are NOT third-party
+ * donations -- project-owned wallets moving funds -- and are therefore left out
+ * of the network-wide totals on Home (issue #258).
+ *
+ * This matters more than it looks. One of these addresses accounts for roughly
+ * 99% of everything the donation addresses have received in the last year.
+ * Including it would headline the Home panel with a number implying broad
+ * community backing that the remaining data does not support, which is the
+ * opposite of what a transparency panel is for.
+ *
+ * Only affects the aggregate display. Donor STATUS (donorStatus.js) is
+ * unchanged: an excluded address that really did donate still qualifies.
+ */
+export const EXCLUDED_FROM_DONATION_TOTALS = ['t1gesjNJGfzU8shfMZj6DVDatRKA3LQj8Nh'];
+
+/*
  * The full donor-gate mechanism (wallet -> chain-donation check -> unlock)
  * is built: DonorContext verifies a wallet's real on-chain donations via
  * fetch_donor_status and gates premium features (currently just /live) on

--- a/client/src/donor/donationTotals.js
+++ b/client/src/donor/donationTotals.js
@@ -1,0 +1,124 @@
+import { DONOR_WINDOW_DAYS, OLD_ADDRESS_FLUX, EXCLUDED_FROM_DONATION_TOTALS } from './config';
+
+/*
+ * Network-wide donation aggregates for the Home transparency panel (issue #258).
+ *
+ * Separate from api/globalStats.js's fetch_total_donations, which answers a
+ * different question -- how many donation TRANSACTIONS one wallet has sent,
+ * which is what the donor/super_donor/sugar_daddy achievements gate on. This
+ * answers "what has the community given in the last year", so it sums FLUX and
+ * counts distinct senders instead.
+ *
+ * Pure on purpose: the numbers it produces are the headline of a panel about
+ * transparency, and the rules below (what counts as a donation, whose money is
+ * excluded, which window) are exactly the sort of thing that looks right in a
+ * screenshot and is wrong on the data.
+ */
+
+const WINDOW_SEC = DONOR_WINDOW_DAYS * 24 * 60 * 60;
+
+function donationAddresses() {
+  // Read at call time, not module load: window.gContent is populated by
+  // public/runtime/app-content.js, which the container entrypoint rewrites.
+  const current = (typeof window !== 'undefined' && window.gContent?.ADDRESS_FLUX) || null;
+  return [current, OLD_ADDRESS_FLUX].filter(Boolean);
+}
+
+/*
+ * What this transaction actually paid to a donation address.
+ *
+ * Summing vout blindly would count CHANGE: a 50 FLUX donation funded by a 200
+ * FLUX input returns 150 to the sender in the same transaction, and that return
+ * leg is not a donation.
+ */
+function paidToDonationAddress(tx, addresses) {
+  let paid = 0;
+  for (const out of tx?.vout || []) {
+    const outAddrs = out?.scriptPubKey?.addresses || [];
+    if (outAddrs.some((a) => addresses.includes(a))) paid += Number(out.value) || 0;
+  }
+  return paid;
+}
+
+/*
+ * Who sent it. Inputs belonging to a donation address are skipped so a
+ * consolidation or refund from the project's own address is never credited as
+ * an incoming donation.
+ */
+function senderOf(tx, addresses) {
+  for (const input of tx?.vin || []) {
+    const addr = input?.addr;
+    if (addr && !addresses.includes(addr)) return addr;
+  }
+  return null;
+}
+
+export function aggregateDonations(txs, { nowMs = Date.now(), excluded } = {}) {
+  const empty = { totalFlux: 0, uniqueDonors: 0, donationCount: 0, lastDonation: null };
+  if (!Array.isArray(txs)) return empty;
+
+  const addresses = donationAddresses();
+  const skip = new Set(excluded || EXCLUDED_FROM_DONATION_TOTALS);
+  const cutoffSec = Math.floor(nowMs / 1000) - WINDOW_SEC;
+
+  // Callers concatenate one scan per donation address, so a transaction paying
+  // BOTH arrives twice.
+  const seen = new Set();
+  const donors = new Set();
+  let totalFlux = 0;
+  let donationCount = 0;
+  let lastDonation = null;
+
+  for (const tx of txs) {
+    if (!tx?.txid || seen.has(tx.txid)) continue;
+    if (typeof tx.time !== 'number' || tx.time < cutoffSec) continue;
+
+    const amount = paidToDonationAddress(tx, addresses);
+    if (amount <= 0) continue;
+
+    const from = senderOf(tx, addresses);
+    if (!from || skip.has(from)) continue;
+
+    seen.add(tx.txid);
+    donors.add(from);
+    totalFlux += amount;
+    donationCount += 1;
+
+    if (!lastDonation || tx.time > lastDonation.timeSec) {
+      lastDonation = { amount, from, timeSec: tx.time };
+    }
+  }
+
+  return {
+    // Rounded so binary floating point cannot put 0.30000000000000004 on screen.
+    totalFlux: Math.round(totalFlux * 1e8) / 1e8,
+    uniqueDonors: donors.size,
+    donationCount,
+    lastDonation
+  };
+}
+
+/*
+ * How long ago, in words.
+ *
+ * Deliberately coarsens past a week. The most recent real donation at the time
+ * of writing was five weeks old, and a bare date that stale reads as "this
+ * project is abandoned" -- "5 weeks ago" says the same thing without the
+ * implication that something is broken.
+ */
+export function relativeAge(timeSec, nowMs = Date.now()) {
+  if (typeof timeSec !== 'number') return null;
+
+  const days = Math.floor((Math.floor(nowMs / 1000) - timeSec) / (24 * 60 * 60));
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days} days ago`;
+
+  if (days < 60) {
+    const weeks = Math.round(days / 7);
+    return weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+  }
+
+  const months = Math.round(days / 30);
+  return months === 1 ? '1 month ago' : `${months} months ago`;
+}

--- a/client/src/donor/donationTotals.test.js
+++ b/client/src/donor/donationTotals.test.js
@@ -1,0 +1,139 @@
+import { aggregateDonations, relativeAge } from './donationTotals';
+
+/*
+ * Issue #258 -- network-wide donation transparency for the Home panel.
+ *
+ * Fixtures mirror the real explorer /txs shape: vout carries
+ * scriptPubKey.addresses, vin carries addr, and a transaction can pay several
+ * outputs of which only some go to a donation address.
+ */
+const DONATION_ADDR = 't1aUmu7HDr7BtwmdR1Y9i2K6KFRZs4Bumbt';
+const OLD_ADDR = 't1ebxupkNYVQiswfwi7xBTwwKtioJqwLmUG';
+const NOW = 1789000000000; // ms
+const DAY = 24 * 3600;
+const sec = (daysAgo) => Math.floor(NOW / 1000) - daysAgo * DAY;
+
+function tx({ txid, from, to = DONATION_ADDR, amount, daysAgo, change = 0 }) {
+  const vout = [{ value: String(amount), scriptPubKey: { addresses: [to] } }];
+  if (change) vout.push({ value: String(change), scriptPubKey: { addresses: [from] } });
+  return { txid, time: sec(daysAgo), vin: [{ addr: from }], vout };
+}
+
+describe('aggregateDonations', () => {
+  it('sums only what was paid TO a donation address, ignoring change outputs', () => {
+    // A 50 FLUX donation from a 200 FLUX input returns 150 as change. Counting
+    // vout blindly would report 200.
+    const r = aggregateDonations([tx({ txid: 'a', from: 't1alice', amount: 50, daysAgo: 10, change: 150 })], { nowMs: NOW });
+    expect(r.totalFlux).toBe(50);
+  });
+
+  it('counts unique donors, not transactions', () => {
+    const r = aggregateDonations([
+      tx({ txid: 'a', from: 't1alice', amount: 10, daysAgo: 5 }),
+      tx({ txid: 'b', from: 't1alice', amount: 10, daysAgo: 4 }),
+      tx({ txid: 'c', from: 't1bob', amount: 10, daysAgo: 3 }),
+    ], { nowMs: NOW });
+    expect(r.uniqueDonors).toBe(2);
+    expect(r.donationCount).toBe(3);
+    expect(r.totalFlux).toBe(30);
+  });
+
+  it('excludes project-owned addresses entirely', () => {
+    // The maintainer's own wallet is 99% of the real total; including it would
+    // present project funds as community support.
+    const r = aggregateDonations([
+      tx({ txid: 'a', from: 't1self', amount: 90000, daysAgo: 5 }),
+      tx({ txid: 'b', from: 't1alice', amount: 25, daysAgo: 4 }),
+    ], { nowMs: NOW, excluded: ['t1self'] });
+    expect(r.totalFlux).toBe(25);
+    expect(r.uniqueDonors).toBe(1);
+    expect(r.donationCount).toBe(1);
+  });
+
+  it('ignores donations older than the 365-day window', () => {
+    const r = aggregateDonations([
+      tx({ txid: 'old', from: 't1alice', amount: 500, daysAgo: 400 }),
+      tx({ txid: 'new', from: 't1bob', amount: 20, daysAgo: 300 }),
+    ], { nowMs: NOW });
+    expect(r.totalFlux).toBe(20);
+    expect(r.uniqueDonors).toBe(1);
+  });
+
+  it('counts both donation addresses, since the project changed address', () => {
+    const r = aggregateDonations([
+      tx({ txid: 'a', from: 't1alice', to: DONATION_ADDR, amount: 10, daysAgo: 5 }),
+      tx({ txid: 'b', from: 't1bob', to: OLD_ADDR, amount: 15, daysAgo: 6 }),
+    ], { nowMs: NOW });
+    expect(r.totalFlux).toBe(25);
+    expect(r.uniqueDonors).toBe(2);
+  });
+
+  it('de-duplicates a transaction that pays both addresses', () => {
+    const both = {
+      txid: 'dup', time: sec(5), vin: [{ addr: 't1alice' }],
+      vout: [
+        { value: '10', scriptPubKey: { addresses: [DONATION_ADDR] } },
+        { value: '5', scriptPubKey: { addresses: [OLD_ADDR] } },
+      ],
+    };
+    // The caller concatenates per-address scans, so the same tx arrives twice.
+    const r = aggregateDonations([both, both], { nowMs: NOW });
+    expect(r.donationCount).toBe(1);
+    expect(r.totalFlux).toBe(15);
+  });
+
+  it('reports the most recent donation, not the last one in the array', () => {
+    const r = aggregateDonations([
+      tx({ txid: 'a', from: 't1alice', amount: 10, daysAgo: 2 }),
+      tx({ txid: 'b', from: 't1bob', amount: 3, daysAgo: 40 }),
+    ], { nowMs: NOW });
+    expect(r.lastDonation).toMatchObject({ amount: 10, from: 't1alice' });
+  });
+
+  it('has no lastDonation when nothing qualifies', () => {
+    expect(aggregateDonations([], { nowMs: NOW }).lastDonation).toBeNull();
+  });
+
+  it('ignores transactions with no identifiable sender', () => {
+    // Coinbase-style inputs have no addr; they are not donations.
+    const orphan = { txid: 'x', time: sec(5), vin: [{}], vout: [{ value: '10', scriptPubKey: { addresses: [DONATION_ADDR] } }] };
+    expect(aggregateDonations([orphan], { nowMs: NOW }).donationCount).toBe(0);
+  });
+
+  it('ignores transactions that pay no donation address', () => {
+    const unrelated = { txid: 'y', time: sec(5), vin: [{ addr: 't1alice' }], vout: [{ value: '10', scriptPubKey: { addresses: ['t1somewhere'] } }] };
+    expect(aggregateDonations([unrelated], { nowMs: NOW }).totalFlux).toBe(0);
+  });
+
+  it('survives a null input rather than throwing', () => {
+    expect(aggregateDonations(null, { nowMs: NOW })).toMatchObject({ totalFlux: 0, uniqueDonors: 0, lastDonation: null });
+  });
+
+  it('does not let floating point noise leak into the displayed total', () => {
+    const r = aggregateDonations([
+      tx({ txid: 'a', from: 't1alice', amount: 0.1, daysAgo: 1 }),
+      tx({ txid: 'b', from: 't1bob', amount: 0.2, daysAgo: 1 }),
+    ], { nowMs: NOW });
+    expect(r.totalFlux).toBeCloseTo(0.3, 8);
+  });
+});
+
+describe('relativeAge', () => {
+  it('reads in days for a recent donation', () => {
+    expect(relativeAge(sec(1), NOW)).toBe('yesterday');
+    expect(relativeAge(sec(3), NOW)).toBe('3 days ago');
+  });
+
+  it('reads today for something within the last day', () => {
+    expect(relativeAge(sec(0), NOW)).toBe('today');
+  });
+
+  it('switches to weeks, then months, so a stale date does not read as abandoned', () => {
+    expect(relativeAge(sec(14), NOW)).toBe('2 weeks ago');
+    expect(relativeAge(sec(70), NOW)).toBe('2 months ago');
+  });
+
+  it('returns null for a missing timestamp', () => {
+    expect(relativeAge(null, NOW)).toBeNull();
+  });
+});

--- a/client/src/donor/walletDonationState.js
+++ b/client/src/donor/walletDonationState.js
@@ -1,0 +1,24 @@
+/*
+ * Which donation chip to show for the wallet currently being viewed
+ * (issue #258).
+ *
+ * Deliberately NOT the donor-benefit rule. donorStatus.js's 10-FLUX/365-day
+ * threshold decides who gets premium features; this decides who gets thanked,
+ * and those should not be the same bar. Telling somebody who donated 5 FLUX
+ * last month that they have not donated is worse than saying nothing at all.
+ *
+ * 'hidden' covers three different situations on purpose -- no wallet, still
+ * checking, and check failed -- because the correct rendering for all three is
+ * the same: nothing. Asking a real donor for a donation because the explorer
+ * returned 429 is the one outcome worth engineering against here.
+ */
+export function walletDonationState({ address, donationCount, settled, failed } = {}) {
+  if (!address) return 'hidden';
+
+  // An acknowledgement already earned is never retracted by a later failure.
+  if (typeof donationCount === 'number' && donationCount > 0) return 'supporter';
+
+  if (!settled || failed) return 'hidden';
+
+  return 'ask';
+}

--- a/client/src/donor/walletDonationState.test.js
+++ b/client/src/donor/walletDonationState.test.js
@@ -1,0 +1,50 @@
+import { walletDonationState } from './walletDonationState';
+
+/*
+ * Issue #258 -- the per-wallet chip next to "Current Wallet Address".
+ *
+ * Three states, and the third is the whole point: showing "support development"
+ * to somebody who HAS donated, because the explorer happened to fail, is the
+ * one genuinely bad outcome here. Silence is always safe; a wrong ask is not.
+ */
+describe('walletDonationState', () => {
+  it('thanks a wallet that has donated', () => {
+    expect(walletDonationState({ address: 't1alice', donationCount: 1, settled: true })).toBe('supporter');
+  });
+
+  it('treats ANY donation as support, not just one over the donor threshold', () => {
+    // The 10-FLUX/365-day rule gates PREMIUM. Telling somebody who gave 5 FLUX
+    // last month that they have not donated would be worse than saying nothing.
+    expect(walletDonationState({ address: 't1alice', donationCount: 1, settled: true })).toBe('supporter');
+  });
+
+  it('asks a wallet that has never donated', () => {
+    expect(walletDonationState({ address: 't1bob', donationCount: 0, settled: true })).toBe('ask');
+  });
+
+  it('shows nothing while the check is still running', () => {
+    expect(walletDonationState({ address: 't1bob', donationCount: 0, settled: false })).toBe('hidden');
+  });
+
+  it('shows nothing when the check FAILED rather than asking a possible donor', () => {
+    expect(walletDonationState({ address: 't1bob', donationCount: 0, settled: true, failed: true })).toBe('hidden');
+  });
+
+  it('still thanks a known donor even if a later refresh failed', () => {
+    // A failed refresh must not retract an acknowledgement already earned.
+    expect(walletDonationState({ address: 't1alice', donationCount: 3, settled: true, failed: true })).toBe('supporter');
+  });
+
+  it('shows nothing when no wallet is being viewed', () => {
+    expect(walletDonationState({ address: null, donationCount: 0, settled: true })).toBe('hidden');
+    expect(walletDonationState({ address: '', donationCount: 0, settled: true })).toBe('hidden');
+  });
+
+  it('treats a missing count as not-yet-known rather than zero', () => {
+    expect(walletDonationState({ address: 't1bob', settled: false })).toBe('hidden');
+  });
+
+  it('survives being called with nothing', () => {
+    expect(walletDonationState()).toBe('hidden');
+  });
+});

--- a/client/src/home/Home.jsx
+++ b/client/src/home/Home.jsx
@@ -10,6 +10,7 @@ import { Col, Container, Row } from 'react-grid-system';
 import { AppToaster } from 'components/AppToaster';
 import { HomeOverview } from 'home/HomeOverview';
 import { DonorBadge } from 'donor/DonorBadge';
+import { WalletDonationChip } from 'donor/WalletDonationChip';
 import { runDonorAutoDetect } from 'donor/runDonorAutoDetect';
 import { CHECK_STATUS } from 'donor/donorWalletCheck';
 import {
@@ -35,7 +36,8 @@ import {
   pa_summary_full,
   validateAddress,
   wallet_pas_summary,
-  fetch_total_donations,
+  fetch_wallet_donation_summary,
+  fetch_donation_totals,
   fetch_total_network_utils,
   fetch_gpu_prices
 } from 'apidata';
@@ -44,7 +46,6 @@ import { appStore, StoreKeys } from 'persistance/store';
 
 import { LayoutContext } from 'contexts/LayoutContext';
 import { blurAllInputs } from 'utils';
-import { FaMedal } from 'react-icons/fa';
 
 
 const WALLET_INPUT_ID = '_WALLET_INPUT_';
@@ -76,8 +77,13 @@ class Home extends React.Component {
       isZelId: false,
 
       totalDonations: 0,
+      donationsChecked: false,
+      donationsCheckFailed: false,
 
       countryCounts: [],
+      donations: null,
+      donationsSettled: false,
+      donationsFailed: false,
       countryCountsSettled: false,
       countryCountsFailed: false,
       gpuPrices: null
@@ -256,6 +262,14 @@ class Home extends React.Component {
     fetch_gpu_prices()
       .then((data) => this.setState({ gpuPrices: data }))
       .catch(() => {});
+
+    // #258: community donation totals. Network-wide, so it belongs here with
+    // the other panels that describe the network rather than the wallet.
+    fetch_donation_totals()
+      .then(({ ok, totals }) =>
+        this.setState({ donations: totals, donationsSettled: true, donationsFailed: !ok })
+      )
+      .catch(() => this.setState({ donationsSettled: true, donationsFailed: true }));
   }
 
   hydrateApp() {
@@ -375,8 +389,14 @@ class Home extends React.Component {
 
     const gstore = await fetch_global_stats(address);
 
-    fetch_total_donations(address).then((res) => {
-      this.setState({ totalDonations: res });
+    // #258: the chip has to tell "never donated" from "could not check",
+    // which fetch_total_donations cannot express -- it resolves 0 for both.
+    fetch_wallet_donation_summary(address).then(({ ok, donationCount }) => {
+      this.setState({
+        totalDonations: donationCount,
+        donationsChecked: true,
+        donationsCheckFailed: !ok
+      });
     });
 
     fetch_total_network_utils(gstore).then((store) => {
@@ -463,25 +483,20 @@ class Home extends React.Component {
         <div className='d-flex gap-2'>
           <span>Current Wallet Address</span>
           <DonorBadge />
-          {this.state.totalDonations > 0 ? (
-            <Tooltip2
-              usePortal={true}
-              intent='danger'
-              placement='bottom'
-              transitionDuration={100}
-              content={
-                <div>
-                  Total donations: <strong>{this.state.totalDonations}</strong>
-                </div>
-              }
-              hoverOpenDelay={60}
-            >
-              <span className='d-inline-flex align-items-center gap-1'>
-                <FaMedal color='gold' size={16} />
-                {this.state.totalDonations}
-              </span>
-            </Tooltip2>
-          ) : null}
+          {/*
+            #258: replaces a second gold medal that sat here showing a raw
+            donation count. Two identical medals meaning different things
+            (premium unlocked vs. this wallet has donated) was confusing, and
+            a wallet that had never donated got nothing at all -- which is the
+            state most visitors are in.
+          */}
+          <WalletDonationChip
+            address={this.state.activeAddress}
+            donationCount={this.state.totalDonations}
+            settled={this.state.donationsChecked}
+            failed={this.state.donationsCheckFailed}
+            donationAddress={window.gContent?.ADDRESS_FLUX}
+          />
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>
@@ -661,6 +676,9 @@ class Home extends React.Component {
                 countryCountsSettled={this.state.countryCountsSettled}
                 countryCountsFailed={this.state.countryCountsFailed}
                 gpuPrices={this.state.gpuPrices}
+                donations={this.state.donations}
+                donationsSettled={this.state.donationsSettled}
+                donationsFailed={this.state.donationsFailed}
               />
             </>
           );

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -11,6 +11,8 @@ import ReactCountryFlag from 'react-country-flag';
 // page animated while the rest of the app did not.
 import CountUp from 'components/CountUp';
 import { geoPanelState } from 'home/networkPanels';
+import { relativeAge } from 'donor/donationTotals';
+import { FaHeart } from 'react-icons/fa';
 
 import { CC_COLLATERAL_CUMULUS, CC_COLLATERAL_NIMBUS, CC_COLLATERAL_STRATUS } from 'content';
 import { AppEcosystemBreakdown } from 'components/AppEcosystemBreakdown';
@@ -457,9 +459,119 @@ function FluxAIPanel({ gpuPrices }) {
   );
 }
 
+
+// ── Panel: Community Support ──────────────────────────────────────────────────
+
+/*
+ * What the community has actually given, over the same 365-day window the donor
+ * benefit uses (issue #258).
+ *
+ * The honest figure is small -- a few hundred FLUX from single-digit donors --
+ * because the one wallet that dwarfs everything is project-owned and excluded
+ * (donor/config.js). A panel about transparency that headlined the unfiltered
+ * total would imply broad backing the data does not show, so the number here is
+ * deliberately the modest true one, and the panel is built to look composed at
+ * that size rather than padded out to seem larger.
+ *
+ * The donation address is part of the panel rather than a link elsewhere: a
+ * reader persuaded by the numbers should not then have to go looking.
+ */
+function CommunitySupportPanel({ donations, donationsSettled, donationsFailed }) {
+  if (!donationsSettled) {
+    return (
+      <div className="hov-panel hov-panel-center hov-panel--support">
+        <Spinner size={20} />
+      </div>
+    );
+  }
+
+  if (donationsFailed || !donations) {
+    return (
+      <div className="hov-panel hov-panel-center hov-panel--support">
+        <div className="hov-empty">Couldn&rsquo;t load donation history &mdash; this may be temporary.</div>
+      </div>
+    );
+  }
+
+  const { totalFlux, uniqueDonors, donationCount, lastDonation } = donations;
+  const address = (typeof window !== 'undefined' && window.gContent?.ADDRESS_FLUX) || '';
+  const shortAddress = address ? `${address.slice(0, 8)}…${address.slice(-6)}` : '—';
+  const lastAge = lastDonation ? relativeAge(lastDonation.timeSec) : null;
+
+  return (
+    <div className="hov-panel hov-panel--support">
+      <PanelHeader title="COMMUNITY SUPPORT" badge={uniqueDonors} />
+
+      {donationCount === 0 ? (
+        <div className="hov-empty">No donations recorded in the last year</div>
+      ) : (
+        <>
+          <div className="hov-support-band">
+            <div className="hov-support-figure">
+              <div className="hov-support-hero">
+                <span className="hov-support-total">{fmtNum(totalFlux, 2)}</span>
+                <span className="hov-support-unit">FLUX</span>
+              </div>
+              <div className="hov-support-sub">donated by the community over the last year</div>
+            </div>
+
+            <div className="hov-kv-list">
+            <div className="hov-kv-row">
+              <span className="hov-kv-label">Supporters</span>
+              <span className="hov-kv-value">{fmtNum(uniqueDonors)}</span>
+            </div>
+            <div className="hov-kv-row">
+              <span className="hov-kv-label">Donations</span>
+              <span className="hov-kv-value">{fmtNum(donationCount)}</span>
+            </div>
+            {lastDonation && (
+              <div className="hov-kv-row">
+                <span className="hov-kv-label">Most recent</span>
+                <span className="hov-kv-value">
+                  {fmtNum(lastDonation.amount, 2)} FLUX &middot; {lastAge}
+                </span>
+              </div>
+            )}
+            </div>
+
+            <div className="hov-support-cta">
+              <FaHeart size={11} className="hov-support-cta-icon" aria-hidden="true" />
+              <span className="hov-support-cta-text">Keep FluxNode running</span>
+              <Tooltip2 content={address || 'Donation address unavailable'} placement="top" hoverOpenDelay={120}>
+                <code className="hov-support-address">{shortAddress}</code>
+              </Tooltip2>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* With no donations there is no band to hang the address off, so it
+          gets its own row rather than disappearing. */}
+      {donationCount === 0 && (
+        <div className="hov-support-cta hov-support-cta--standalone">
+          <FaHeart size={11} className="hov-support-cta-icon" aria-hidden="true" />
+          <span className="hov-support-cta-text">Keep FluxNode running</span>
+          <Tooltip2 content={address || 'Donation address unavailable'} placement="top" hoverOpenDelay={120}>
+            <code className="hov-support-address">{shortAddress}</code>
+          </Tooltip2>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Main export ───────────────────────────────────────────────────────────────
 
-export function HomeOverview({ gstore, countryCounts, countryCountsSettled, countryCountsFailed, gpuPrices }) {
+export function HomeOverview({
+  gstore,
+  countryCounts,
+  countryCountsSettled,
+  countryCountsFailed,
+  gpuPrices,
+  donations,
+  donationsSettled,
+  donationsFailed
+}) {
   return (
     <div className="home-overview">
       <div className="home-overview-row">
@@ -467,6 +579,11 @@ export function HomeOverview({ gstore, countryCounts, countryCountsSettled, coun
         <NetworkResourcesPanel gstore={gstore} />
         <AppEcosystemBreakdown gstore={gstore} />
       </div>
+      <CommunitySupportPanel
+        donations={donations}
+        donationsSettled={donationsSettled}
+        donationsFailed={donationsFailed}
+      />
       <TopHostedApps gstore={gstore} />
       {SHOW_FLUX_AI_PANEL && <FluxAIPanel gpuPrices={gpuPrices} />}
       <GeoDistributionPanel

--- a/client/src/home/HomeOverview/index.scss
+++ b/client/src/home/HomeOverview/index.scss
@@ -547,3 +547,111 @@
     color: #94a3b8;
   }
 }
+
+/*
+ * Community Support panel (issue #258).
+ *
+ * A full-width band rather than a third-width card. The honest community figure
+ * is a few hundred FLUX from single-digit donors -- too little to fill a tall
+ * column without looking padded, and putting it alone in the three-column row
+ * above would have stranded it exactly the way DEPLOYED TODAY was stranded on
+ * the Apps tab (#248). Laid out horizontally it reads as a summary line across
+ * the page, which is what it is.
+ */
+.hov-panel--support {
+  .hov-support-band {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+    flex-wrap: wrap;
+    padding-top: 4px;
+  }
+
+  .hov-support-figure {
+    flex: 0 0 auto;
+  }
+
+  .hov-support-hero {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  .hov-support-total {
+    font-size: 1.9rem;
+    font-weight: 600;
+    line-height: 1.05;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hov-support-unit {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #22c55e;
+  }
+
+  .hov-support-sub {
+    font-size: 0.72rem;
+    color: var(--text-tertiary, rgba(128, 128, 128, 0.9));
+    margin-top: 2px;
+  }
+
+  /*
+   * Held to a readable measure. Left to grow, the kv rows' space-between
+   * pushed each label and its value to opposite ends of a 1,700px band, so
+   * "Supporters" and "9" ended up too far apart to read as a pair.
+   */
+  .hov-kv-list {
+    flex: 0 1 auto;
+    min-width: 240px;
+    max-width: 340px;
+  }
+
+  /*
+   * The address sits in the panel, not behind a link: someone persuaded by the
+   * numbers should not then have to go looking for where to send anything.
+   */
+  .hov-support-cta {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    flex: 0 0 auto;
+    margin-left: auto;
+    font-size: 0.74rem;
+  }
+
+  .hov-support-cta--standalone {
+    margin-left: 0;
+  }
+
+  .hov-support-cta--standalone {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(128, 128, 128, 0.14);
+  }
+
+  .hov-support-cta-icon {
+    color: #d6336c;
+    flex-shrink: 0;
+  }
+
+  .hov-support-cta-text {
+    color: var(--text-secondary, rgba(128, 128, 128, 0.95));
+  }
+
+  .hov-support-address {
+    font-size: 0.72rem;
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-inset);
+    color: var(--text-secondary, inherit);
+    cursor: default;
+  }
+
+  @media (max-width: 720px) {
+    .hov-support-band {
+      gap: 14px;
+    }
+  }
+}

--- a/client/src/main/MainApp.jsx
+++ b/client/src/main/MainApp.jsx
@@ -39,7 +39,7 @@ import {
   pa_summary_full,
   validateAddress,
   wallet_pas_summary,
-  fetch_total_donations,
+  fetch_wallet_donation_summary,
   fetch_total_network_utils,
   fetch_global_performance_rankings,
 } from 'apidata';
@@ -48,8 +48,8 @@ import { appStore, StoreKeys } from 'persistance/store';
 
 import { LayoutContext } from 'contexts/LayoutContext';
 import { blurAllInputs } from 'utils';
-import { FaMedal } from 'react-icons/fa';
 import { DonorBadge } from 'donor/DonorBadge';
+import { WalletDonationChip } from 'donor/WalletDonationChip';
 //import { setGAEvent } from 'g-analytic';
 
 const WALLET_INPUT_ID = '_WALLET_INPUT_';
@@ -82,6 +82,8 @@ class MainApp extends React.Component {
       isZelId: false,
 
       totalDonations: 0,
+      donationsChecked: false,
+      donationsCheckFailed: false,
       globalRankings: null,
       walletHealth: null,
     };
@@ -394,8 +396,14 @@ class MainApp extends React.Component {
 
     const gstore = await fetch_global_stats(address);
 
-    fetch_total_donations(address).then((res) => {
-      this.setState({ totalDonations: res });
+    // #258: the chip has to tell "never donated" from "could not check",
+    // which fetch_total_donations cannot express -- it resolves 0 for both.
+    fetch_wallet_donation_summary(address).then(({ ok, donationCount }) => {
+      this.setState({
+        totalDonations: donationCount,
+        donationsChecked: true,
+        donationsCheckFailed: !ok
+      });
     });
 
     rankingsPromise.then((rankings) => {
@@ -475,25 +483,20 @@ class MainApp extends React.Component {
         <div className='d-flex gap-2'>
           <span>Current Wallet Address</span>
           <DonorBadge />
-          {this.state.totalDonations > 0 ? (
-            <Tooltip2
-              usePortal={true}
-              intent='danger'
-              placement='bottom'
-              transitionDuration={100}
-              content={
-                <div>
-                  Total donations: <strong>{this.state.totalDonations}</strong>
-                </div>
-              }
-              hoverOpenDelay={60}
-            >
-              <span className='d-inline-flex align-items-center gap-1'>
-                <FaMedal color='gold' size={16} />
-                {this.state.totalDonations}
-              </span>
-            </Tooltip2>
-          ) : null}
+          {/*
+            #258: replaces a second gold medal that sat here showing a raw
+            donation count. Two identical medals meaning different things
+            (premium unlocked vs. this wallet has donated) was confusing, and
+            a wallet that had never donated got nothing at all -- which is the
+            state most visitors are in.
+          */}
+          <WalletDonationChip
+            address={this.state.activeAddress}
+            donationCount={this.state.totalDonations}
+            settled={this.state.donationsChecked}
+            failed={this.state.donationsCheckFailed}
+            donationAddress={window.gContent?.ADDRESS_FLUX}
+          />
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>


### PR DESCRIPTION
Wave 3. Closes #258.

Two halves of the same idea: what the community has given, and whether the wallet you just pasted is part of it.

## COMMUNITY SUPPORT panel (Home)

Total FLUX, distinct supporters, donation count, and the most recent donation — over the same 365-day window the donor benefit uses.

**The headline number is deliberately the modest true one.** The raw total across both donation addresses for the last year is **91,225 FLUX from 10 donors** — but **90,440 of that is a single project-owned wallet, 99.1% of the total**. Publishing that as a donation figure would imply broad community backing the rest of the data doesn't support, which is the opposite of what a transparency panel is for.

`EXCLUDED_FROM_DONATION_TOTALS` in `donor/config.js` leaves it out, giving the real community figure:

> **785 FLUX · 9 supporters · 17 donations · most recent 1 FLUX, 5 weeks ago**

The constant is documented as "project-owned addresses whose transfers are not third-party donations" and nothing more — it doesn't need to say whose wallet it is.

Laid out as a **full-width band**, not a third-width card. A few hundred FLUX from single-digit donors can't fill a tall column without looking padded, and putting it alone in the three-column row above would have stranded it exactly the way DEPLOYED TODAY was stranded on the Apps tab in #248. The donation address sits **in** the panel rather than behind a link — a reader persuaded by the numbers shouldn't then have to go looking.

Relative ages ("5 weeks ago") rather than a bare date, deliberately: the most recent real donation is over a month old, and a stale date reads as "this project is abandoned" in a way "5 weeks ago" doesn't.

## Per-wallet chip (Home and /nodes)

Replaces the second gold medal that sat next to the wallet address showing a raw donation count. **Two identical medals meaning different things** — premium unlocked vs. this wallet has donated — was confusing, and a wallet that had never donated got **nothing at all**, which is the state most visitors are in. A heart now, so it can't be mistaken for the premium badge beside it.

**"Has donated" is ANY donation**, not the 10-FLUX/365-day donor threshold. That rule gates premium; using it here would tell somebody who gave 5 FLUX last month that they hadn't donated, which is worse than saying nothing.

**Three states, and the third is the point.** `fetch_total_donations` resolves `0` when the explorer is unreachable — correct for the achievement gates it feeds, wrong here, because asking a real supporter to donate after a 429 is the one genuinely bad outcome. New `fetch_wallet_donation_summary` shares the same scan and reports whether the chain could actually be read, so "couldn't check" renders as silence.

## Plumbing

The pagination / 429-failover / txid-dedupe scan inside `fetch_total_donations` is now `scanBothDonationAddresses`, shared by all three consumers rather than copied. `fetch_total_donations` itself is unchanged — achievements still gate on exactly what they did before.

## Verification

- **670 tests, 46 suites** (645/44 before). 25 new unit tests across `donationTotals` (change outputs vs. real donations, unique donors, the exclusion, the 365-day boundary, both addresses, cross-address dedupe, most-recent selection, senderless coinbase inputs) and `walletDonationState`.
- **`walletDonationState` was mutation-tested**: removing the `failed` guard fails exactly one test — the one that names that behaviour — and no others. The suite discriminates rather than blanket-failing.
- **`apidataParity` caught the two new exports, as designed.** The baseline got exactly two keys added **by hand** rather than being regenerated, so anything *else* that moved would still fail loudly.
- Production build clean. **D1 calculation audit agrees**, `compare.py` exit 0.
- **Node page re-checked**: 127 rows, all NIMBUS, unchanged.
- Browser-verified both chip states against real wallets — `t1bAB8f6…` (non-donor → "Support development") and `t1e4sQRc…` (donor → "Supporter" beside the gold premium badge) — and the panel against live chain data.

## Worth a look during review

The **wording and the icon** are the part most worth your eye, since the ask is shown to nearly every visitor on nearly every visit:

- supporter: *Supporter*, tooltip "N donations from this wallet. Thank you for keeping FluxNode running."
- ask: *Support development*, tooltip "FluxNode is free and unfunded. If it saves you time, a donation to `<address>` keeps it running."

I kept the ask visually quieter than the acknowledgement on purpose — muted grey until hover — so it can live beside the wallet address indefinitely without becoming something people resent. Easy to dial up if you want it louder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9