### PR TITLE
fix(#257): Privacy Mode silently zeroed the enterprise node score

### DIFF
--- a/client/src/main/MainApp.jsx
+++ b/client/src/main/MainApp.jsx
@@ -20,6 +20,7 @@ import {
   processedAddressPatch,
   resolveHydrationTarget
 } from 'wallet/addressInput';
+import { sumEnterpriseScore } from 'wallet/enterpriseScore';
 import { DashboardCells } from 'main/Header';
 import { ParallelAssets } from 'main/ParallelAssets';
 import { PayoutTimer } from 'main/PayoutTimer';
@@ -267,11 +268,9 @@ class MainApp extends React.Component {
 
   async _getTotalScoreAgainstSearchedWallet(wallet) {
     const enterpriseNodesRaw = await getEnterpriseNodes();
-    const enterpriseNodesFiltered = enterpriseNodesRaw.filter((item) => item?.payment_address === wallet);
-    const sum = enterpriseNodesFiltered.reduce((prev, current) => prev + current.score, 0);
     this.setState({
       ...this.state,
-      totalScoreAgainstSearchedWallet: sum
+      totalScoreAgainstSearchedWallet: sumEnterpriseScore(enterpriseNodesRaw, wallet)
     });
   }
 
@@ -283,8 +282,6 @@ class MainApp extends React.Component {
     const { location } = this.props.router;
     let params = new URLSearchParams(location.search);
     let wallet = params.get('wallet');
-
-    this._getTotalScoreAgainstSearchedWallet(wallet);
 
     /*
      * resolveHydrationTarget owns the "which wallet, if any" decision (#249).
@@ -298,6 +295,13 @@ class MainApp extends React.Component {
       activeAddress: this.state.activeAddress,
       searchHistory: this.state.searchHistory
     });
+
+    /*
+     * #257: this used to run above with the raw ?wallet= param, which Privacy
+     * Mode has already masked -- so it filtered on a row of X's and scored 0.
+     * It needs the RESOLVED address, which only exists after this point.
+     */
+    this._getTotalScoreAgainstSearchedWallet(address);
 
     if (address) {
       this.onProcessAddress(address);

--- a/client/src/wallet/enterpriseScore.js
+++ b/client/src/wallet/enterpriseScore.js
@@ -1,0 +1,21 @@
+/*
+ * Total enterprise-node score for one wallet (issue #257).
+ *
+ * Extracted from MainApp so the "which address do we compare against" question
+ * is answerable without a browser. The bug it fixes was invisible by
+ * inspection: MainApp handed this the raw ?wallet= param, which LayoutContext
+ * has already MASKED when Privacy Mode is on, so the comparison ran against a
+ * row of X's and summed to zero. Nothing errored -- the figure simply read 0,
+ * identical to a wallet that genuinely has no enterprise nodes.
+ *
+ * The rule the rest of the app follows since #256: the RESOLVED address is the
+ * join key, and the masked form is only ever for display.
+ */
+export function sumEnterpriseScore(enterpriseNodes, walletAddress) {
+  if (!walletAddress || !Array.isArray(enterpriseNodes)) return 0;
+
+  return enterpriseNodes.reduce(
+    (total, node) => (node?.payment_address === walletAddress ? total + (Number(node.score) || 0) : total),
+    0
+  );
+}

--- a/client/src/wallet/enterpriseScore.test.js
+++ b/client/src/wallet/enterpriseScore.test.js
@@ -1,0 +1,49 @@
+import { sumEnterpriseScore } from './enterpriseScore';
+
+/*
+ * Issue #257 -- with Privacy Mode on, the enterprise node score read 0 for
+ * every wallet.
+ *
+ * MainApp passed the RAW ?wallet= param to the filter. LayoutContext has
+ * already masked that param in place by then, so the comparison was against a
+ * row of X's, matched nothing, and summed to zero -- silently, and
+ * indistinguishably from a wallet that genuinely has no enterprise nodes.
+ */
+const NODES = [
+  { payment_address: 't1alice', score: 40 },
+  { payment_address: 't1alice', score: 60 },
+  { payment_address: 't1bob', score: 15 },
+  { payment_address: 't1carol' },            // score missing
+];
+
+describe('sumEnterpriseScore', () => {
+  it('sums every enterprise node belonging to the wallet', () => {
+    expect(sumEnterpriseScore(NODES, 't1alice')).toBe(100);
+  });
+
+  it('is zero for a wallet with no enterprise nodes', () => {
+    expect(sumEnterpriseScore(NODES, 't1nobody')).toBe(0);
+  });
+
+  it('never matches a MASKED address, which is what #257 was', () => {
+    // hide_sensitive_string turns every alphanumeric into X.
+    expect(sumEnterpriseScore(NODES, 'XXXXXXX')).toBe(0);
+  });
+
+  it('treats a missing score as zero rather than producing NaN', () => {
+    // One undefined score used to poison the whole running total.
+    expect(sumEnterpriseScore(NODES, 't1carol')).toBe(0);
+    expect(Number.isNaN(sumEnterpriseScore(NODES, 't1carol'))).toBe(false);
+  });
+
+  it('is zero for no wallet at all rather than summing the whole network', () => {
+    expect(sumEnterpriseScore(NODES, null)).toBe(0);
+    expect(sumEnterpriseScore(NODES, '')).toBe(0);
+    expect(sumEnterpriseScore(NODES, undefined)).toBe(0);
+  });
+
+  it('survives a missing node list', () => {
+    expect(sumEnterpriseScore(null, 't1alice')).toBe(0);
+    expect(sumEnterpriseScore(undefined, 't1alice')).toBe(0);
+  });
+});


### PR DESCRIPTION
Wave 5. Closes #257. (#261 and #189 closed separately — no code needed, evidence below.)

## #257 — the bug

With Privacy Mode on, the enterprise score on `/nodes` read **0 for every wallet**.

`hydrateApp` passed the **raw `?wallet=` param** to the score lookup, and LayoutContext has already masked that param in place by then. So the filter compared `payment_address` against a row of `X`s, matched nothing, and summed to zero.

Nothing errored. The figure just read `0` — indistinguishable from a wallet that genuinely has no enterprise nodes, which is exactly why it survived this long.

Two changes:

- The call now takes the **resolved** address from `resolveHydrationTarget`, and moves below that resolution since the address doesn't exist before it. This is the rule #256 established: the resolved address is the join key, the masked form is only ever for display.
- The summation moves to `wallet/enterpriseScore.js` so it's provable without a browser. Six tests, including the masked-address case that *is* this bug — and a missing `score` field, which used to poison the whole running total into `NaN` since the old reduce added `current.score` unguarded.

Verified with Privacy Mode **genuinely active** (setting it in localStorage after mount doesn't engage it — I checked that trap first):

```
privacyModeInState   true
input masked         true
URL masked           true
activeAddress        real
enterprise score     32,435   ← was 0
```

## #261 — already fixed, and proved so

"Footer missing in the Node page" is the same defect as #246, fixed by #260 which merged shortly after it was filed.

I didn't want to assume that, so I removed the one-line fix on this branch and re-measured `/nodes`:

| | footer height |
|---|---|
| with `flex-shrink: 0` | **63px** |
| without it | **0.83px** ← the reported symptom |

Same root cause: `.App` is a fixed-height flex column with `overflow: auto`, and a flex child defaults to `flex-shrink: 1`, so *any* route tall enough to overflow crushed the footer. `/live` was just where it was spotted first.

## #189 — confirmed fixed by #218

The screenshot's "CORS" errors were **429s without CORS headers**. Both offending endpoints are now dealt with:

- `/api/currency` isn't requested at all any more — rates come from Frankfurter, a different host.
- `richest-addresses-list` goes through the two-host explorer pool with `Retry-After` benching instead of re-hammering the throttled host.

Fresh load on `main`: FLUX Price $0.0505, Locked Supply 88.1M, Unique Wallets 837, Block Height 2,942,717, no zeroed panels, and no 429/CORS/"Failed to fetch" in console. The report had every one of those reading `0` or `—`.

## Verification

- **706 tests, 49 suites** (700/48 before). Build clean.
- D1 audit agrees, `compare.py` exit 0, D4 tier suite passes.
- Node page: 127 rows, all NIMBUS, **all 127 ranked**, footer 63px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9