### PR TITLE
fix(#271): align api/Cargo.toml with the app version, and stop it drifting again

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -231,7 +231,7 @@ checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fluxnode_api_mask"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "futures",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluxnode_api_mask"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 publish = false
 

--- a/client/src/audit/versionParity.test.js
+++ b/client/src/audit/versionParity.test.js
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * Issue #271 -- client/package.json and api/Cargo.toml are two hand-maintained
+ * copies of the same number, and they had already drifted: the client was 1.2.0
+ * while the API was still the 0.1.0 it was created with.
+ *
+ * That was invisible until #145 added GET /api/v1/header, which publishes
+ * CARGO_PKG_VERSION as `app.version` -- so the endpoint reported 0.1.0 while the
+ * footer, reading package.json, rendered v1.2.0.
+ *
+ * This is the same shape of problem constantsParity.test.js catches for the CC_*
+ * constants: nothing enforced agreement, so they silently diverged. Checking it
+ * here means a future version bump cannot land in only one file.
+ */
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function clientVersion() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'package.json'), 'utf8'));
+  return pkg.version;
+}
+
+function apiVersion() {
+  const cargo = fs.readFileSync(path.join(repoRoot, 'api', 'Cargo.toml'), 'utf8');
+  // The FIRST `version =` under [package]; dependency versions follow later and
+  // matching those would make this test pass for the wrong reason.
+  const packageSection = cargo.split(/^\[/m).find((section) => section.startsWith('package]'));
+  const match = /^version\s*=\s*"([^"]+)"/m.exec(packageSection || '');
+  return match ? match[1] : null;
+}
+
+describe('app version parity', () => {
+  it('reads a version from both manifests', () => {
+    expect(clientVersion()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(apiVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('keeps client/package.json and api/Cargo.toml on the same version', () => {
+    // If this fails you bumped one and not the other. /api/v1/header publishes
+    // the Cargo one; the footer publishes the package.json one. They are the
+    // same application and must not disagree about what it is.
+    expect(apiVersion()).toBe(clientVersion());
+  });
+});


### PR DESCRIPTION
Closes #271.

`client/package.json` was **1.2.0** while `api/Cargo.toml` was still the **0.1.0** it was created with. Harmless while nothing surfaced it — then #145 added `GET /api/v1/header`, which publishes `CARGO_PKG_VERSION` as `app.version`. The endpoint reported `0.1.0` while the footer, two lines away, rendered `v1.2.0`.

## Why this isn't just a bump

Bumping the number alone fixes today and drifts again at the next release. So the bump ships with a test that makes the two **unable** to disagree — the same shape as `constantsParity.test.js`, which exists because the `CC_*` constants had exactly this problem: two hand-maintained copies and nothing enforcing agreement.

The test parses the `[package]` section specifically. Matching any `version =` in `Cargo.toml` would find a *dependency's* version and pass for the wrong reason.

`Cargo.lock` carries the package version too and is updated to match; leaving it stale risks a build that disagrees with its own manifest.

## Verification

- **Test written first and watched fail on the real drift**: `Expected "1.2.0", Received "0.1.0"`.
- **770 tests, 55 suites** (768/54 before).
- Rust compiled clean, then verified in a running container: `/api/v1/header` now reports `app.version: "1.2.0"`, matching `client/package.json`.

## On #272 — deliberately not in this PR

`CLAUDE.md` is **explicitly gitignored** (`.gitignore:12`), so it cannot be part of a PR at all.

I've corrected it **in place** instead: ag-grid 29 → 31.3.4, axum 0.5 → 0.7, plus a "Running the FULL app (Docker)" section (the `yarn start` dev server serves no `/api/v1/*` routes, which has cost real debugging time), the newer endpoints, and the audit/parity guards with the warning never to regenerate the parity fixture.

**Whether that file should be tracked is your call, not mine** — someone chose to ignore it, and I'm not going to reverse that by committing it. If you'd like it in the repo, say so and I'll add it properly. Until then the fix is local to this machine, which is worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9