### PR TITLE
fix(#275, #276): stop the wallet dashboard scrolling sideways on phones, and free the app from 100vh

### DIFF
--- a/client/src/components/NodeGridTable/index.scss
+++ b/client/src/components/NodeGridTable/index.scss
@@ -215,6 +215,10 @@
     }
     .chrome-tabs {
         margin-bottom: 6px;
+        // The tab strip is a fixed-width flex row. Let it scroll within the
+        // header rather than widen the whole page (issue #275).
+        max-width: 100%;
+        overflow-x: auto;
     }
 }
 

--- a/client/src/home/Home.scss
+++ b/client/src/home/Home.scss
@@ -8,6 +8,26 @@
 
     padding: 7px 80px;
 
+    // 80px a side is 160px of fixed padding, which left a 215px content box on
+    // a 375px phone. Together with the un-wrappable address below it pinned the
+    // dashboard's content floor at 662px, so every phone scrolled sideways
+    // (issue #275). The wide padding is a desktop look; below the 768px
+    // breakpoint it is just lost space.
+    @media (max-width: 768px) {
+        padding: 7px 16px;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    // The full 35-char t-address is a single unbreakable token, so it rendered
+    // 289px wide and pushed the row's right edge past the viewport. Let it
+    // break rather than overflow -- the footer solves the same problem by
+    // eliding.
+    a {
+        overflow-wrap: anywhere;
+        word-break: break-all;
+    }
+
     color: var(--text-secondary);
 }
 

--- a/client/src/main/MainApp.scss
+++ b/client/src/main/MainApp.scss
@@ -8,6 +8,26 @@
 
     padding: 7px 80px;
 
+    // 80px a side is 160px of fixed padding, which left a 215px content box on
+    // a 375px phone. Together with the un-wrappable address below it pinned the
+    // dashboard's content floor at 662px, so every phone scrolled sideways
+    // (issue #275). The wide padding is a desktop look; below the 768px
+    // breakpoint it is just lost space.
+    @media (max-width: 768px) {
+        padding: 7px 16px;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    // The full 35-char t-address is a single unbreakable token, so it rendered
+    // 289px wide and pushed the row's right edge past the viewport. Let it
+    // break rather than overflow -- the footer solves the same problem by
+    // eliding.
+    a {
+        overflow-wrap: anywhere;
+        word-break: break-all;
+    }
+
     color: #495057;
     @include rule-mode-dark() {
         color: rgb(181, 175, 166);

--- a/client/src/main/WalletNodes/Projection.scss
+++ b/client/src/main/WalletNodes/Projection.scss
@@ -4,7 +4,11 @@
     padding: 20px;
 
     height: 100%;
-    min-width: 410px;
+    // Was a flat `min-width: 410px`, which is wider than every phone viewport
+    // and so bled ~40px off the right edge (issue #275). min() keeps the 410px
+    // floor wherever there is room for it and yields to the container when
+    // there isn't.
+    min-width: min(410px, 100%);
     border-radius: 8px;
 }
 

--- a/client/src/main/WalletNodes/index.scss
+++ b/client/src/main/WalletNodes/index.scss
@@ -94,6 +94,15 @@
 .cta-button-wrapper {
     display: flex;
     gap: 5px;
+
+    // Holds the IP filter input plus Clear/Reset/Refresh/fullscreen -- ~426px
+    // of controls in a row that could not wrap, which was the last thing
+    // pushing the dashboard wider than a 320px phone (issue #275).
+    // Wrapping takes this row from ~426px to ~239px, which clears the overflow
+    // at 375px and up. A residual 8px remains at 320px; see issue #275.
+    @media (max-width: 480px) {
+        flex-wrap: wrap;
+    }
 }
 
 /* ============================ */

--- a/client/src/styles/_global.scss
+++ b/client/src/styles/_global.scss
@@ -81,10 +81,22 @@ code {
 }
 
 #root {
-    min-width: 100vw;
+    // 100vh on iOS Safari is the LARGE viewport -- the height the page would
+    // have if the URL bar were hidden. With the bar actually on screen the
+    // real area is ~60-110px shorter, so the bottom of #root (and therefore
+    // .App's bottom edge, where the sticky footer lives) sat below the fold
+    // with body and #root both overflow: hidden -- unreachable by scrolling.
+    // That is issue #246's symptom arriving by a second route, iOS-only.
+    // dvh tracks the DYNAMIC viewport instead; the vh line stays as the
+    // fallback for anything that doesn't understand dvh (issue #276).
     min-height: 100vh;
-    width: 100vw;
+    min-height: 100dvh;
     height: 100vh;
+    height: 100dvh;
+    // 100vw includes the scrollbar gutter, which forced a few px of
+    // horizontal overflow on desktop. 100% is the width we actually want.
+    min-width: 100%;
+    width: 100%;
     overflow: hidden;
 }
 


### PR DESCRIPTION
Closes #275. Addresses #276 (the iOS half needs a real device to confirm — see below).

Browser QA across 320–1440 px in a real viewport found the wallet dashboard
(`/nodes`, `/demo`) demanding a constant **662 px** of width no matter how narrow
the window got, so every phone scrolled the whole dashboard sideways.

## #275 — three causes

| | cause | fix |
|---|---|---|
| 1 | `.addrview` hard-coded `padding: 7px 80px` — 160 px of fixed padding, leaving a 215 px content box on a 375 px phone | 16 px below the 768 px breakpoint |
| 2 | the 35-char t-address rendered as a bare `<a>` with `word-break: normal` — one unbreakable **289 px** token, which set the 662 px floor on its own | wraps |
| 3 | `.proj-card` had a flat `min-width: 410px`, wider than every phone viewport | `min(410px, 100%)` |

Plus the grid header: `.cta-button-wrapper` (IP filter + Clear/Reset/Refresh/fullscreen,
~426 px, non-wrapping) and the fixed-width `.chrome-tabs` strip now wrap/scroll below 480 px.

**Result — `.App` horizontal bleed on `/nodes` with a wallet loaded:**

| viewport | before | after |
|---|---|---|
| 320 | 361 px | **8 px** |
| 375 | 306 px | **0** |
| 390 | 291 px | **0** |
| 430 | 251 px | **0** |
| 600 | 81 px | **0** |
| 768 / 1024 / 1440 | 0 | **0** |

The 8 px residual at 320 px is not fixed; it is measured and recorded on #275.

## #276 — `100vh`

`#root` was pinned to `height: 100vh`. On iOS Safari `100vh` is the *large*
viewport — the height the page would have with the URL bar hidden. With the bar
on screen the real area is ~60–110 px shorter, so the bottom of `#root` sat below
the fold. With `body` and `#root` both `overflow: hidden`, and `.App` being
`height: 100%` of that, the footer was unreachable by scrolling: issue #246's
symptom arriving by a second, iOS-only route.

Now `100dvh`, with the `100vh` line kept ahead of it as the fallback. Also
`width: 100vw` → `100%`, since `100vw` includes the scrollbar gutter.

**This half is not confirmed on hardware.** It is read from the CSS and from
documented iOS viewport behaviour; desktop Chrome has static browser chrome, so
the bug cannot reproduce there. The change is safe regardless (`dvh` is iOS
Safari 15.4+, and the `vh` fallback stays), but #276 should stay open until
someone loads it on a real iPhone.

## Verification

Against a production container (`TESTING=true`) in a real viewport:

- **Node page regression**, wallet `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`:
  settles at **127 rows, all NIMBUS**, Cumulus 0 / Stratus 0, Total Nodes 127 —
  the documented baseline.
- **Monthly projection $2,454.09 reconciles to the D1 reference**:
  6.2803738 FLUX/day ×2 (`CC_PA_REWARD = 100` makes `pa_amount == payment_amount`,
  issue #205) ×127 nodes ×30 days ×$0.0513 = $2,455.
- **D1 calculation audit: AGREE**, `compare.py` exit 0.
- Client suite **762 passed, 6 skipped, 0 failed**; production build clean.
- `dvh`, the `100vh` fallback and `min(410px,100%)` all confirmed present in the
  minified CSS.
- All four Analytics tabs, `/home`, `/live` and `/guide` measured 0 bleed at
  390 px both before and after — this was specific to the wallet dashboard.

CSS only; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
