### PR TITLE
feat(#266): band rich-list standing instead of one badge for everybody

### DIFF
--- a/client/src/api/__fixtures__/apidataBaseline.json
+++ b/client/src/api/__fixtures__/apidataBaseline.json
@@ -28,6 +28,7 @@
       "patch": 3
     },
     "in_rich_list": false,
+    "rich_list_rank": null,
     "nodePaymentAddresses": [
       {
         "activesince": "1700000000",
@@ -355,6 +356,7 @@
         "patch": 0
       },
       "in_rich_list": false,
+      "rich_list_rank": null,
       "nodePaymentAddresses": [],
       "node_count": {
         "cumulus": 0,

--- a/client/src/api/globalStats.js
+++ b/client/src/api/globalStats.js
@@ -31,6 +31,7 @@ import { categorizeRunningApps } from 'runningAppsCategorized';
 import { explorerFetchJson } from 'explorer';
 import { OLD_ADDRESS_FLUX } from 'donor/config';
 import { aggregateDonations } from 'donor/donationTotals';
+import { richListRank } from 'wallet/richList';
 import {
   fetch_node_benchmarks,
   fetch_node_resources,
@@ -103,6 +104,8 @@ export function create_global_store() {
     bench_latest_version: fluxos_version_desc(0, 0, 0),
     current_block_height: 0,
     in_rich_list: false,
+    // 1-based position on the rich list, or null when unlisted (#266).
+    rich_list_rank: null,
     total_donations: 0,
     arcane_os: {
       total_nodes: 0,
@@ -611,7 +614,16 @@ export async function fetch_global_stats(walletAddress = null) {
     try {
       const json = await explorerFetchJson('/statistics/richest-addresses-list');
       if (Array.isArray(json)) {
-        store.in_rich_list = json.some((wAddress) => wAddress.address === walletAddress);
+        /*
+         * The endpoint returns the list IN ORDER, and this used to throw the
+         * position away with `.some()` -- so a wallet at rank 1,000 (26,974
+         * FLUX) got exactly the same "whale" treatment as rank 1 (160 million).
+         * Capturing the rank is the whole fix; `in_rich_list` is kept so the
+         * existing rich_list achievement is untouched (#266).
+         */
+        const rank = richListRank(json, walletAddress);
+        store.rich_list_rank = rank;
+        store.in_rich_list = rank !== null;
       }
     } catch (error) {
       console.log('error', error);

--- a/client/src/home/Home.jsx
+++ b/client/src/home/Home.jsx
@@ -11,6 +11,7 @@ import { AppToaster } from 'components/AppToaster';
 import { HomeOverview } from 'home/HomeOverview';
 import { DonorBadge } from 'donor/DonorBadge';
 import { WalletDonationChip } from 'donor/WalletDonationChip';
+import { RichListChip } from 'wallet/RichListChip';
 import { runDonorAutoDetect } from 'donor/runDonorAutoDetect';
 import { CHECK_STATUS } from 'donor/donorWalletCheck';
 import {
@@ -497,6 +498,11 @@ class Home extends React.Component {
             failed={this.state.donationsCheckFailed}
             donationAddress={window.gContent?.ADDRESS_FLUX}
           />
+          {/*
+            #266: rich-list standing, banded. Was previously not shown here at
+            all -- membership only fed an achievement, and even that was binary.
+          */}
+          <RichListChip rank={this.state.gstore?.rich_list_rank} privacyMode={this.state.privacyMode} />
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>

--- a/client/src/main/MainApp.jsx
+++ b/client/src/main/MainApp.jsx
@@ -54,6 +54,7 @@ import { LayoutContext } from 'contexts/LayoutContext';
 import { blurAllInputs } from 'utils';
 import { DonorBadge } from 'donor/DonorBadge';
 import { WalletDonationChip } from 'donor/WalletDonationChip';
+import { RichListChip } from 'wallet/RichListChip';
 //import { setGAEvent } from 'g-analytic';
 
 const WALLET_INPUT_ID = '_WALLET_INPUT_';
@@ -531,6 +532,11 @@ class MainApp extends React.Component {
             failed={this.state.donationsCheckFailed}
             donationAddress={window.gContent?.ADDRESS_FLUX}
           />
+          {/*
+            #266: rich-list standing, banded. Was previously not shown here at
+            all -- membership only fed an achievement, and even that was binary.
+          */}
+          <RichListChip rank={this.state.gstore?.rich_list_rank} privacyMode={privacyMode} />
         </div>
 
         <a href={'https://explorer.runonflux.io/address/' + this.state.activeAddress}>

--- a/client/src/wallet/RichListChip/index.jsx
+++ b/client/src/wallet/RichListChip/index.jsx
@@ -1,0 +1,48 @@
+import { GiSpermWhale, GiDolphin, GiFishbone } from 'react-icons/gi';
+import { Tooltip2 } from '@blueprintjs/popover2';
+import { richListBand, RICH_LIST_BANDS } from 'wallet/richList';
+import './index.scss';
+
+/*
+ * Where this wallet sits on the Flux rich list, banded (issue #266).
+ *
+ * Previously nothing appeared here at all -- rich-list membership only fed an
+ * achievement, and even there it was binary. A wallet at rank 1,000 (26,974
+ * FLUX) and one at rank 1 (160 million) were indistinguishable.
+ *
+ * Three creatures rather than three copies of the same whale, so the band is
+ * readable at a glance without reading the label. The whale is reserved for the
+ * top 100, which is the only group the word was ever really meant for.
+ */
+const BAND_ICONS = {
+  top100: GiSpermWhale,
+  top500: GiDolphin,
+  top1000: GiFishbone
+};
+
+export function RichListChip({ rank, privacyMode }) {
+  const band = richListBand(rank);
+  if (!band) return null;
+
+  /*
+   * Privacy Mode hides the band, not just the rank.
+   *
+   * The address, balance and USD value are all masked when it is on; leaving a
+   * "Top 100" badge visible would leak the wealth bracket those maskings exist
+   * to hide -- arguably the most sensitive fact on the page, since it is
+   * exactly what makes a wallet worth targeting.
+   */
+  if (privacyMode) return null;
+
+  const Icon = BAND_ICONS[band];
+  const { label, blurb } = RICH_LIST_BANDS[band];
+
+  return (
+    <Tooltip2 content={`${blurb} — currently #${rank.toLocaleString()}`} placement="bottom" hoverOpenDelay={60}>
+      <span className={`rlc rlc--${band}`}>
+        <Icon size={13} aria-hidden="true" />
+        {label}
+      </span>
+    </Tooltip2>
+  );
+}

--- a/client/src/wallet/RichListChip/index.scss
+++ b/client/src/wallet/RichListChip/index.scss
@@ -1,0 +1,52 @@
+/*
+ * Rich-list band chip (issue #266).
+ *
+ * Weighted by band rather than three identical pills: the top band earns a
+ * warmer, more saturated treatment, the entry band stays close to the
+ * surrounding text. The point of the issue was that everyone looked the same,
+ * so the styling has to carry the distinction as much as the icon does.
+ */
+.rlc {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.rlc--top100 {
+  color: #8a6100;
+  background: rgba(232, 163, 61, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(232, 163, 61, 0.45);
+
+  .app-mode-dark & {
+    color: #f0c274;
+    background: rgba(232, 163, 61, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(232, 163, 61, 0.4);
+  }
+}
+
+.rlc--top500 {
+  color: #1f6fb5;
+  background: rgba(38, 134, 208, 0.14);
+
+  .app-mode-dark & {
+    color: #7cc0f5;
+    background: rgba(38, 134, 208, 0.2);
+  }
+}
+
+.rlc--top1000 {
+  color: rgba(90, 96, 106, 0.95);
+  background: rgba(128, 128, 128, 0.1);
+  font-weight: 500;
+
+  .app-mode-dark & {
+    color: rgba(168, 176, 190, 0.95);
+    background: rgba(255, 255, 255, 0.06);
+  }
+}

--- a/client/src/wallet/richList.js
+++ b/client/src/wallet/richList.js
@@ -1,0 +1,42 @@
+/*
+ * Where a wallet sits on the Flux rich list, in bands (issue #266).
+ *
+ * `in_rich_list` used to be a single boolean: you were on the list or you were
+ * not, and everyone on it got the same whale. The list is 1,000 entries sorted
+ * by balance, and when this was written rank 1 held 160,000,029 FLUX while rank
+ * 1,000 held 26,974 -- a ~5,900x spread behind one identical badge. The top 100
+ * alone hold 82.6% of the listed balance.
+ *
+ * Bands are RANK-based and must stay that way. The balances at each boundary
+ * move every day, so encoding "320,000 FLUX = top 100" would be wrong within a
+ * week; the rank is the stable fact.
+ */
+
+export const RICH_LIST_BANDS = {
+  top100: { label: 'Top 100', max: 100, blurb: 'Top 100 wallet on the Flux rich list' },
+  top500: { label: 'Top 500', max: 500, blurb: 'Top 500 wallet on the Flux rich list' },
+  top1000: { label: 'Rich list', max: Infinity, blurb: 'Listed on the Flux rich list' }
+};
+
+// Most significant first, so the first match wins.
+const ORDER = ['top100', 'top500', 'top1000'];
+
+/*
+ * 1-based position, or null when the wallet is not listed.
+ *
+ * This is the whole fix for the original defect: globalStats used `.some()` and
+ * threw the position away, even though the endpoint returns the list in order.
+ */
+export function richListRank(entries, walletAddress) {
+  if (!Array.isArray(entries) || !walletAddress) return null;
+  const index = entries.findIndex((entry) => entry?.address === walletAddress);
+  return index === -1 ? null : index + 1;
+}
+
+export function richListBand(rank) {
+  if (typeof rank !== 'number' || rank < 1) return null;
+  // Beyond the last explicit boundary everything falls into the entry band --
+  // the list is 1,000 long today, but that is the explorer's choice and could
+  // change without notice.
+  return ORDER.find((band) => rank <= RICH_LIST_BANDS[band].max) || 'top1000';
+}

--- a/client/src/wallet/richList.test.js
+++ b/client/src/wallet/richList.test.js
@@ -1,0 +1,76 @@
+import { richListBand, richListRank, RICH_LIST_BANDS } from './richList';
+
+/*
+ * Issue #266 -- "whale" was a single binary flag.
+ *
+ * /statistics/richest-addresses-list returns 1,000 entries sorted by balance
+ * descending. Rank 1 held 160,000,029 FLUX and rank 1,000 held 26,974 when this
+ * was written -- a ~5,900x spread that produced identical treatment. The top 100
+ * alone hold 82.6% of the listed balance.
+ *
+ * Bands are RANK-based, never balance-based: those balances move daily, so a
+ * hardcoded "320,000 FLUX = top 100" would be wrong within days.
+ */
+const list = (n) => Array.from({ length: n }, (_, i) => ({ address: `t1addr${i + 1}`, balance: 1000 - i }));
+
+describe('richListRank', () => {
+  it('is 1-based, so the richest address is rank 1 rather than 0', () => {
+    expect(richListRank(list(10), 't1addr1')).toBe(1);
+  });
+
+  it('finds an address further down the list', () => {
+    expect(richListRank(list(1000), 't1addr500')).toBe(500);
+  });
+
+  it('is null for an address that is not listed', () => {
+    expect(richListRank(list(10), 't1nobody')).toBeNull();
+  });
+
+  it('is null for a missing list or address', () => {
+    expect(richListRank(null, 't1addr1')).toBeNull();
+    expect(richListRank(list(10), null)).toBeNull();
+    expect(richListRank(undefined, undefined)).toBeNull();
+  });
+
+  it('tolerates malformed entries rather than throwing', () => {
+    expect(richListRank([null, {}, { address: 't1a' }], 't1a')).toBe(3);
+  });
+});
+
+describe('richListBand', () => {
+  it('puts the very top of the list in the top band', () => {
+    expect(richListBand(1)).toBe('top100');
+    expect(richListBand(100)).toBe('top100');
+  });
+
+  it('starts the middle band at 101', () => {
+    // The boundary is the whole point of this issue -- 100 and 101 must differ.
+    expect(richListBand(101)).toBe('top500');
+    expect(richListBand(500)).toBe('top500');
+  });
+
+  it('starts the entry band at 501', () => {
+    expect(richListBand(501)).toBe('top1000');
+    expect(richListBand(1000)).toBe('top1000');
+  });
+
+  it('still bands a rank beyond 1000, in case the list ever grows', () => {
+    // The list is 1,000 today but that is the explorer's choice, not ours.
+    expect(richListBand(1001)).toBe('top1000');
+  });
+
+  it('is null for an unranked wallet', () => {
+    expect(richListBand(null)).toBeNull();
+    expect(richListBand(undefined)).toBeNull();
+    expect(richListBand(0)).toBeNull();
+    expect(richListBand(-3)).toBeNull();
+  });
+
+  it('describes every band it can return', () => {
+    for (const band of ['top100', 'top500', 'top1000']) {
+      expect(RICH_LIST_BANDS[band]).toBeDefined();
+      expect(typeof RICH_LIST_BANDS[band].label).toBe('string');
+      expect(RICH_LIST_BANDS[band].label.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Wave 8. Closes #266.

## The defect

"Whale" was a single boolean. `api/globalStats.js` called `.some()` on an endpoint that returns its list **in order** — throwing the position away. So a wallet at rank 1,000 (**26,974 FLUX**) and one at rank 1 (**160,000,029**) were indistinguishable. A ~5,900× spread behind one identical badge, while the top 100 alone hold **82.6%** of the listed balance.

The data-layer fix is one call: `findIndex` instead of `some`, stored as `rich_list_rank`. `in_rich_list` is kept and derived from it, so the existing `rich_list` achievement is untouched and **nobody loses an achievement**.

## Three bands

| Rank | Icon | Label |
|---|---|---|
| 1–100 | whale | **Top 100** |
| 101–500 | dolphin | **Top 500** |
| 501+ | fishbone | **Rich list** |

Different creatures rather than three copies of the same whale, so the band reads at a glance without reading the label — and the whale is reserved for the top 100, which is the only group the word was ever really meant for.

**Bands are rank-based, deliberately.** The balance at each boundary moves daily (320,000 FLUX was the top-100 cut when this was written); encoding that would be wrong within a week. The rank is the stable fact.

Note that **nothing appeared in the wallet row before this** — rich-list membership only ever fed an achievement, so this is new surface rather than a restyle.

## One thing I added that wasn't in the issue

**The chip is hidden entirely when Privacy Mode is on.**

The address, balance and USD value are all masked in that mode. Leaving a "Top 100" badge visible would leak the wealth bracket those maskings exist to hide — arguably the most sensitive thing on the page, since it's exactly what makes a wallet worth targeting. Adding the chip without this would have been a real privacy regression, so it ships with it.

## Verification

- **751 tests, 53 suites** (740/52 before). 11 new, covering the **100/101** and **500/501** boundaries, 1-based ranking, unlisted wallets, malformed entries, and ranks beyond 1,000 in case the explorer ever lengthens the list.
- **`apidataParity` caught the new store field**, as designed. The baseline got `rich_list_rank` added **by hand** in the two places the store shape is captured, not regenerated — so anything *else* that moved would still fail.
- Production build clean. **D1 audit agrees.** D4 not auditable this run — `capture.py` got a 429 from upstream; this diff touches no tier or ranking code.
- **Browser-verified all five cases against real wallets and their true ranks:**

| Wallet | True rank | Rendered |
|---|---|---|
| `t3c4Efx…` | #4 | Top 100 |
| `t1bAB8f6…` | #22 | Top 100 |
| `t3RKwtB…` | **#101** | **Top 500** ← the boundary |
| `t1Rwq3f…` | #502 | Rich list |
| `t1T6tf83…` | unlisted | *no chip* |
| any, Privacy Mode on | — | *no chip* |

Worth noting on that table: I initially assumed `t1bAB8f6…` was unlisted and treated its "Top 100" as a possible bug — it's genuinely rank #22 with 1.59M FLUX. Checked rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9