### PR TITLE
fix(#253): make the Chain Activity drill-down reachable, and stop it stranding

### DIFF
--- a/client/src/analytics/ChainActivityTab/drilldownState.js
+++ b/client/src/analytics/ChainActivityTab/drilldownState.js
@@ -1,0 +1,29 @@
+/*
+ * The two decisions that kept the block drill-down stuck (issue #253).
+ *
+ * Pulled out of the effect because effect-cleanup behaviour is exactly the kind
+ * of thing that is invisible in review and untestable in place: the bug below
+ * only appears if you close the panel during the window where its fetch is
+ * still in flight.
+ */
+
+/** Fetch once, on open. Never while closed, never on top of a result. */
+export function shouldFetchDrilldown(open, status) {
+  return open && status === 'idle';
+}
+
+/*
+ * What the state should become when an in-flight load is cancelled -- which is
+ * what the effect cleanup does when the panel closes.
+ *
+ * Returning to 'idle' is the fix. Previously the status stayed 'loading': the
+ * late resolve was discarded because `cancelled` was set, and
+ * shouldFetchDrilldown then refused every subsequent attempt, so the panel
+ * showed "Loading blocks..." forever with no request behind it.
+ *
+ * A finished load (ready/error) is returned unchanged -- and by identity, so
+ * React bails out of the re-render rather than looping.
+ */
+export function stateAfterCancel(state) {
+  return state?.status === 'loading' ? { status: 'idle', data: null } : state;
+}

--- a/client/src/analytics/ChainActivityTab/drilldownState.test.js
+++ b/client/src/analytics/ChainActivityTab/drilldownState.test.js
@@ -1,0 +1,54 @@
+import { shouldFetchDrilldown, stateAfterCancel } from './drilldownState';
+
+/*
+ * Issue #253 -- the block drill-down could get PERMANENTLY stuck on
+ * "Loading blocks...".
+ *
+ * UtilityDrilldown fetches once, guarded by `state.status !== 'idle'`, and its
+ * effect cleanup sets `cancelled = true` so a late resolve is ignored. Closing
+ * the panel before the fetch resolved therefore left status at 'loading'
+ * forever: the resolve was skipped, and the guard then refused to retry on
+ * reopen. No further request was ever issued -- confirmed in the browser, where
+ * reopening produced zero network calls.
+ */
+describe('shouldFetchDrilldown', () => {
+  it('fetches when opened for the first time', () => {
+    expect(shouldFetchDrilldown(true, 'idle')).toBe(true);
+  });
+
+  it('does not fetch while closed', () => {
+    expect(shouldFetchDrilldown(false, 'idle')).toBe(false);
+  });
+
+  it('does not re-fetch what it already has', () => {
+    expect(shouldFetchDrilldown(true, 'ready')).toBe(false);
+    expect(shouldFetchDrilldown(true, 'loading')).toBe(false);
+  });
+
+  it('does not retry an error on its own, so it cannot hammer a failing API', () => {
+    expect(shouldFetchDrilldown(true, 'error')).toBe(false);
+  });
+});
+
+describe('stateAfterCancel', () => {
+  it('returns an interrupted load to idle so reopening retries', () => {
+    // THE bug: without this, status stays 'loading' and the guard above blocks
+    // every future attempt.
+    expect(stateAfterCancel({ status: 'loading', data: null })).toEqual({ status: 'idle', data: null });
+  });
+
+  it('leaves a completed load alone', () => {
+    const ready = { status: 'ready', data: { blocks: [] } };
+    expect(stateAfterCancel(ready)).toBe(ready);
+  });
+
+  it('leaves an error alone, so the message survives a close', () => {
+    const err = { status: 'error', data: null };
+    expect(stateAfterCancel(err)).toBe(err);
+  });
+
+  it('leaves idle alone', () => {
+    const idle = { status: 'idle', data: null };
+    expect(stateAfterCancel(idle)).toBe(idle);
+  });
+});

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from 'analytics/chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, blocksRemainingInScan, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from 'analytics/chainActivity';
+import { shouldFetchDrilldown, stateAfterCancel } from './drilldownState';
 import './index.scss';
 
 /*
@@ -66,7 +67,9 @@ function SyncStatusBanner({ syncStatus, lastSuccessAt, lastScannedHeight, scanSt
   // 2,937,099") read as "syncing millions of blocks" at a glance, even
   // though the actual gap being scanned is small (bounded by
   // RETENTION_BLOCKS) — show the real remaining count instead.
-  const blocksRemaining = hasRange ? Math.max(0, scanTargetHeight - lastScannedHeight) : 0;
+  const blocksRemaining = hasRange
+    ? blocksRemainingInScan({ lastScannedHeight, scanStartHeight, scanTargetHeight })
+    : 0;
   const progressText = hasRange
     ? ` ${fmtNum(blocksRemaining)} blocks remaining in this scan (${scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight })}%).`
     : '';
@@ -110,19 +113,54 @@ const DRILLDOWN_LIMIT = 50;
 function UtilityDrilldown({ open, expectedTotal }) {
   const [state, setState] = useState({ status: 'idle', data: null });
 
+  /*
+   * Status is mirrored in a ref so it can gate the fetch WITHOUT being an
+   * effect dependency.
+   *
+   * Keeping `state.status` in the dependency array is what made the first
+   * attempt at this fix loop: the cleanup runs on every dependency change, not
+   * only on close, so resetting to 'idle' there drove
+   * idle -> loading -> cleanup -> idle -> ... and fired ~290,000 requests in a
+   * few seconds. With `[open]` alone the cleanup runs only when the panel
+   * actually closes or unmounts, which is the only moment a reset is wanted.
+   */
+  const statusRef = useRef('idle');
+
   useEffect(() => {
-    if (!open || state.status !== 'idle') return;
+    if (!open) {
+      /*
+       * Closing mid-flight used to strand this on 'loading' forever: the late
+       * resolve is discarded below because `cancelled` is set, and the guard
+       * then refused every retry -- so reopening showed "Loading blocks..."
+       * with no request behind it at all (issue #253).
+       */
+      const reset = stateAfterCancel({ status: statusRef.current, data: null });
+      if (reset.status !== statusRef.current) {
+        statusRef.current = reset.status;
+        setState(reset);
+      }
+      return;
+    }
+
+    if (!shouldFetchDrilldown(open, statusRef.current)) return;
+
     let cancelled = false;
+    statusRef.current = 'loading';
     setState({ status: 'loading', data: null });
+
     (async () => {
       const result = await fetch_chain_activity_blocks(DRILLDOWN_LIMIT);
       if (cancelled) return;
-      setState({ status: result.ok ? 'ready' : 'error', data: result });
+      statusRef.current = result.ok ? 'ready' : 'error';
+      setState({ status: statusRef.current, data: result });
     })().catch(() => {
-      if (!cancelled) setState({ status: 'error', data: null });
+      if (cancelled) return;
+      statusRef.current = 'error';
+      setState({ status: 'error', data: null });
     });
+
     return () => { cancelled = true; };
-  }, [open, state.status]);
+  }, [open]);
 
   if (!open) return null;
 
@@ -193,8 +231,7 @@ function UtilityDrilldown({ open, expectedTotal }) {
   );
 }
 
-function UtilitySummary({ daily, syncStatus, theme }) {
-  const [drilldownOpen, setDrilldownOpen] = useState(false);
+function UtilitySummary({ daily, syncStatus, theme, drilldownOpen, onToggleDrilldown }) {
   const { utilityBlocks, emptyBlocks } = summarizeDaily(daily);
   const total = utilityBlocks + emptyBlocks;
   const badgeText = daily.length === 1 ? '1 day' : `${daily.length} days`;
@@ -230,7 +267,7 @@ function UtilitySummary({ daily, syncStatus, theme }) {
             <button
               type="button"
               className={`ca-utility-stat ca-utility-stat--utility ca-utility-stat--button${drilldownOpen ? ' ca-utility-stat--open' : ''}`}
-              onClick={() => setDrilldownOpen((v) => !v)}
+              onClick={onToggleDrilldown}
               aria-expanded={drilldownOpen}
               aria-controls="ca-utility-drilldown"
             >
@@ -289,6 +326,9 @@ export function ChainActivityTab({ theme = 'dark' }) {
     syncStatus: 'never_run',
   });
   const [loading, setLoading] = useState(true);
+  // Lifted out of UtilitySummary so the hero above can open the same panel.
+  const [drilldownOpen, setDrilldownOpen] = useState(false);
+  const toggleDrilldown = () => setDrilldownOpen((v) => !v);
 
   useEffect(() => {
     let cancelled = false;
@@ -315,12 +355,40 @@ export function ChainActivityTab({ theme = 'dark' }) {
     );
   }
 
+  const { utilityBlocks, emptyBlocks } = summarizeDaily(data.daily);
+  const hasBlocks = utilityBlocks + emptyBlocks > 0;
+
   return (
     <div className="chain-activity-tab">
-      <div className="ca-tab-hero">
-        <span className="ca-tab-hero-value">{fmtNum(todaysUtilityBlocks(data.daily))}</span>
-        <span className="ca-tab-hero-label">Utility blocks today</span>
-      </div>
+      {/*
+        * The hero is the biggest thing on the tab and the first thing anyone
+        * tries to click, but it did nothing -- the only way into the block
+        * drill-down was a small caret on a stat line below the chart, which
+        * reads as decoration (issue #253). It opens the same panel now.
+        *
+        * Only interactive when there are blocks to show: a button that does
+        * nothing is worse than a plain figure.
+        */}
+      {hasBlocks ? (
+        <button
+          type="button"
+          className={`ca-tab-hero ca-tab-hero--button${drilldownOpen ? ' ca-tab-hero--open' : ''}`}
+          onClick={toggleDrilldown}
+          aria-expanded={drilldownOpen}
+          aria-controls="ca-utility-drilldown"
+        >
+          <span className="ca-tab-hero-value">{fmtNum(todaysUtilityBlocks(data.daily))}</span>
+          <span className="ca-tab-hero-label">
+            Utility blocks today
+            <span className="ca-tab-hero-hint">{drilldownOpen ? 'Hide blocks' : 'Show blocks'}</span>
+          </span>
+        </button>
+      ) : (
+        <div className="ca-tab-hero">
+          <span className="ca-tab-hero-value">{fmtNum(todaysUtilityBlocks(data.daily))}</span>
+          <span className="ca-tab-hero-label">Utility blocks today</span>
+        </div>
+      )}
       <SyncStatusBanner
         syncStatus={data.syncStatus}
         lastSuccessAt={data.lastSuccessAt}
@@ -328,7 +396,13 @@ export function ChainActivityTab({ theme = 'dark' }) {
         scanStartHeight={data.scanStartHeight}
         scanTargetHeight={data.scanTargetHeight}
       />
-      <UtilitySummary daily={data.daily} syncStatus={data.syncStatus} theme={theme} />
+      <UtilitySummary
+        daily={data.daily}
+        syncStatus={data.syncStatus}
+        theme={theme}
+        drilldownOpen={drilldownOpen}
+        onToggleDrilldown={toggleDrilldown}
+      />
       <TeamTxList teamTxs={data.teamTxs} lastScannedHeight={data.lastScannedHeight} />
     </div>
   );

--- a/client/src/analytics/ChainActivityTab/index.scss
+++ b/client/src/analytics/ChainActivityTab/index.scss
@@ -405,3 +405,49 @@
   color: var(--text-tertiary);
   padding-top: 8px;
 }
+
+/*
+ * The hero as a control (issue #253).
+ *
+ * It is the largest element on the tab and the first thing anyone clicks, but
+ * it used to be inert -- the only way into the drill-down was a small caret on
+ * a stat line below the chart. Styled to stay visually identical to the plain
+ * figure it replaces, with the affordance carried by a hint and a hover state
+ * rather than by making it look like a button; a dashboard hero dressed as a
+ * form control would be worse.
+ */
+.ca-tab-hero--button {
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 1px solid rgba(43, 97, 209, 0.7);
+    outline-offset: 4px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.ca-tab-hero-hint {
+  margin-left: 10px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #2b61d1;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+
+  .app-mode-dark & {
+    color: #5b9bf5;
+  }
+}
+
+.ca-tab-hero--button:hover .ca-tab-hero-hint,
+.ca-tab-hero--button:focus-visible .ca-tab-hero-hint,
+.ca-tab-hero--open .ca-tab-hero-hint {
+  opacity: 1;
+}

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -99,6 +99,25 @@ export async function fetch_chain_activity() {
 // Returns 0 rather than NaN/Infinity when there's no real range yet (the
 // InProgress status written before the range is known — see
 // run_scan_cycle's two-step write in chain_activity.rs).
+/*
+ * How many blocks this scan still has to cover (issue #253).
+ *
+ * The banner used to compute `scanTargetHeight - lastScannedHeight` directly.
+ * On a cold start lastScannedHeight is 0 -- nothing has been scanned -- so that
+ * reported the chain TIP, telling the user a first-time backfill was 2.9
+ * MILLION blocks when the scanner's own log said 23,040. "A few minutes" and
+ * "this will never finish" are very different messages.
+ *
+ * Clamping to scanStartHeight is what fixes it: the scan never covers anything
+ * before its own start, whatever the checkpoint says.
+ */
+export function blocksRemainingInScan({ lastScannedHeight, scanStartHeight, scanTargetHeight }) {
+  const span = scanTargetHeight - scanStartHeight;
+  if (span <= 0) return 0;
+  const scannedTo = Math.max(lastScannedHeight || 0, scanStartHeight);
+  return Math.max(0, scanTargetHeight - scannedTo);
+}
+
 export function scanProgressPct({ lastScannedHeight, scanStartHeight, scanTargetHeight }) {
   const span = scanTargetHeight - scanStartHeight;
   if (span <= 0) return 0;

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,4 +1,6 @@
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from './chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel,
+  blocksRemainingInScan
+} from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
@@ -315,5 +317,46 @@ describe('blockCategoryLabel', () => {
     expect(blockCategoryLabel({ isP2p: false, isDapp: false })).toBe('\u2014');
     expect(blockCategoryLabel(null)).toBe('\u2014');
     expect(blockCategoryLabel(undefined)).toBe('\u2014');
+  });
+});
+
+/*
+ * Issue #253 -- the sync banner told a cold-start user the backfill was 2.9
+ * MILLION blocks when the scanner's own log said 23,040.
+ *
+ * `blocksRemaining` was `scanTargetHeight - lastScannedHeight`, and on a cold
+ * start lastScannedHeight is 0 (nothing scanned yet), so it reported the chain
+ * TIP rather than the span being scanned. The difference matters: 23,040 blocks
+ * is "a few minutes", 2.9 million reads as "this will never finish".
+ */
+describe('blocksRemainingInScan', () => {
+  it('is the span still to scan, not the chain tip, on a cold start', () => {
+    // Exactly the live cold start: nothing scanned, retention window 23,040.
+    expect(
+      blocksRemainingInScan({ lastScannedHeight: 0, scanStartHeight: 2919732, scanTargetHeight: 2942772 })
+    ).toBe(23040);
+  });
+
+  it('counts down as the scan progresses', () => {
+    expect(
+      blocksRemainingInScan({ lastScannedHeight: 2930000, scanStartHeight: 2919732, scanTargetHeight: 2942772 })
+    ).toBe(12772);
+  });
+
+  it('is zero once caught up', () => {
+    expect(
+      blocksRemainingInScan({ lastScannedHeight: 2942772, scanStartHeight: 2919732, scanTargetHeight: 2942772 })
+    ).toBe(0);
+  });
+
+  it('never goes negative if the checkpoint is ahead of the target', () => {
+    expect(
+      blocksRemainingInScan({ lastScannedHeight: 2999999, scanStartHeight: 2919732, scanTargetHeight: 2942772 })
+    ).toBe(0);
+  });
+
+  it('is zero when there is no range yet', () => {
+    // run_scan_cycle writes InProgress BEFORE it knows the range.
+    expect(blocksRemainingInScan({ lastScannedHeight: 0, scanStartHeight: 0, scanTargetHeight: 0 })).toBe(0);
   });
 });


### PR DESCRIPTION
Wave 6. Closes #253.

Docker came back, so I ran the real Rust API and could finally observe this tab. It turned up **three** separate defects.

## First: the scanner is fine

That question has been open since the QA pass. A fresh container logs:

```
[chain_activity] scan starting: 23040 blocks remaining (heights 2919732 -> 2942772, retention window 23040)
```

and works through it. **The tab was empty because a cold start genuinely takes a long time**, not because anything was broken.

## 1. The hero did nothing

"N UTILITY BLOCKS TODAY" is the largest element on the tab and the first thing anyone clicks — but the only way into the block drill-down was a small caret on a stat line *below the chart*, which reads as decoration. That's your "I cannot click on utility section".

It now opens the same panel, sharing one piece of state with the stat line so the two can't disagree. It stays a plain figure when there are no blocks — a button that does nothing is worse than no button.

## 2. It could strand permanently on "Loading blocks…"

The drill-down fetches once, guarded by `status !== 'idle'`, and its cleanup sets `cancelled = true` so a late resolve is ignored. **Close the panel before that fetch resolves and status stays `'loading'` forever**: the resolve is discarded, and the guard then refuses every retry. Confirmed in the browser — reopening issued *zero* network requests.

**My first fix was worse than the bug.** Resetting to `'idle'` in the cleanup, with `state.status` still in the dependency array, drove `idle → loading → cleanup → idle → …` and fired **~290,000 requests in a few seconds**. The cleanup runs on every dependency change, not only on close.

Status is now mirrored in a ref so it can gate the fetch without being a dependency, and the effect depends on `[open]` alone. Verified: closing mid-flight leaves exactly **1** request, reopening makes exactly **1** more.

I only caught that because I re-checked in the browser — the test suite was green for the looping version.

## 3. The sync banner lied about scan size

`blocksRemaining` was `scanTargetHeight - lastScannedHeight`. On a cold start `lastScannedHeight` is `0`, so it reported the chain **tip**:

> "2,942,772 blocks remaining in this scan (0%)"

for a backfill the scanner's own log put at **23,040**. "A few minutes" and "this will never finish" are very different messages to a user deciding whether the page is broken.

## Verification

- **719 tests, 50 suites** (713/49 before). `stateAfterCancel` was mutation-tested: restoring the original bug fails exactly one test, the one that names it.
- Production build clean. **D1 audit agrees.**
- **D4 could not be audited this run** — `capture.py`'s node-list fetch got a 429 from upstream, so that fixture is missing. Saying so rather than implying it passed; this diff touches no tier or ranking code and is confined to the Chain Activity tab.
- **Node page**: 127 rows, all NIMBUS, all 127 ranked, footer 63px.
- Browser-verified end to end against a populated tab: hero opens/closes the drill-down, `aria-expanded` tracks, three block rows render.

## Worth knowing

The scanner **only persists its checkpoint at the end of a full cycle**, so `last_scanned_height` stays `0` for the entire cold-start backfill and the progress percentage reads 0% the whole time, then jumps to done. Not fixed here — it's a change to the Rust scanner, not the client — but it's why a first run looks stalled even when healthy. Happy to file it separately if you want it addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9