### PR TITLE
feat(#254): make the Network map an interactive continent / country explorer

### DIFF
--- a/client/src/analytics/NetworkTab/index.jsx
+++ b/client/src/analytics/NetworkTab/index.jsx
@@ -3,7 +3,18 @@ import { Spinner } from '@blueprintjs/core';
 import { FiCpu, FiHardDrive, FiDownload, FiUpload } from 'react-icons/fi';
 import { FaTrophy } from 'react-icons/fa';
 import ReactCountryFlag from 'react-country-flag';
-import { fetch_node_geolocation } from 'networkNodes';
+import {
+  fetch_node_geolocation,
+  fetch_node_benchmarks,
+  fetch_node_running_apps,
+  fetch_flux_nodes
+} from 'networkNodes';
+import { aggregateRegions, selectRegionStats, countriesIn } from 'analytics/regionStats';
+import { appNameFromContainer } from 'fluxinfo';
+import { fetch_global_app_specs_raw } from 'apidata';
+import { buildSpecIndex } from 'appSpecs';
+import { isOpaqueRuntimeImage } from 'main/Gamification/appCategories';
+import { TotalNetworkCard, NetworkResourcesCard, HostedApplicationsCard } from './regionCards';
 import { fetch_global_performance_rankings } from 'apidata';
 import { rollupByContinent } from 'analytics/continentDistribution';
 import { WorldMap } from 'analytics/WorldMap';
@@ -164,11 +175,84 @@ function ContinentBreakdown({ continents, networkTotal }) {
   );
 }
 
+/*
+ * Region selector. Continent first, then the countries within it (issue #254).
+ *
+ * Sits ABOVE the map because it drives the map -- the continent list used to be
+ * a read-only panel underneath, which read as a summary rather than a control.
+ */
+function ScopeSelector({ agg, scope, onChange }) {
+  const continents = Object.entries(agg?.continents || {})
+    .filter(([name]) => name !== 'Unlocated')
+    .sort((a, b) => b[1].nodes - a[1].nodes)
+    .map(([name, b]) => ({ name, nodes: b.nodes }));
+
+  const countries = scope.continent ? countriesIn(agg, scope.continent) : [];
+
+  return (
+    <div className="nt-scope">
+      <div className="nt-scope-group">
+        <span className="nt-scope-label">Continent</span>
+        <div className="nt-chips">
+          <button
+            type="button"
+            className={`nt-chip${scope.level === 'network' ? ' nt-chip--active' : ''}`}
+            onClick={() => onChange({ level: 'network' })}
+          >
+            Whole network
+          </button>
+          {continents.map((c) => (
+            <button
+              key={c.name}
+              type="button"
+              className={`nt-chip${scope.continent === c.name ? ' nt-chip--active' : ''}`}
+              onClick={() => onChange({ level: 'continent', continent: c.name })}
+            >
+              {c.name}
+              <span className="nt-chip-count">{c.nodes.toLocaleString()}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Only once a continent narrows it to a usable list -- 57 countries at
+          once is a wall, not a control. */}
+      {scope.continent && countries.length > 0 && (
+        <div className="nt-scope-group">
+          <span className="nt-scope-label">Country</span>
+          <div className="nt-chips">
+            <button
+              type="button"
+              className={`nt-chip${scope.level === 'continent' ? ' nt-chip--active' : ''}`}
+              onClick={() => onChange({ level: 'continent', continent: scope.continent })}
+            >
+              All of {scope.continent}
+            </button>
+            {countries.map((c) => (
+              <button
+                key={c.countryCode}
+                type="button"
+                className={`nt-chip${scope.country === c.countryCode ? ' nt-chip--active' : ''}`}
+                onClick={() => onChange({ level: 'country', continent: scope.continent, country: c.countryCode })}
+              >
+                {c.country}
+                <span className="nt-chip-count">{c.nodes.toLocaleString()}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function NetworkTab() {
   const [countryCounts, setCountryCounts] = useState([]);
   const [continentData, setContinentData] = useState({ continents: [], networkTotal: 0 });
   const [globalRankings, setGlobalRankings] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [agg, setAgg] = useState(null);
+  const [scope, setScope] = useState({ level: 'network' });
 
   useEffect(() => {
     let cancelled = false;
@@ -197,6 +281,68 @@ export function NetworkTab() {
       setGlobalRankings(rankings);
     })().catch(() => {});
 
+    /*
+     * Region aggregation (#254). Every feed here is shared via networkNodes.js,
+     * so the 4 MB node list and the 3.45 MB benchmark projection are each
+     * fetched once for this page even though rankings above wants them too.
+     */
+    (async () => {
+      const [nodes, geoEntries, benchmarks, runningApps, rawSpecs] = await Promise.all([
+        fetch_flux_nodes(),
+        fetch_node_geolocation(),
+        fetch_node_benchmarks(),
+        fetch_node_running_apps(),
+        // Cached for 5 minutes in sessionStorage and already warm from the Apps
+        // tab; needed so these categories match the ones shown there.
+        fetch_global_app_specs_raw()
+      ]);
+      if (cancelled) return;
+
+      const geoByHost = {};
+      for (const entry of geoEntries || []) {
+        const geo = entry?.geolocation;
+        if (geo?.ip) geoByHost[(geo.ip || '').split(':')[0]] = geo;
+      }
+
+      // Keyed on the exact ip:port: capacity is per NODE, and one machine can
+      // run several nodes with very different hardware allocations.
+      const capByNode = {};
+      for (const entry of benchmarks || []) {
+        const bench = entry?.benchmark?.bench;
+        if (bench?.ipaddress) {
+          capByNode[bench.ipaddress] = { cores: bench.cores, ram: bench.ram, ssd: bench.ssd };
+        }
+      }
+
+      const appsByNode = {};
+      for (const entry of runningApps || []) {
+        const running = entry?.apps?.runningapps;
+        if (!entry?.ip || !Array.isArray(running)) continue;
+        appsByNode[entry.ip] = running
+          .map((a) => appNameFromContainer((a?.Names || [])[0]))
+          .filter(Boolean);
+      }
+
+      /*
+       * The SAME categorisation the Apps tab uses: join the running app's name
+       * to its globalappsspecifications entry and read spec.category. A keyword
+       * match on the name instead puts ~61% of instances in "other", and two
+       * different breakdowns of the same apps on one page is worse than none.
+       *
+       * The isOpaqueRuntimeImage guard mirrors runningAppsCategorized.js:
+       * runonflux/orbit is a git-deployment wrapper, so its real workload is
+       * unknowable and categorising it by the operator's deployment name would
+       * be misleading.
+       */
+      const specIndex = buildSpecIndex(rawSpecs || []);
+      const categoryOf = (appName) => {
+        const spec = specIndex[appName];
+        return isOpaqueRuntimeImage(spec?.repotag) ? 'other' : spec?.category || 'other';
+      };
+
+      setAgg(aggregateRegions({ nodes, geoByHost, capByNode, appsByNode, categoryOf }));
+    })().catch(() => {});
+
     return () => { cancelled = true; };
   }, []);
 
@@ -214,6 +360,14 @@ export function NetworkTab() {
       + (globalRankings.officialNodeCounts?.STRATUS || 0)
     : null;
 
+  const stats = selectRegionStats(agg, scope);
+  const scopeLabel =
+    scope.level === 'country'
+      ? agg?.countries?.[scope.country]?.country || scope.country
+      : scope.level === 'continent'
+        ? scope.continent
+        : 'Whole network';
+
   return (
     <div className="network-tab">
       <div className="network-tab-hero">
@@ -221,9 +375,45 @@ export function NetworkTab() {
         <span className="network-tab-hero-label">Total nodes</span>
       </div>
 
-      <PanelGate panelKey="worldMap" feature="World Map" preview="blur">
-        <WorldMap countryCounts={countryCounts} />
-      </PanelGate>
+      {agg && <ScopeSelector agg={agg} scope={scope} onChange={setScope} />}
+
+      {/*
+        * Map and cards side by side. The map used to be full width and very
+        * tall; at a third of the page it still reads while leaving room for the
+        * figures it is now a control for (#254).
+        */}
+      <div className="network-tab-explorer">
+        <PanelGate panelKey="worldMap" feature="World Map" preview="blur">
+          <WorldMap
+            countryCounts={countryCounts}
+            scope={scope}
+            selectedCountry={scope.level === 'country' ? scope.country : null}
+            onSelectCountry={
+              agg
+                ? (code) => {
+                    const c = agg.countries?.[code];
+                    if (c) setScope({ level: 'country', continent: c.continent, country: code });
+                  }
+                : undefined
+            }
+          />
+        </PanelGate>
+
+        <div className="network-tab-cards">
+          {stats ? (
+            <>
+              <TotalNetworkCard stats={stats} label={scopeLabel} />
+              <NetworkResourcesCard stats={stats} label={scopeLabel} />
+              <HostedApplicationsCard stats={stats} label={scopeLabel} />
+            </>
+          ) : (
+            <div className="hov-panel hov-panel-center nt-card">
+              <Spinner size={20} />
+            </div>
+          )}
+        </div>
+      </div>
+
       <div className="network-tab-continent-row">
         <PanelGate panelKey="continentBreakdown" feature="Continent Breakdown" preview="blur">
           <ContinentBreakdown continents={continentData.continents} networkTotal={continentData.networkTotal} />

--- a/client/src/analytics/NetworkTab/index.scss
+++ b/client/src/analytics/NetworkTab/index.scss
@@ -376,3 +376,167 @@
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
+
+/*
+ * Region explorer layout (issue #254).
+ *
+ * The map was full-width and very tall, which left no room for the figures it
+ * is now a control for. Two-thirds map, one-third cards at desktop; stacked
+ * below 1100px where side-by-side would squeeze both.
+ */
+.network-tab-explorer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  margin-bottom: 16px;
+
+  @media (min-width: 1100px) {
+    grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
+  }
+}
+
+.network-tab-cards {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  align-content: start;
+}
+
+.nt-card {
+  display: flex;
+  flex-direction: column;
+
+  /*
+   * The kv row styling these cards use lives in home/HomeOverview's stylesheet,
+   * which is only in the bundle when that page's chunk is loaded -- so on a
+   * direct load of /analytics the labels and values ran together. Scoped here
+   * instead, so the cards do not depend on another route having been visited.
+   */
+  .hov-kv-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+    padding: 2px 0;
+  }
+
+  .hov-kv-label {
+    font-size: 0.76rem;
+    color: var(--text-secondary, rgba(128, 128, 128, 0.95));
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .hov-kv-value {
+    font-size: 0.78rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+}
+
+.nt-card-scope {
+  font-size: 0.7rem;
+  color: var(--text-tertiary, rgba(128, 128, 128, 0.85));
+  padding-bottom: 6px;
+}
+
+.nt-card-foot {
+  margin-top: auto;
+  padding-top: 8px;
+  font-size: 0.67rem;
+  color: var(--text-tertiary, rgba(128, 128, 128, 0.8));
+}
+
+.nt-tier-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.nt-app-icon {
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.nt-kv-row--total {
+  border-top: 1px solid rgba(128, 128, 128, 0.14);
+  margin-top: 4px;
+  padding-top: 6px;
+}
+
+.nt-apps-list {
+  max-height: 190px;
+  overflow-y: auto;
+}
+
+/* ── Scope selector ──────────────────────────────────────────────────────── */
+
+.nt-scope {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.nt-scope-group {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.nt-scope-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary, rgba(128, 128, 128, 0.85));
+  flex: 0 0 62px;
+}
+
+.nt-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.nt-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.22);
+  background: var(--surface-inset);
+  color: inherit;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 0.73rem;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+
+  &:hover {
+    border-color: rgba(43, 97, 209, 0.55);
+  }
+
+  &:focus-visible {
+    outline: 1px solid rgba(43, 97, 209, 0.7);
+    outline-offset: 2px;
+  }
+}
+
+.nt-chip--active {
+  border-color: #2b61d1;
+  background: rgba(43, 97, 209, 0.14);
+  font-weight: 600;
+}
+
+.nt-chip-count {
+  font-size: 0.66rem;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}

--- a/client/src/analytics/NetworkTab/regionCards.jsx
+++ b/client/src/analytics/NetworkTab/regionCards.jsx
@@ -1,0 +1,124 @@
+import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+
+/*
+ * The three region-scoped cards beside the Network map (issue #254).
+ *
+ * Every figure here is whatever `stats` holds, and `stats` is produced by
+ * regionStats.js for the current selection -- so selecting Europe re-computes
+ * these rather than filtering a rendered list. Keeping them dumb means the
+ * aggregation can be tested without React, which is where the real risk is:
+ * a region total that is wrong looks exactly like a region total that is right.
+ */
+
+const TIER_COLORS = { CUMULUS: '#2686d0', NIMBUS: '#e8a33d', STRATUS: '#e05263' };
+
+function fmtNum(n, decimals = 0) {
+  if (!n && n !== 0) return '—';
+  return n.toLocaleString(undefined, { maximumFractionDigits: decimals });
+}
+
+/** TB where it helps, GB where TB would read as 0.0. */
+function fmtStorage(gb) {
+  if (!gb) return '—';
+  return gb >= 1024 ? `${(gb / 1024).toLocaleString(undefined, { maximumFractionDigits: 1 })} TB` : `${fmtNum(gb)} GB`;
+}
+
+export function TotalNetworkCard({ stats, label }) {
+  const t = stats?.tiers || {};
+  return (
+    <div className="hov-panel nt-card">
+      <div className="hov-header">
+        <span className="hov-header-title">TOTAL NETWORK</span>
+        <span className="hov-header-badge">{fmtNum(stats?.nodes)}</span>
+      </div>
+      <div className="nt-card-scope">{label}</div>
+      <div className="hov-kv-list">
+        {['CUMULUS', 'NIMBUS', 'STRATUS'].map((tier) => (
+          <div key={tier} className="hov-kv-row">
+            <span className="hov-kv-label">
+              <span className="nt-tier-dot" style={{ background: TIER_COLORS[tier] }} />
+              {tier.charAt(0) + tier.slice(1).toLowerCase()}
+            </span>
+            <span className="hov-kv-value">{fmtNum(t[tier] || 0)}</span>
+          </div>
+        ))}
+        <div className="hov-kv-row nt-kv-row--total">
+          <span className="hov-kv-label">Unique wallets</span>
+          <span className="hov-kv-value">{fmtNum(stats?.wallets)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NetworkResourcesCard({ stats, label }) {
+  const rows = [
+    { key: 'cores', label: 'CPU cores', value: fmtNum(stats?.cores) },
+    { key: 'ram', label: 'RAM', value: fmtStorage(stats?.ram) },
+    { key: 'ssd', label: 'SSD', value: fmtStorage(stats?.ssd) }
+  ];
+
+  // Capacity comes from the benchmark feed, which not every node reports.
+  // Saying so is the difference between "this region is small" and "we measured
+  // less of it".
+  const measured = stats?.capNodes || 0;
+  const total = stats?.nodes || 0;
+  const shortfall = total - measured;
+
+  return (
+    <div className="hov-panel nt-card">
+      <div className="hov-header">
+        <span className="hov-header-title">NETWORK RESOURCES</span>
+        <span className="hov-header-badge">{fmtNum(measured)}</span>
+      </div>
+      <div className="nt-card-scope">{label}</div>
+      <div className="hov-kv-list">
+        {rows.map((r) => (
+          <div key={r.key} className="hov-kv-row">
+            <span className="hov-kv-label">{r.label}</span>
+            <span className="hov-kv-value">{r.value}</span>
+          </div>
+        ))}
+      </div>
+      <div className="nt-card-foot">
+        {total === 0
+          ? 'No nodes in this region'
+          : `measured across ${fmtNum(measured)} of ${fmtNum(total)} nodes${shortfall > 0 ? ` · ${fmtNum(shortfall)} not benchmarked` : ''}`}
+      </div>
+    </div>
+  );
+}
+
+export function HostedApplicationsCard({ stats, label }) {
+  const entries = Object.entries(stats?.appsByCategory || {}).sort((a, b) => b[1] - a[1]);
+  const total = stats?.appInstances || 0;
+
+  return (
+    <div className="hov-panel nt-card">
+      <div className="hov-header">
+        <span className="hov-header-title">HOSTED APPLICATIONS</span>
+        <span className="hov-header-badge">{fmtNum(total)}</span>
+      </div>
+      <div className="nt-card-scope">{label}</div>
+      {entries.length === 0 ? (
+        <div className="hov-empty">No running apps in this region</div>
+      ) : (
+        <div className="hov-kv-list nt-apps-list">
+          {entries.map(([category, count]) => {
+            const meta = APP_CATEGORY_META[category] || APP_CATEGORY_META.other;
+            const Icon = meta?.Icon;
+            return (
+              <div key={category} className="hov-kv-row">
+                <span className="hov-kv-label">
+                  {Icon && <Icon size={11} style={{ color: meta.color }} className="nt-app-icon" />}
+                  {meta?.label || category}
+                </span>
+                <span className="hov-kv-value">{fmtNum(count)}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/analytics/WorldMap/index.jsx
+++ b/client/src/analytics/WorldMap/index.jsx
@@ -4,6 +4,7 @@ import './index.scss';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { getCountryCentroid, projectToPercent } from 'geo/countryCentroids';
 import { WORLD_LAND_PATH } from 'geo/worldLandPath';
+import { boundsFor, viewBoxFor, remapToBounds, WORLD_BOUNDS } from 'geo/regionBounds';
 
 const MIN_RADIUS_PX = 3;
 const MAX_RADIUS_PX = 11;
@@ -25,8 +26,10 @@ function fmtNum(n) {
   return n.toLocaleString();
 }
 
-export function WorldMap({ countryCounts }) {
+export function WorldMap({ countryCounts, scope, selectedCountry, onSelectCountry }) {
   const counts = countryCounts || [];
+  const bounds = boundsFor(scope) || WORLD_BOUNDS;
+  const viewBox = viewBoxFor(bounds);
   const maxCount = counts[0]?.nodeCount || 1;
 
   // Countries with no known centroid are left off the map rather than
@@ -71,7 +74,7 @@ export function WorldMap({ countryCounts }) {
               */}
             <svg
               className="wm-land"
-              viewBox="0 0 360 180"
+              viewBox={viewBox}
               preserveAspectRatio="none"
               aria-hidden="true"
               focusable="false"
@@ -83,37 +86,64 @@ export function WorldMap({ countryCounts }) {
               <div
                 key={`lat-${lat}`}
                 className="wm-graticule wm-graticule--h"
-                style={{ top: `${projectToPercent([lat, 0]).yPct}%` }}
+                style={{ top: `${remapToBounds(projectToPercent([lat, 0]), bounds).yPct}%` }}
               />
             ))}
             {GRATICULE_LONS.map((lon) => (
               <div
                 key={`lon-${lon}`}
                 className="wm-graticule wm-graticule--v"
-                style={{ left: `${projectToPercent([0, lon]).xPct}%` }}
+                style={{ left: `${remapToBounds(projectToPercent([0, lon]), bounds).xPct}%` }}
               />
             ))}
 
-            {bubbles.map((b) => (
-              <Tooltip2
-                key={b.countryCode}
-                content={`${b.country}: ${fmtNum(b.nodeCount)} nodes`}
-                placement="top"
-                hoverOpenDelay={150}
-                transitionDuration={80}
-              >
-                <div
-                  className="wm-bubble"
-                  title={`${b.country}: ${fmtNum(b.nodeCount)} nodes`}
-                  style={{
-                    left: `${b.xPct}%`,
-                    top: `${b.yPct}%`,
-                    width: `${b.radiusPx * 2}px`,
-                    height: `${b.radiusPx * 2}px`,
-                  }}
-                />
-              </Tooltip2>
-            ))}
+            {bubbles.map((b) => {
+              /*
+               * Bubbles are HTML in percent, the landmass is SVG -- both are
+               * remapped through the SAME bounds so a zoom cannot drift one off
+               * the other (#254).
+               */
+              const { xPct, yPct } = remapToBounds({ xPct: b.xPct, yPct: b.yPct }, bounds);
+              // Outside the current view. Hidden rather than clamped: pinned to
+              // an edge it would read as a real node in the wrong country.
+              if (xPct < -2 || xPct > 102 || yPct < -2 || yPct > 102) return null;
+
+              const isSelected = selectedCountry && b.countryCode === selectedCountry;
+              return (
+                <Tooltip2
+                  key={b.countryCode}
+                  content={`${b.country}: ${fmtNum(b.nodeCount)} nodes`}
+                  placement="top"
+                  hoverOpenDelay={150}
+                  transitionDuration={80}
+                >
+                  <div
+                    className={`wm-bubble${isSelected ? ' wm-bubble--selected' : ''}${onSelectCountry ? ' wm-bubble--clickable' : ''}`}
+                    role={onSelectCountry ? 'button' : undefined}
+                    tabIndex={onSelectCountry ? 0 : undefined}
+                    aria-label={onSelectCountry ? `Show ${b.country}` : undefined}
+                    onClick={onSelectCountry ? () => onSelectCountry(b.countryCode) : undefined}
+                    onKeyDown={
+                      onSelectCountry
+                        ? (e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              onSelectCountry(b.countryCode);
+                            }
+                          }
+                        : undefined
+                    }
+                    title={`${b.country}: ${fmtNum(b.nodeCount)} nodes`}
+                    style={{
+                      left: `${xPct}%`,
+                      top: `${yPct}%`,
+                      width: `${b.radiusPx * 2}px`,
+                      height: `${b.radiusPx * 2}px`,
+                    }}
+                  />
+                </Tooltip2>
+              );
+            })}
           </div>
           {unmappedCount > 0 && (
             <div className="wm-caption">

--- a/client/src/analytics/WorldMap/index.scss
+++ b/client/src/analytics/WorldMap/index.scss
@@ -168,3 +168,14 @@
   color: var(--text-tertiary);
   text-align: right;
 }
+
+/* Selectable bubbles (issue #254) */
+.wm-bubble--clickable {
+  cursor: pointer;
+}
+
+.wm-bubble--selected {
+  outline: 2px solid #2b61d1;
+  outline-offset: 2px;
+  z-index: 2;
+}

--- a/client/src/analytics/regionStats.js
+++ b/client/src/analytics/regionStats.js
@@ -1,0 +1,138 @@
+/*
+ * Region-scoped network statistics for the Network tab (issue #254).
+ *
+ * THE JOIN, and why it is this way round: this iterates the NODE LIST and looks
+ * geolocation up by host -- not the other way round. The node list is the only
+ * feed carrying `ip:port` and `tier` on the same record, so driving from it
+ * gives every node its exact tier. Driving from the geolocation feed instead
+ * would reintroduce exactly the collapse #215 was about: geolocation is
+ * per-MACHINE, and 254 hosts on this network run more than one tier, covering
+ * 1,366 nodes (21.5%). There is no defensible tier for those from geo alone.
+ *
+ * Everything here is pure. Region totals are the headline of a page about the
+ * network's shape, and an aggregation bug would look entirely plausible on
+ * screen -- Europe being wrong by a few hundred nodes reads the same as Europe
+ * being right.
+ */
+
+const TIERS = ['CUMULUS', 'NIMBUS', 'STRATUS'];
+const UNLOCATED = 'Unlocated';
+
+/** The bare host. Geolocation is per-machine, so it keys on this and nothing else. */
+export function hostOf(address) {
+  return (address || '').split(':')[0];
+}
+
+function emptyBucket(extra = {}) {
+  return {
+    nodes: 0,
+    tiers: {},
+    wallets: 0,
+    _wallets: new Set(),
+    cores: 0,
+    ram: 0,
+    ssd: 0,
+    capNodes: 0,
+    appInstances: 0,
+    appsByCategory: {},
+    ...extra
+  };
+}
+
+function addNode(bucket, node, cap, apps, categoryOf) {
+  bucket.nodes += 1;
+
+  const tier = (node.tier || '').toUpperCase();
+  if (TIERS.includes(tier)) bucket.tiers[tier] = (bucket.tiers[tier] || 0) + 1;
+
+  if (node.payment_address) bucket._wallets.add(node.payment_address);
+
+  // Only nodes that actually reported a benchmark contribute capacity, and
+  // capNodes records how many did -- without it a region with poor benchmark
+  // coverage would silently look under-resourced rather than under-measured.
+  if (cap && typeof cap.cores === 'number') {
+    bucket.cores += cap.cores || 0;
+    bucket.ram += cap.ram || 0;
+    bucket.ssd += cap.ssd || 0;
+    bucket.capNodes += 1;
+  }
+
+  for (const appName of apps || []) {
+    const category = categoryOf(appName);
+    bucket.appsByCategory[category] = (bucket.appsByCategory[category] || 0) + 1;
+    bucket.appInstances += 1;
+  }
+}
+
+function seal(bucket) {
+  bucket.wallets = bucket._wallets.size;
+  delete bucket._wallets;
+  return bucket;
+}
+
+/*
+ * `categoryOf` is REQUIRED rather than defaulted.
+ *
+ * The Apps tab derives an app's category by joining its name to the
+ * globalappsspecifications index; a keyword match on the name alone puts ~61%
+ * of instances in "other". Both are defensible in isolation, but two different
+ * breakdowns on one page is the silent canonical-source swap the calculation
+ * audit's D2 domain exists to catch. Making the caller supply the categoriser
+ * forces that choice to be explicit at the call site instead of buried here.
+ */
+export function aggregateRegions({ nodes, geoByHost, capByNode, appsByNode, categoryOf } = {}) {
+  const toCategory = typeof categoryOf === 'function' ? categoryOf : () => 'other';
+  const network = emptyBucket();
+  const continents = {};
+  const countries = {};
+
+  for (const node of nodes || []) {
+    const geo = (geoByHost || {})[hostOf(node?.ip)] || null;
+    const cap = (capByNode || {})[node?.ip] || null;
+    const apps = (appsByNode || {})[node?.ip] || null;
+
+    addNode(network, node, cap, apps, toCategory);
+
+    const continent = geo?.continent || UNLOCATED;
+    if (!continents[continent]) continents[continent] = emptyBucket({ continent });
+    addNode(continents[continent], node, cap, apps, toCategory);
+
+    // A node with no geolocation has no country either. It still counts in the
+    // Unlocated continent bucket above, so the totals reconcile.
+    const code = geo?.countryCode;
+    if (!code) continue;
+    if (!countries[code]) {
+      countries[code] = emptyBucket({ countryCode: code, country: geo.country || code, continent });
+    }
+    addNode(countries[code], node, cap, apps, toCategory);
+  }
+
+  seal(network);
+  Object.values(continents).forEach(seal);
+  Object.values(countries).forEach(seal);
+
+  return { network, continents, countries };
+}
+
+/*
+ * The bucket the current selection points at. Falls back to network totals for
+ * a selection that no longer exists -- regions come and go between refreshes as
+ * the last node in a country drops off, and a stale selection must not blank
+ * the cards.
+ */
+export function selectRegionStats(agg, scope) {
+  if (!agg) return null;
+  const level = scope?.level;
+
+  if (level === 'country' && agg.countries[scope.country]) return agg.countries[scope.country];
+  if (level === 'continent' && agg.continents[scope.continent]) return agg.continents[scope.continent];
+  return agg.network;
+}
+
+/** A continent's countries, busiest first -- the order the Country selector offers them in. */
+export function countriesIn(agg, continent) {
+  if (!agg) return [];
+  return Object.values(agg.countries)
+    .filter((c) => c.continent === continent)
+    .sort((a, b) => b.nodes - a.nodes);
+}

--- a/client/src/analytics/regionStats.test.js
+++ b/client/src/analytics/regionStats.test.js
@@ -1,0 +1,158 @@
+import { aggregateRegions, selectRegionStats, countriesIn } from './regionStats';
+
+/*
+ * Issue #254 -- the Network tab's three stat cards, scoped to whatever
+ * continent or country is selected.
+ *
+ * The join that matters: iterate the NODE LIST, not the geolocation feed.
+ * The node list carries ip:port AND tier together, so every node gets its exact
+ * tier; geolocation is per-machine and is looked up by bare host. Driving this
+ * from the geo feed instead would reintroduce the mixed-tier collapse that #215
+ * was about -- one host running a CUMULUS and a STRATUS cannot be tiered from
+ * geolocation alone.
+ */
+const NODES = [
+  { ip: '1.1.1.1:16137', tier: 'CUMULUS', payment_address: 't1alice' },
+  { ip: '1.1.1.1:16147', tier: 'STRATUS', payment_address: 't1alice' },  // same host, different tier
+  { ip: '2.2.2.2:16137', tier: 'NIMBUS',  payment_address: 't1bob' },
+  { ip: '3.3.3.3:16137', tier: 'CUMULUS', payment_address: 't1carol' },
+  { ip: '9.9.9.9:16137', tier: 'CUMULUS', payment_address: 't1dave' },   // no geolocation
+];
+
+const GEO_BY_HOST = {
+  '1.1.1.1': { continent: 'Europe', country: 'Germany', countryCode: 'DE' },
+  '2.2.2.2': { continent: 'Europe', country: 'France', countryCode: 'FR' },
+  '3.3.3.3': { continent: 'North America', country: 'United States', countryCode: 'US' },
+};
+
+const CAP_BY_NODE = {
+  '1.1.1.1:16137': { cores: 4, ram: 8, ssd: 220 },
+  '1.1.1.1:16147': { cores: 16, ram: 64, ssd: 1000 },
+  '2.2.2.2:16137': { cores: 8, ram: 32, ssd: 440 },
+  // 3.3.3.3 deliberately absent: not every node reports a benchmark
+};
+
+const APPS_BY_NODE = {
+  '1.1.1.1:16137': ['FoldingAtRunOnFlux22', 'presearchnode'],
+  '2.2.2.2:16137': ['FoldingAtRunOnFlux23'],
+};
+
+// Stands in for the spec-index lookup the real caller supplies.
+const CATEGORY_OF = (name) => (/folding/i.test(name) ? 'computing' : 'other');
+
+const AGG = () => aggregateRegions({
+  nodes: NODES, geoByHost: GEO_BY_HOST, capByNode: CAP_BY_NODE, appsByNode: APPS_BY_NODE, categoryOf: CATEGORY_OF
+});
+
+describe('aggregateRegions', () => {
+  it('tiers every node exactly, including two tiers on one host', () => {
+    // 1.1.1.1 runs a CUMULUS and a STRATUS. Both must be counted as themselves.
+    const eu = AGG().continents.Europe;
+    expect(eu.tiers).toEqual({ CUMULUS: 1, NIMBUS: 1, STRATUS: 1 });
+    expect(eu.nodes).toBe(3);
+  });
+
+  it('counts distinct wallets, not nodes', () => {
+    // t1alice owns two nodes in Europe; that is one wallet.
+    expect(AGG().continents.Europe.wallets).toBe(2);
+  });
+
+  it('sums capacity only over nodes that actually reported it', () => {
+    const eu = AGG().continents.Europe;
+    expect(eu.cores).toBe(28);   // 4 + 16 + 8
+    expect(eu.ram).toBe(104);    // 8 + 64 + 32
+    expect(eu.ssd).toBe(1660);   // 220 + 1000 + 440
+    expect(eu.capNodes).toBe(3);
+  });
+
+  it('reports how many nodes lacked a benchmark, so the figure can be qualified', () => {
+    const na = AGG().continents['North America'];
+    expect(na.nodes).toBe(1);
+    expect(na.capNodes).toBe(0);
+    expect(na.cores).toBe(0);
+  });
+
+  it('puts nodes with no geolocation in an explicit Unlocated bucket', () => {
+    const agg = AGG();
+    expect(agg.continents.Unlocated.nodes).toBe(1);
+    expect(agg.continents.Unlocated.tiers.CUMULUS).toBe(1);
+  });
+
+  it('reconciles: continents sum to the network total', () => {
+    const agg = AGG();
+    const summed = Object.values(agg.continents).reduce((n, c) => n + c.nodes, 0);
+    expect(summed).toBe(agg.network.nodes);
+    expect(agg.network.nodes).toBe(NODES.length);
+  });
+
+  it('counts app instances per category using the supplied categoriser', () => {
+    const eu = AGG().continents.Europe;
+    expect(eu.appInstances).toBe(3);
+    expect(eu.appsByCategory).toEqual({ computing: 2, other: 1 });
+    expect(Object.values(eu.appsByCategory).reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
+  it('puts everything in "other" when no categoriser is supplied, rather than quietly using a different one', () => {
+    const agg = aggregateRegions({ nodes: NODES, geoByHost: GEO_BY_HOST, capByNode: {}, appsByNode: APPS_BY_NODE });
+    expect(agg.network.appsByCategory).toEqual({ other: 3 });
+  });
+
+  it('aggregates countries separately from continents', () => {
+    const agg = AGG();
+    expect(agg.countries.DE.nodes).toBe(2);
+    expect(agg.countries.FR.nodes).toBe(1);
+    expect(agg.countries.DE.continent).toBe('Europe');
+    expect(agg.countries.DE.country).toBe('Germany');
+  });
+
+  it('network totals cover every node regardless of location', () => {
+    const n = AGG().network;
+    expect(n.nodes).toBe(5);
+    expect(n.tiers).toEqual({ CUMULUS: 3, NIMBUS: 1, STRATUS: 1 });
+    expect(n.wallets).toBe(4);
+  });
+
+  it('survives empty inputs rather than throwing', () => {
+    const agg = aggregateRegions({ nodes: [], geoByHost: {}, capByNode: {}, appsByNode: {} });
+    expect(agg.network.nodes).toBe(0);
+    expect(agg.continents).toEqual({});
+  });
+
+  it('tolerates a node with no tier', () => {
+    const agg = aggregateRegions({
+      nodes: [{ ip: '1.1.1.1:1', payment_address: 't1x' }],
+      geoByHost: GEO_BY_HOST, capByNode: {}, appsByNode: {}
+    });
+    expect(agg.network.nodes).toBe(1);
+    expect(agg.network.tiers.CUMULUS || 0).toBe(0);
+  });
+});
+
+describe('selectRegionStats', () => {
+  it('returns network totals at the network level', () => {
+    expect(selectRegionStats(AGG(), { level: 'network' }).nodes).toBe(5);
+  });
+
+  it('returns the continent when one is selected', () => {
+    expect(selectRegionStats(AGG(), { level: 'continent', continent: 'Europe' }).nodes).toBe(3);
+  });
+
+  it('returns the country when one is selected', () => {
+    expect(selectRegionStats(AGG(), { level: 'country', country: 'DE' }).nodes).toBe(2);
+  });
+
+  it('falls back to network totals for an unknown selection rather than crashing', () => {
+    expect(selectRegionStats(AGG(), { level: 'continent', continent: 'Atlantis' }).nodes).toBe(5);
+    expect(selectRegionStats(AGG(), { level: 'country', country: 'ZZ' }).nodes).toBe(5);
+  });
+});
+
+describe('countriesIn', () => {
+  it('lists a continent\'s countries, busiest first', () => {
+    expect(countriesIn(AGG(), 'Europe').map((c) => c.countryCode)).toEqual(['DE', 'FR']);
+  });
+
+  it('is empty for a continent with nothing in it', () => {
+    expect(countriesIn(AGG(), 'Antarctica')).toEqual([]);
+  });
+});

--- a/client/src/api/rankings.js
+++ b/client/src/api/rankings.js
@@ -19,7 +19,7 @@
  */
 
 import { explorerFetchJson } from 'explorer';
-import { fetch_node_benchmarks, fetch_node_geolocation } from 'networkNodes';
+import { fetch_node_benchmarks, fetch_node_geolocation, fetch_flux_nodes } from 'networkNodes';
 import { topInGroup } from 'main/Gamification/rankInGroup';
 import { EXPLORER_FLUX_NODES_PATH } from 'api/endpoints';
 
@@ -145,13 +145,15 @@ export async function fetch_global_performance_rankings() {
     // benchmark and geolocation come from the shared fetchers so they are not
     // pulled a second time by fetch_total_network_utils / fetch_country_node_counts
     const [nodesJsonRaw, benchData, geoData, countRes] = await Promise.all([
-      explorerFetchJson(EXPLORER_FLUX_NODES_PATH),
+      // Shared so the Network tab's region aggregation does not pull this 4 MB
+      // list a second time on the same page load (#254).
+      fetch_flux_nodes(),
       fetch_node_benchmarks(),
       fetch_node_geolocation(),
       fetch('https://api.runonflux.io/daemon/getzelnodecount'),
     ]);
 
-    const nodesJson = nodesJsonRaw || {};
+    const nodesJson = { fluxNodes: Array.isArray(nodesJsonRaw) ? nodesJsonRaw : [] };
     const benchJson = { data: benchData };
     const geoJson = { data: geoData };
     const countJson = await countRes.json();

--- a/client/src/geo/regionBounds.js
+++ b/client/src/geo/regionBounds.js
@@ -1,0 +1,77 @@
+/*
+ * Bounding boxes for zooming the Network map (issue #254).
+ *
+ * Boxes are [south, west, north, east] in degrees. They are generous rather
+ * than tight -- the job is to frame a continent recognisably, not to clip it
+ * exactly, and a box slightly too large is far less jarring than one that cuts
+ * the corner off Scandinavia.
+ *
+ * Continent names are the strings the geolocation feed actually returns
+ * (fluxinfo's `geolocation.continent`), verified live: Europe, North America,
+ * South America, Asia, Africa, Oceania.
+ */
+
+export const WORLD_BOUNDS = [-90, -180, 90, 180];
+
+export const CONTINENT_BOUNDS = {
+  Europe: [34, -25, 71, 45],
+  'North America': [7, -170, 72, -52],
+  'South America': [-56, -82, 13, -34],
+  Asia: [-11, 26, 78, 180],
+  Africa: [-35, -18, 38, 52],
+  Oceania: [-48, 110, 0, 180]
+};
+
+/*
+ * A COUNTRY zooms to its continent, not to itself.
+ *
+ * The map draws one bubble per country, so cropping to a single country would
+ * frame a lone dot on an empty stretch of coastline -- technically a zoom,
+ * visually a dead end. Keeping the continent view means the selected country
+ * can be highlighted in the context of its neighbours, which is the thing
+ * actually worth seeing.
+ */
+export function boundsFor(scope) {
+  const key = scope?.level === 'country' || scope?.level === 'continent' ? scope.continent : null;
+  return CONTINENT_BOUNDS[key] || WORLD_BOUNDS;
+}
+
+/*
+ * The SVG viewBox for a box.
+ *
+ * WorldMap draws its landmass with viewBox "0 0 360 180" and
+ * preserveAspectRatio="none", so the SVG's coordinate space IS
+ * (lon + 180, 90 - lat). Converting a bounds box is therefore a direct
+ * translation with no projection maths.
+ */
+export function viewBoxFor(bounds) {
+  const [south, west, north, east] = bounds || WORLD_BOUNDS;
+  const x = west + 180;
+  const y = 90 - north;
+  return `${x} ${y} ${east - west} ${north - south}`;
+}
+
+/*
+ * A whole-world percentage position, restated relative to the zoomed box.
+ *
+ * Bubbles are HTML elements positioned in percent inside the same frame as the
+ * SVG, so they have to be remapped by the same box the viewBox came from --
+ * otherwise the pings drift off their countries as soon as anything zooms.
+ *
+ * Deliberately does NOT clamp: a result outside 0-100 means the point is off
+ * the current view, and the caller hides it rather than pinning it to an edge
+ * where it would read as a real node in the wrong place.
+ */
+export function remapToBounds({ xPct, yPct }, bounds) {
+  const [south, west, north, east] = bounds || WORLD_BOUNDS;
+
+  const x0 = ((west + 180) / 360) * 100;
+  const x1 = ((east + 180) / 360) * 100;
+  const y0 = ((90 - north) / 180) * 100;
+  const y1 = ((90 - south) / 180) * 100;
+
+  return {
+    xPct: ((xPct - x0) / (x1 - x0)) * 100,
+    yPct: ((yPct - y0) / (y1 - y0)) * 100
+  };
+}

--- a/client/src/geo/regionBounds.test.js
+++ b/client/src/geo/regionBounds.test.js
@@ -1,0 +1,92 @@
+import { CONTINENT_BOUNDS, boundsFor, viewBoxFor, remapToBounds, WORLD_BOUNDS } from './regionBounds';
+
+/*
+ * Issue #254 -- zooming the Network map to a continent.
+ *
+ * The map is an SVG landmass plus percentage-positioned HTML bubbles. Both have
+ * to move together or the pings drift off their countries, so the viewBox and
+ * the bubble remap are derived from ONE bounds object rather than tuned
+ * separately.
+ */
+describe('CONTINENT_BOUNDS', () => {
+  it('covers every continent the geolocation feed actually reports', () => {
+    // These are the values seen live: the feed's `continent` strings.
+    for (const c of ['Europe', 'North America', 'South America', 'Asia', 'Africa', 'Oceania']) {
+      expect(CONTINENT_BOUNDS[c]).toBeDefined();
+    }
+  });
+
+  it('states every box as [south, west, north, east] within real world limits', () => {
+    for (const [name, b] of Object.entries(CONTINENT_BOUNDS)) {
+      const [south, west, north, east] = b;
+      expect(north).toBeGreaterThan(south);
+      expect(east).toBeGreaterThan(west);
+      expect(south).toBeGreaterThanOrEqual(-90);
+      expect(north).toBeLessThanOrEqual(90);
+      expect(west).toBeGreaterThanOrEqual(-180);
+      expect(east).toBeLessThanOrEqual(180);
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('places Europe north of the equator and around the prime meridian', () => {
+    const [south, west, north, east] = CONTINENT_BOUNDS.Europe;
+    expect(south).toBeGreaterThan(30);
+    expect(north).toBeLessThan(82);
+    expect(west).toBeLessThan(0);
+    expect(east).toBeGreaterThan(0);
+  });
+});
+
+describe('boundsFor', () => {
+  it('gives the whole world at network level', () => {
+    expect(boundsFor({ level: 'network' })).toEqual(WORLD_BOUNDS);
+  });
+
+  it('gives the continent box when a continent is selected', () => {
+    expect(boundsFor({ level: 'continent', continent: 'Europe' })).toEqual(CONTINENT_BOUNDS.Europe);
+  });
+
+  it('zooms a COUNTRY to its containing continent, not to the country', () => {
+    // A country holds one bubble; cropping to it would show a single dot on an
+    // empty coastline. The continent keeps it in context.
+    expect(boundsFor({ level: 'country', continent: 'Europe', country: 'DE' })).toEqual(CONTINENT_BOUNDS.Europe);
+  });
+
+  it('falls back to the world for anywhere it does not know', () => {
+    expect(boundsFor({ level: 'continent', continent: 'Atlantis' })).toEqual(WORLD_BOUNDS);
+    expect(boundsFor({ level: 'continent', continent: 'Unlocated' })).toEqual(WORLD_BOUNDS);
+    expect(boundsFor()).toEqual(WORLD_BOUNDS);
+  });
+});
+
+describe('viewBoxFor', () => {
+  it('is the full equirectangular frame for the world', () => {
+    expect(viewBoxFor(WORLD_BOUNDS)).toBe('0 0 360 180');
+  });
+
+  it('converts a box to the map\'s lon+180 / 90-lat coordinate space', () => {
+    // [south, west, north, east] = [0, 0, 90, 90]
+    //   x = west + 180 = 180, y = 90 - north = 0, w = 90, h = 90
+    expect(viewBoxFor([0, 0, 90, 90])).toBe('180 0 90 90');
+  });
+});
+
+describe('remapToBounds', () => {
+  it('leaves percentages untouched for the world view', () => {
+    expect(remapToBounds({ xPct: 25, yPct: 40 }, WORLD_BOUNDS)).toEqual({ xPct: 25, yPct: 40 });
+  });
+
+  it('rescales a point into the zoomed box', () => {
+    // Box covering the eastern/northern quarter: x 50..100%, y 0..50%.
+    // A point at 75%,25% sits dead centre of it.
+    const out = remapToBounds({ xPct: 75, yPct: 25 }, [0, 0, 90, 180]);
+    expect(out.xPct).toBeCloseTo(50, 6);
+    expect(out.yPct).toBeCloseTo(50, 6);
+  });
+
+  it('reports points outside the box as outside, so they can be hidden', () => {
+    const out = remapToBounds({ xPct: 10, yPct: 90 }, [0, 0, 90, 180]);
+    expect(out.xPct < 0 || out.xPct > 100 || out.yPct < 0 || out.yPct > 100).toBe(true);
+  });
+});

--- a/client/src/networkNodes.js
+++ b/client/src/networkNodes.js
@@ -16,12 +16,20 @@
  * duplication; a second load refetches, as it did before.
  */
 
+import { explorerFetchJson } from 'explorer';
+import { EXPLORER_FLUX_NODES_PATH } from 'api/endpoints';
+
 const BENCHMARKS_URL = 'https://stats.runonflux.io/fluxinfo?projection=benchmark';
 
 // `ip` so utilisation rows can be attributed to a node for the showcase.
 const RESOURCES_URL = 'https://stats.runonflux.io/fluxinfo?projection=apps.resources,ip';
 
 const GEOLOCATION_URL = 'https://stats.runonflux.io/fluxinfo?projection=geolocation';
+
+// Running app container names per node, for the Network tab's per-region app
+// breakdown (#254). `ip` carries the port, so this keys per NODE rather than
+// per machine -- two nodes on one host run different apps.
+const RUNNING_APPS_URL = 'https://stats.runonflux.io/fluxinfo?projection=apps.runningapps.Names,ip';
 
 /*
  * In-flight sharing alone only helps when callers overlap. fetch_country_node_counts
@@ -74,6 +82,51 @@ function _shared(url) {
 export const fetch_node_benchmarks = _shared(BENCHMARKS_URL);
 export const fetch_node_resources = _shared(RESOURCES_URL);
 export const fetch_node_geolocation = _shared(GEOLOCATION_URL);
+export const fetch_node_running_apps = _shared(RUNNING_APPS_URL);
+
+/*
+ * The deterministic node list: the only feed carrying ip:port, tier AND
+ * payment_address on one record.
+ *
+ * Shared for the same reason as the projections above -- it is ~4 MB, and
+ * fetch_global_performance_rankings and the Network tab's region aggregation
+ * both need it on the same page load. It goes through the explorer pool rather
+ * than plain fetch so a 429 on the primary host fails over.
+ */
+let _fluxNodesInFlight = null;
+let _fluxNodesCache = null;
+let _fluxNodesAt = 0;
+
+export async function fetch_flux_nodes() {
+  if (_fluxNodesCache && Date.now() - _fluxNodesAt < RESULT_TTL_MS) return _fluxNodesCache;
+  if (_fluxNodesInFlight) return _fluxNodesInFlight;
+
+  _fluxNodesInFlight = (async () => {
+    try {
+      const json = await explorerFetchJson(EXPLORER_FLUX_NODES_PATH);
+      const nodes = json?.fluxNodes;
+      if (!Array.isArray(nodes)) {
+        console.warn('[networkNodes] explorer returned no fluxNodes');
+        return [];
+      }
+      return nodes;
+    } catch (error) {
+      console.warn('[networkNodes] flux node list fetch failed:', error?.message);
+      return [];
+    }
+  })();
+
+  try {
+    const data = await _fluxNodesInFlight;
+    if (data.length > 0) {
+      _fluxNodesCache = data;
+      _fluxNodesAt = Date.now();
+    }
+    return data;
+  } finally {
+    _fluxNodesInFlight = null;
+  }
+}
 
 /** The bare IP, no port. Geolocation is per-machine, so it keys on this. */
 export function hostOf(address) {


### PR DESCRIPTION
Wave 4. Closes #254.

The Network tab was a tall static map with a read-only continent list underneath. It's now a region explorer: pick a continent or a country and the map plus three stat cards re-compute for it.

## The join, and why it's this way round

Region aggregation iterates the **node list** and looks geolocation up by host — not the other way round. The node list is the only feed carrying `ip:port` and `tier` on one record, so every node gets its exact tier.

Driving it from the geolocation feed instead would reintroduce exactly the collapse #215 was about: geolocation is per-**machine**, and **254 hosts run more than one tier across 1,366 nodes (21.5%)**. My own comment on this issue warned the feature was at risk from that — measuring it showed the opposite. Approached from the node list there's no ambiguity at all.

## What you get

Three cards, all scoped to the selection:

| | |
|---|---|
| **Total Network** | nodes per tier, unique wallets |
| **Network Resources** | CPU cores, RAM, SSD |
| **Hosted Applications** | instances per category |

Selecting **Europe** zooms the map and gives 4,559 nodes / 493 wallets / 38,896 cores / 5,267 apps. Selecting **Germany** then gives 1,425 / 113 / 13,040 / 1,583, with its bubble ringed on the map.

**A country does not crop the map to itself.** The map draws one bubble per country, so cropping to one would frame a lone dot on an empty coastline — technically a zoom, visually a dead end. It holds the continent view so the country is seen among its neighbours, which is what you picked.

## The app-category bug I nearly shipped

The first cut categorised apps with a keyword match on the app name and put **4,737 of 7,796 instances (61%) in "other"**. Defensible in isolation — and completely wrong next to the Apps tab, which derives categories by joining the app name to its `globalappsspecifications` entry. Two different breakdowns of the same apps on one page is the silent canonical-source swap the calculation audit's D2 domain exists to catch.

It now uses the same source, and network-wide reproduces the Apps tab almost exactly:

| | This tab | Apps tab |
|---|---|---|
| Computing | 2,220 | 2,220 |
| Enterprise | 1,826 | 1,825 |
| Blockchain | 1,042 | 1,042 |
| VPN / Privacy | 683 | 683 |

(The Enterprise difference is one instance of live drift between reads.)

The categoriser is now a **required argument** to `aggregateRegions` rather than a default, so the choice is explicit at the call site — with a test asserting that omitting it yields "other" for everything rather than quietly falling back to a different rule.

## Honest about coverage

Network Resources states its own: *"measured across 6,221 of 6,369 nodes · 148 not benchmarked"*. Capacity comes from the benchmark feed, which not every node reports, and without saying so a poorly-measured region reads as a small one.

Nodes with no geolocation (209, ~3%) go in an explicit `Unlocated` bucket, and a test asserts the continents sum to the network total.

## Plumbing

The 4 MB node list moves behind a shared fetcher in `networkNodes.js`, so `fetch_global_performance_rankings` and this aggregation share one call instead of pulling it twice on the same page load.

## Verification

- **700 tests, 48 suites** (670/46 before). 30 new: `regionStats` (two tiers on one host, distinct wallets, capacity coverage, the Unlocated bucket, continent/network reconciliation, the missing-categoriser case) and `regionBounds`.
- Production build clean. **D1 audit agrees**, `compare.py` exit 0, and the **D4 tier-resolution suite passes** — it covers the `rankings.js` path this refactored.
- **Node page re-checked** because `rankings.js` changed: 127 rows, all NIMBUS, and **all 127 carry a rank** — the figure that refactor could plausibly have broken.
- Browser-verified: world → Europe moves the viewBox `0 0 360 180` → `155 19 70 37` and hides 23 of 54 bubbles. Both Europe and Germany reconcile with an independent Python aggregation of the same upstream feeds.

## On #242

This covers the intent of #242's step 1 — the network-shape panels now have a proper home on the Network tab. **#242 step 2 (repurposing Home) is deliberately not in here**: that's a separate decision about Home's content, and Home is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9