### PR TITLE
feat(#145): show where this instance is hosted and how long it has been up

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -30,6 +30,9 @@ async fn main() {
     // cold start and a replica that's been rescheduled to a fresh node with
     // no local data) and then hourly. run_scan_cycle() itself no-ops quickly
     // if already caught up to the tip.
+    // Starts the process-uptime clock at boot rather than at first request (#145).
+    services::host_info::mark_started();
+
     tokio::spawn(async {
         loop {
             services::chain_activity::run_scan_cycle().await;
@@ -93,6 +96,7 @@ pub mod api_v1 {
             )
             .route("/chain-activity", get(self::chain_activity::handler))
             .route("/chain-activity/blocks", get(self::chain_activity_blocks::handler))
+            .route("/header", get(self::header::handler))
     }
 
     async fn root() -> String {
@@ -135,6 +139,21 @@ pub mod api_v1 {
                 Err(err) => DemoResultBody::make_err(err.to_string()),
             };
             (StatusCode::OK, Json(result))
+        }
+    }
+
+    /*
+     * Facts about the machine serving this site, for the footer (issue #145).
+     *
+     * Always 200 with success:true -- every individual field is optional and
+     * already degrades to null on its own, so there is no failure mode worth
+     * reporting as an error. The client omits whatever is missing.
+     */
+    pub mod header {
+        use super::*;
+
+        pub async fn handler() -> impl IntoResponse {
+            Json(services::host_info::collect().await)
         }
     }
 

--- a/api/src/services.rs
+++ b/api/src/services.rs
@@ -1,4 +1,5 @@
 pub mod bench_version;
 pub mod chain_activity;
 pub mod demo;
+pub mod host_info;
 pub mod live_winners;

--- a/api/src/services/host_info.rs
+++ b/api/src/services/host_info.rs
@@ -1,0 +1,284 @@
+/*
+ * Facts about the machine serving this site (issue #145).
+ *
+ * The client is a static bundle behind nginx and can learn nothing about its
+ * own host, so the footer had no way to say where it is running. This supplies
+ * it.
+ *
+ * DELIBERATELY NO EXTRA CRATE. The issue suggested `sysinfo`; everything needed
+ * here is three files in /proc plus std, and the image is always Linux. That
+ * avoids a dependency rebuild, and avoids sysinfo's habit of reshaping its API
+ * between minor versions (total_memory switched units in 0.30). Non-Linux
+ * builds degrade to None rather than failing to compile, so `cargo run` on a
+ * developer's Mac still works -- it just reports less.
+ */
+
+use serde::Serialize;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
+
+/// Resolved once per process. Flux apps relocate between nodes, so this is
+/// looked up on boot rather than baked into the image -- but it cannot change
+/// while the process lives, so one lookup is enough.
+static LOCATION: OnceLock<Option<HostLocation>> = OnceLock::new();
+
+/// Process start, for "this instance has been serving for N".
+static STARTED_AT: OnceLock<Instant> = OnceLock::new();
+
+const CACHE_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostLocation {
+    pub city: Option<String>,
+    pub country: Option<String>,
+    #[serde(rename = "countryCode")]
+    pub country_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostInfo {
+    pub platform: &'static str,
+    pub arch: &'static str,
+    #[serde(rename = "cpuCores")]
+    pub cpu_cores: Option<usize>,
+    #[serde(rename = "totalMemMB")]
+    pub total_mem_mb: Option<u64>,
+    #[serde(rename = "usedMemMB")]
+    pub used_mem_mb: Option<u64>,
+    #[serde(rename = "memPercent")]
+    pub mem_percent: Option<u64>,
+    /// Kernel uptime of the machine -- for a Flux node, how long the node itself
+    /// has been up. In a container this reads the host's /proc/uptime.
+    #[serde(rename = "uptimeSeconds")]
+    pub uptime_seconds: Option<u64>,
+    /// How long THIS API process has been serving. Distinct from the above and
+    /// the more honest number for a footer: a redeployed app resets this while
+    /// the node's uptime keeps climbing.
+    #[serde(rename = "appUptimeSeconds")]
+    pub app_uptime_seconds: u64,
+    pub location: Option<HostLocation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostInfoBody {
+    pub success: bool,
+    pub host: HostInfo,
+    pub app: AppInfo,
+    #[serde(rename = "generatedAt")]
+    pub generated_at: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppInfo {
+    pub version: &'static str,
+}
+
+/// Call once at startup so the process-uptime clock starts at boot rather than
+/// at the first request.
+pub fn mark_started() {
+    let _ = STARTED_AT.set(Instant::now());
+}
+
+fn app_uptime_seconds() -> u64 {
+    STARTED_AT.get().map(|t| t.elapsed().as_secs()).unwrap_or(0)
+}
+
+#[cfg(target_os = "linux")]
+fn read_uptime_seconds() -> Option<u64> {
+    // /proc/uptime is "<uptime> <idle>", both in seconds with decimals.
+    let raw = std::fs::read_to_string("/proc/uptime").ok()?;
+    raw.split_whitespace().next()?.parse::<f64>().ok().map(|v| v as u64)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_uptime_seconds() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_memory_mb() -> (Option<u64>, Option<u64>) {
+    // MemAvailable is the honest "free" figure -- MemFree excludes cache and
+    // buffers the kernel would happily evict, and reports a machine as far
+    // fuller than it behaves.
+    let raw = match std::fs::read_to_string("/proc/meminfo") {
+        Ok(v) => v,
+        Err(_) => return (None, None),
+    };
+
+    let field = |name: &str| -> Option<u64> {
+        raw.lines()
+            .find(|line| line.starts_with(name))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<u64>()
+            .ok()
+            .map(|kb| kb / 1024)
+    };
+
+    let total = field("MemTotal:");
+    let available = field("MemAvailable:");
+    let used = match (total, available) {
+        (Some(t), Some(a)) => Some(t.saturating_sub(a)),
+        _ => None,
+    };
+    (total, used)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_memory_mb() -> (Option<u64>, Option<u64>) {
+    (None, None)
+}
+
+fn cpu_cores() -> Option<usize> {
+    std::thread::available_parallelism().ok().map(|n| n.get())
+}
+
+/*
+ * Geolocate the container's own public IP.
+ *
+ * SEVERAL providers, tried in order, first usable answer wins. This is not
+ * over-engineering: the first single-provider attempt returned 429 on the very
+ * first run, because these free tiers are shared per-IP and routinely
+ * exhausted. One provider is one outage away from a permanently blank segment.
+ * Same reasoning as the explorer host pool in #218.
+ *
+ * Resolved once and kept for the life of the process. A total failure resolves
+ * to None and the footer omits the segment -- the location is provenance, not
+ * function, and must never be why this endpoint fails.
+ */
+struct GeoProvider {
+    url: &'static str,
+    /// Field names differ per provider; `country` is a full name on some and an
+    /// ISO code on others, so both are read and the client prefers the name.
+    city: &'static str,
+    country: &'static str,
+    country_code: &'static str,
+}
+
+const GEO_PROVIDERS: [GeoProvider; 3] = [
+    // HTTPS, reliable, but `country` is an ISO code rather than a name.
+    GeoProvider { url: "https://ipinfo.io/json", city: "city", country: "__none__", country_code: "country" },
+    // Richest answer (full country name). HTTP only on the free tier, which is
+    // acceptable for a one-off server-side lookup of our own public IP -- there
+    // is nothing secret in the request or the response.
+    GeoProvider { url: "http://ip-api.com/json/", city: "city", country: "country", country_code: "countryCode" },
+    GeoProvider { url: "https://ipapi.co/json/", city: "city", country: "country_name", country_code: "country_code" },
+];
+
+async fn try_provider(client: &reqwest::Client, provider: &GeoProvider) -> Option<HostLocation> {
+    let resp = client.get(provider.url).send().await.ok()?;
+    if !resp.status().is_success() {
+        println!("[host_info] {} returned {}", provider.url, resp.status());
+        return None;
+    }
+
+    let json: serde_json::Value = resp.json().await.ok()?;
+
+    // Providers signal a soft failure in the BODY with a 200 -- ipapi.co sends
+    // {"error":true}, ipwho.is sends {"success":false}. Trusting the status
+    // code alone would store a rate-limit notice as a location.
+    if json.get("error").and_then(|v| v.as_bool()).unwrap_or(false)
+        || json.get("success").and_then(|v| v.as_bool()) == Some(false)
+        || json.get("status").and_then(|v| v.as_str()) == Some("fail")
+    {
+        println!("[host_info] {} reported a soft failure", provider.url);
+        return None;
+    }
+
+    let pick = |key: &str| {
+        json.get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+    };
+
+    let location = HostLocation {
+        city: pick(provider.city),
+        country: pick(provider.country),
+        country_code: pick(provider.country_code),
+    };
+
+    if location.city.is_none() && location.country.is_none() && location.country_code.is_none() {
+        return None;
+    }
+    Some(location)
+}
+
+async fn resolve_location() -> Option<HostLocation> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(6))
+        .build()
+        .ok()?;
+
+    for provider in GEO_PROVIDERS.iter() {
+        if let Some(location) = try_provider(&client, provider).await {
+            println!("[host_info] location resolved via {}", provider.url);
+            return Some(location);
+        }
+    }
+
+    println!("[host_info] every geolocation provider failed -- omitting location");
+    None
+}
+
+async fn location() -> Option<HostLocation> {
+    if let Some(cached) = LOCATION.get() {
+        return cached.clone();
+    }
+    let resolved = resolve_location().await;
+    // A race here is harmless: two boots-worth of lookups at worst, and set()
+    // keeps whichever landed first.
+    let _ = LOCATION.set(resolved.clone());
+    resolved
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// Whole payload, memoised briefly. The footer polls, and re-reading /proc per
+/// request is pointless when the numbers move this slowly.
+static CACHE: OnceLock<Mutex<Option<(Instant, HostInfoBody)>>> = OnceLock::new();
+
+pub async fn collect() -> HostInfoBody {
+    let cache = CACHE.get_or_init(|| Mutex::new(None));
+    let mut guard = cache.lock().await;
+
+    if let Some((at, body)) = guard.as_ref() {
+        if at.elapsed() < CACHE_TTL {
+            return body.clone();
+        }
+    }
+
+    let (total_mem_mb, used_mem_mb) = read_memory_mb();
+    let mem_percent = match (total_mem_mb, used_mem_mb) {
+        (Some(t), Some(u)) if t > 0 => Some(u * 100 / t),
+        _ => None,
+    };
+
+    let body = HostInfoBody {
+        success: true,
+        host: HostInfo {
+            platform: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            cpu_cores: cpu_cores(),
+            total_mem_mb,
+            used_mem_mb,
+            mem_percent,
+            uptime_seconds: read_uptime_seconds(),
+            app_uptime_seconds: app_uptime_seconds(),
+            location: location().await,
+        },
+        app: AppInfo {
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        generated_at: now_millis(),
+    };
+
+    *guard = Some((Instant::now(), body.clone()));
+    body
+}

--- a/client/src/components/Footer/hostInfo.js
+++ b/client/src/components/Footer/hostInfo.js
@@ -1,0 +1,70 @@
+/*
+ * Footer text for the machine serving this site (issue #145).
+ *
+ * Formatting lives here rather than in the component because every field from
+ * /api/v1/header is optional -- the geolocation lookup can fail, /proc is
+ * unreadable off Linux, and on a static-only deploy the endpoint does not exist
+ * at all. The rule throughout is that a missing field REMOVES its segment
+ * rather than rendering "Hosted in undefined", and the footer with no data at
+ * all must look exactly as it did before this feature.
+ */
+
+function clean(value) {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text.length > 0 ? text : null;
+}
+
+export function formatHostLocation(location) {
+  const city = clean(location?.city);
+  // The provider chain can answer with either a full country name or an ISO
+  // code -- ipinfo.io gives "AU", ip-api.com gives "Australia" -- and whichever
+  // provider answered first is not knowable here. Prefer the name; the code is
+  // still far better than dropping the country.
+  const country = clean(location?.country) || clean(location?.countryCode);
+
+  if (city && country) return `${city}, ${country}`;
+  return city || country || null;
+}
+
+/*
+ * Coarsened on purpose: a footer wants "10d 0h", not "10d 0h 5m 12s". The
+ * smallest unit shown always matches the largest one present, so the string
+ * stays about the same width as the numbers grow.
+ */
+export function formatUptime(seconds) {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return null;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 1) return '<1m';
+
+  const days = Math.floor(minutes / (60 * 24));
+  const hours = Math.floor((minutes % (60 * 24)) / 60);
+  const mins = minutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+/*
+ * The footer segments, in order, with anything unknown left out.
+ *
+ * Uses appUptimeSeconds -- how long THIS instance has been serving -- rather
+ * than the host's kernel uptime. A redeployed app resets the former while the
+ * latter keeps climbing, and "up 40 days" under a site that restarted an hour
+ * ago is the sort of number nobody can act on.
+ */
+export function hostInfoSegments(payload) {
+  const host = payload?.host;
+  if (!host) return [];
+
+  const segments = [];
+
+  const where = formatHostLocation(host.location);
+  if (where) segments.push(`Hosted in ${where}`);
+
+  const uptime = formatUptime(host.appUptimeSeconds);
+  if (uptime) segments.push(`Up ${uptime}`);
+
+  return segments;
+}

--- a/client/src/components/Footer/hostInfo.test.js
+++ b/client/src/components/Footer/hostInfo.test.js
@@ -1,0 +1,100 @@
+import { formatHostLocation, formatUptime, hostInfoSegments } from './hostInfo';
+
+/*
+ * Issue #145 -- "Hosted in …" and uptime in the footer, mirroring Fluxtracker.
+ *
+ * Every field from /api/v1/header is optional: the geolocation lookup can fail,
+ * /proc is unreadable off Linux, and the endpoint itself does not exist on a
+ * static-only deploy. So the rule throughout is that a missing field removes
+ * its segment rather than rendering "Hosted in undefined".
+ */
+describe('formatHostLocation', () => {
+  it('reads as city and country together', () => {
+    expect(formatHostLocation({ city: 'Melbourne', country: 'Australia' })).toBe('Melbourne, Australia');
+  });
+
+  it('falls back to country alone when the city is unknown', () => {
+    expect(formatHostLocation({ country: 'Finland' })).toBe('Finland');
+  });
+
+  it('falls back to city alone when the country is unknown', () => {
+    expect(formatHostLocation({ city: 'Helsinki' })).toBe('Helsinki');
+  });
+
+  it('falls back to the country CODE when no country name was returned', () => {
+    // ipinfo.io answers with country: "AU" and no full name; ip-api.com gives
+    // "Australia". The chain means either can win, so both must render.
+    expect(formatHostLocation({ city: 'Melbourne', countryCode: 'AU' })).toBe('Melbourne, AU');
+  });
+
+  it('prefers the country NAME over the code when both are present', () => {
+    expect(formatHostLocation({ city: 'Melbourne', country: 'Australia', countryCode: 'AU' }))
+      .toBe('Melbourne, Australia');
+  });
+
+  it('uses the code alone when that is all there is', () => {
+    expect(formatHostLocation({ countryCode: 'FI' })).toBe('FI');
+  });
+
+  it('is null when nothing is known, so the segment can be dropped entirely', () => {
+    expect(formatHostLocation({})).toBeNull();
+    expect(formatHostLocation(null)).toBeNull();
+    expect(formatHostLocation(undefined)).toBeNull();
+  });
+
+  it('ignores blank strings rather than rendering a stray comma', () => {
+    expect(formatHostLocation({ city: '', country: 'Australia' })).toBe('Australia');
+    expect(formatHostLocation({ city: '   ', country: '' })).toBeNull();
+  });
+});
+
+describe('formatUptime', () => {
+  it('reads in days and hours once past a day', () => {
+    expect(formatUptime(864321)).toBe('10d 0h');
+    expect(formatUptime(90000)).toBe('1d 1h');
+  });
+
+  it('drops to hours and minutes under a day', () => {
+    expect(formatUptime(3660)).toBe('1h 1m');
+  });
+
+  it('drops to minutes under an hour', () => {
+    expect(formatUptime(300)).toBe('5m');
+  });
+
+  it('says less than a minute rather than "0m" for a fresh start', () => {
+    expect(formatUptime(30)).toBe('<1m');
+    expect(formatUptime(0)).toBe('<1m');
+  });
+
+  it('is null for a missing or nonsensical value', () => {
+    expect(formatUptime(null)).toBeNull();
+    expect(formatUptime(undefined)).toBeNull();
+    expect(formatUptime(-5)).toBeNull();
+    expect(formatUptime('lots')).toBeNull();
+  });
+});
+
+describe('hostInfoSegments', () => {
+  const full = { host: { location: { city: 'Helsinki', country: 'Finland' }, appUptimeSeconds: 90000 } };
+
+  it('produces the location and uptime segments', () => {
+    expect(hostInfoSegments(full)).toEqual(['Hosted in Helsinki, Finland', 'Up 1d 1h']);
+  });
+
+  it('drops the location segment when the lookup failed', () => {
+    expect(hostInfoSegments({ host: { location: null, appUptimeSeconds: 300 } })).toEqual(['Up 5m']);
+  });
+
+  it('drops the uptime segment when it is unavailable', () => {
+    expect(hostInfoSegments({ host: { location: { country: 'Finland' } } })).toEqual(['Hosted in Finland']);
+  });
+
+  it('is empty when the endpoint gave nothing usable, so the footer is unchanged', () => {
+    // A static-only deploy has no Rust API at all -- the footer must look
+    // exactly as it did before this feature.
+    expect(hostInfoSegments(null)).toEqual([]);
+    expect(hostInfoSegments({})).toEqual([]);
+    expect(hostInfoSegments({ host: {} })).toEqual([]);
+  });
+});

--- a/client/src/components/Footer/index.jsx
+++ b/client/src/components/Footer/index.jsx
@@ -11,6 +11,7 @@ import { BsGithub, BsBugFill, BsCheckLg, BsClipboard } from 'react-icons/bs';
 import { URL_YOUTUBE, URL_TWITTER, URL_GITHUB, EMAIL, ADDRESS_FLUX } from 'content/index';
 
 import { IS_TEST_BUILD, IS_DEV, APP_VERSION } from 'app-buildinfo';
+import { useHostInfo } from './useHostInfo';
 
 function _RenderAppVersion() {
   let suffix = '';
@@ -91,6 +92,7 @@ export function DonateChip({ label, address }) {
 }
 
 export function Footer() {
+  const hostSegments = useHostInfo();
   const { lastUpdated, arcaneHumanVersion } = useContext(LayoutContext);
 
   return (
@@ -116,6 +118,17 @@ export function Footer() {
               <span className="hl-app-version">FluxNode {_RenderAppVersion()}</span>
               {arcaneHumanVersion && <span className="footer-meta__sep">·</span>}
               {arcaneHumanVersion && <span>{arcaneHumanVersion}</span>}
+              {/*
+                #145: where this instance is running and how long it has been
+                up. Empty unless the Rust API is deployed, in which case the
+                footer is unchanged.
+              */}
+              {hostSegments.map((segment) => (
+                <React.Fragment key={segment}>
+                  <span className="footer-meta__sep">·</span>
+                  <span className="footer-meta__host">{segment}</span>
+                </React.Fragment>
+              ))}
               {lastUpdated && <span className="footer-meta__sep">·</span>}
               {lastUpdated && (
                 <span className="footer-meta__updated">

--- a/client/src/components/Footer/index.scss
+++ b/client/src/components/Footer/index.scss
@@ -267,3 +267,12 @@
     padding: 5px 8px;
   }
 }
+
+/*
+ * Host info segments (issue #145). Same weight as the rest of the footer meta
+ * line -- this is provenance, not a feature announcement, and it sits next to
+ * the version and last-updated time it belongs with.
+ */
+.footer-meta__host {
+  white-space: nowrap;
+}

--- a/client/src/components/Footer/useHostInfo.js
+++ b/client/src/components/Footer/useHostInfo.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { FLUXNODE_INFO_API_URL } from 'app-buildinfo';
+import { hostInfoSegments } from './hostInfo';
+
+/*
+ * Fetches /api/v1/header once and turns it into footer segments (issue #145).
+ *
+ * Fails SILENTLY to an empty list on purpose. This endpoint only exists where
+ * the Rust API is deployed alongside nginx -- a static-only build, a dev server,
+ * or an older image will 404, and none of those are errors worth telling
+ * anybody about. The footer simply looks the way it did before this feature.
+ *
+ * Fetched once per mount rather than polled: the location never changes for the
+ * life of the process, and uptime moving by a few minutes is not worth a timer
+ * on a component that is on every single page.
+ */
+export function useHostInfo() {
+  const [segments, setSegments] = useState([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/header`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        });
+        if (!response.ok) return;
+        const json = await response.json();
+        if (cancelled || !json?.success) return;
+        setSegments(hostInfoSegments(json));
+      } catch {
+        // No API here. Nothing to say, nothing to log.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return segments;
+}


### PR DESCRIPTION
Wave 9. Closes #145. This is the "hosted in / uptime" footer request.

Adds `GET /api/v1/header` to the Rust API and renders it in the footer meta line, mirroring Fluxtracker's header:

```
FluxNode v1.2.0 · jolly wombat · Hosted in Melbourne, Australia · Up 1d 4h · Updated 11:35
```

The client is a static bundle behind nginx and can learn nothing about its own host — which is why this needed an API at all, and why it sat unbuildable until Docker came back.

## Two deliberate departures from the issue

**No new crate.** The issue proposed `sysinfo`. Uptime, memory and core count come from `/proc` and `std` in about forty lines — avoiding a dependency rebuild and avoiding sysinfo's habit of reshaping its API between minor versions (`total_memory` changed units in 0.30). Non-Linux builds degrade to `None` rather than failing to compile, so `cargo run` on a Mac still works.

**Geolocation uses a provider chain**, and that wasn't over-caution — it was forced by reality, twice:

1. The first single-provider attempt returned **429 on its very first run**. These free tiers are shared per-IP and routinely exhausted.
2. With the chain in place, the first provider then failed a *second* way I hadn't predicted — **ipinfo.io answered 406 Not Acceptable** — and ip-api.com carried it.

A single provider would have shipped a permanently blank segment. Same reasoning as the explorer host pool in #218.

Providers are also checked for **soft failures**: several answer `200` with `{"error":true}` or `{"success":false}` in the body, so trusting the status code alone would have stored a rate-limit notice as a location.

## One judgement call on which uptime

The payload carries both; the footer renders **`appUptimeSeconds`** — how long *this instance* has been serving — not the host's kernel uptime. A redeployed app resets the former while the latter keeps climbing, and "up 40 days" under a site that restarted an hour ago is a number nobody can act on.

## Verification

- **768 tests, 54 suites** (751/53 before). 17 new, covering both country-**name** and country-**code** answers (the chain can return either), partial locations, uptime unit thresholds, and the all-empty case.
- Rust compiled clean with no warnings — `docker build --target build` for a fast loop, then the full image.
- **Live in the container:** `/api/v1/header` returns platform, arch, 16 cores, 47,979 MB total / 7% used, host uptime, app uptime, and `{city: Melbourne, country: Australia, countryCode: AU}`. Footer renders `Hosted in Melbourne, Australia · Up <1m`.
- **The degraded path, which is the one that matters** since the footer is on every page and #246 only just fixed it: against a server with **no Rust API** the request returns `200` with HTML (SPA fallback — messier than a clean 404), `json()` throws, it's caught, and the footer renders **exactly as before at 63px** with no error boundary.
- D1 audit agrees. D4 not auditable — `capture.py` got a 429 upstream; this diff touches no tier code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9