### PR TITLE
feat(#242): reward-reduction countdown and a "what supporters unlock" panel on Home

### DIFF
--- a/client/src/donor/donorPitch.js
+++ b/client/src/donor/donorPitch.js
@@ -1,0 +1,80 @@
+import { DONOR_THRESHOLD_FLUX } from 'donor/config';
+
+/*
+ * Copy and figures for the Home page's donor panel (issue #242).
+ *
+ * Pure and data-only -- it takes the store Home already has and returns
+ * strings. No fetching: every number here comes from data the page has
+ * loaded anyway, so the panel costs nothing to render and cannot be the
+ * reason Home is slow.
+ *
+ * The point of the teasers is to show the SIZE of what sits behind the
+ * gate without showing the thing itself. "6,366 nodes across 54 countries"
+ * is a reason to want the map; it is not the map.
+ */
+
+const fmt = (n) => Math.round(n).toLocaleString('en-US');
+
+/*
+ * The donor threshold in FLUX, with a dollar figure at the CURRENT price
+ * rather than a hardcoded one -- the user's explicit ask, and the only
+ * honest way to state it when FLUX moves.
+ *
+ * Falls back to the bare FLUX figure when the price has not loaded or is
+ * nonsense. A cost line reading "10 FLUX ~ $0.00" is worse than one that
+ * simply doesn't mention dollars.
+ */
+export function formatDonorCost(fluxPriceUsd) {
+  const price = Number(fluxPriceUsd);
+  if (!Number.isFinite(price) || price <= 0) return `${DONOR_THRESHOLD_FLUX} FLUX`;
+  return `${DONOR_THRESHOLD_FLUX} FLUX \u2248 $${(DONOR_THRESHOLD_FLUX * price).toFixed(2)}`;
+}
+
+// Exported so the panel's layout can be reasoned about without calling the
+// builder, and so a test can assert the set never silently changes shape.
+export const DONOR_HIGHLIGHT_KEYS = ['worldMap', 'appEcosystem', 'chainActivity', 'nodeDetail', 'live'];
+
+export function donorHighlights({ gstore, countryCounts } = {}) {
+  const store = gstore || {};
+  const totalNodes = Number(store.node_count?.total) || 0;
+  const countries = countryCounts ? Object.keys(countryCounts).length : 0;
+
+  const categories = store.runningCategoryMap;
+  const instances = categories
+    ? Object.values(categories).reduce((sum, n) => sum + (Number(n) || 0), 0)
+    : 0;
+
+  return [
+    {
+      key: 'worldMap',
+      title: 'World map & continent breakdown',
+      teaser:
+        totalNodes > 0 && countries > 0
+          ? `${fmt(totalNodes)} nodes across ${fmt(countries)} countries`
+          : 'Every node placed on the map, by country and continent',
+    },
+    {
+      key: 'appEcosystem',
+      title: 'App ecosystem & top hosted apps',
+      teaser:
+        instances > 0
+          ? `${fmt(instances)} app instances running right now`
+          : 'What the network is actually running, by category',
+    },
+    {
+      key: 'chainActivity',
+      title: 'Chain activity & your 7-day ledger',
+      teaser: 'Node rewards, exchange moves and transfers, split apart',
+    },
+    {
+      key: 'nodeDetail',
+      title: 'Achievements & per-node apps',
+      teaser: 'For every node in your wallet, on the nodes page',
+    },
+    {
+      key: 'live',
+      title: 'Live chain view',
+      teaser: 'Blocks and payouts as they land',
+    },
+  ];
+}

--- a/client/src/donor/donorPitch.test.js
+++ b/client/src/donor/donorPitch.test.js
@@ -1,0 +1,64 @@
+import { formatDonorCost, donorHighlights, DONOR_HIGHLIGHT_KEYS } from 'donor/donorPitch';
+import { DONOR_THRESHOLD_FLUX } from 'donor/config';
+
+describe('formatDonorCost', () => {
+  test('converts the donor threshold at the live FLUX price', () => {
+    // 10 FLUX x $0.0513 = $0.513
+    expect(formatDonorCost(0.0513)).toBe(`${DONOR_THRESHOLD_FLUX} FLUX \u2248 $0.51`);
+  });
+
+  test('tracks the price rather than hardcoding a dollar figure', () => {
+    expect(formatDonorCost(0.25)).toBe(`${DONOR_THRESHOLD_FLUX} FLUX \u2248 $2.50`);
+  });
+
+  test.each([0, null, undefined, NaN, -1])(
+    'omits the dollar figure when the price is unusable (%p)',
+    (price) => {
+      expect(formatDonorCost(price)).toBe(`${DONOR_THRESHOLD_FLUX} FLUX`);
+    }
+  );
+});
+
+describe('donorHighlights', () => {
+  const gstore = {
+    node_count: { total: 6366 },
+    runningCategoryMap: { Computing: 2219, Enterprise: 1832, Blockchain: 1157 },
+  };
+  const countryCounts = { US: 900, DE: 700, AU: 42 };
+
+  const byKey = (list, key) => list.find((h) => h.key === key);
+
+  test('puts the live node and country counts in the map teaser', () => {
+    const teaser = byKey(donorHighlights({ gstore, countryCounts }), 'worldMap').teaser;
+    expect(teaser).toContain('6,366');
+    expect(teaser).toContain('3 countries');
+  });
+
+  test('falls back to generic copy when country data has not arrived', () => {
+    const teaser = byKey(donorHighlights({ gstore, countryCounts: {} }), 'worldMap').teaser;
+    expect(teaser).not.toContain('0 countries');
+    expect(teaser.length).toBeGreaterThan(0);
+  });
+
+  test('sums the running-app categories into the ecosystem teaser', () => {
+    // 2219 + 1832 + 1157 = 5208
+    expect(byKey(donorHighlights({ gstore, countryCounts }), 'appEcosystem').teaser).toContain('5,208');
+  });
+
+  test('falls back when the running-app map has not arrived', () => {
+    const bare = { node_count: { total: 6366 } };
+    const teaser = byKey(donorHighlights({ gstore: bare, countryCounts }), 'appEcosystem').teaser;
+    expect(teaser).not.toContain('0 ');
+    expect(teaser.length).toBeGreaterThan(0);
+  });
+
+  test('returns a stable set of highlights so the panel does not reflow', () => {
+    const keys = donorHighlights({ gstore, countryCounts }).map((h) => h.key);
+    expect(keys).toEqual(DONOR_HIGHLIGHT_KEYS);
+  });
+
+  test('survives a completely empty store', () => {
+    const keys = donorHighlights({ gstore: {}, countryCounts: null }).map((h) => h.key);
+    expect(keys).toEqual(DONOR_HIGHLIGHT_KEYS);
+  });
+});

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -18,6 +18,12 @@ import { CC_COLLATERAL_CUMULUS, CC_COLLATERAL_NIMBUS, CC_COLLATERAL_STRATUS } fr
 import { AppEcosystemBreakdown } from 'components/AppEcosystemBreakdown';
 import { TopHostedApps } from 'components/TopHostedApps';
 import { fluxos_version_string, daemon_version_string } from 'main/flux_version';
+import { useNavigate } from 'react-router-dom';
+import { RewardCountdown } from 'rewards/RewardCountdown';
+import { hasScheduledReduction } from 'rewards/rewardReduction';
+import { CC_BLOCK_REWARD, CC_NEXT_BLOCK_REWARD } from 'content/index';
+import { formatDonorCost, donorHighlights } from 'donor/donorPitch';
+import { useDonorStatus } from 'contexts/DonorContext';
 
 // ── Format helpers ─────────────────────────────────────────────────────────────
 
@@ -560,6 +566,88 @@ function CommunitySupportPanel({ donations, donationsSettled, donationsFailed })
   );
 }
 
+/*
+ * The next block-reward reduction, as a full-width band above the panels
+ * (issue #242).
+ *
+ * Reuses rewards/RewardCountdown rather than building a second clock -- the
+ * same component the Analytics donor tab renders. It sits at the top because
+ * it is a network-wide deadline that changes every operator's earnings, and
+ * it removes itself once no reduction is scheduled.
+ *
+ * The band states the two reward figures and deliberately does NOT restate
+ * them as a percentage. 14 -> 12.6 is both a 10% cut and 11.1% higher than
+ * the new figure depending on which way you read it; rewards/rewardReduction
+ * has a long note on that confusion, and Analytics' REWARD REDUCTION IMPACT
+ * panel is where the derived numbers belong.
+ */
+function RewardReductionBand({ gstore }) {
+  const currentBlock = gstore?.current_block_height || 0;
+  if (!hasScheduledReduction(currentBlock)) return null;
+
+  return (
+    <div className="hov-panel hov-panel--reward-band">
+      <RewardCountdown currentBlock={currentBlock} compact />
+      <div className="hov-reward-delta">
+        Block reward falls from <strong>{CC_BLOCK_REWARD}</strong> to{' '}
+        <strong>{CC_NEXT_BLOCK_REWARD} FLUX</strong> per block
+      </div>
+    </div>
+  );
+}
+
+/*
+ * What donating unlocks, with the real cost (issue #242).
+ *
+ * Informational rather than promotional, per the user's explicit direction --
+ * it sits on a public page that is otherwise all data, and reads as "here is
+ * what else exists" rather than a sales pitch.
+ *
+ * Each row shows the SIZE of what is behind the gate without showing the
+ * thing itself, using figures Home has already loaded (donor/donorPitch has
+ * the reasoning). The cost is converted at the live FLUX price rather than
+ * hardcoded, which is the only honest way to state it when FLUX moves.
+ *
+ * Renders nothing for someone who has already unlocked -- there is nothing
+ * left to tell them.
+ */
+function DonorPitchPanel({ gstore, countryCounts }) {
+  const donor = useDonorStatus();
+  const navigate = useNavigate();
+
+  if (donor?.isUnlocked) return null;
+
+  const cost = formatDonorCost(gstore?.flux_price_usd);
+  const highlights = donorHighlights({ gstore, countryCounts });
+
+  return (
+    <div className="hov-panel hov-panel--pitch">
+      <PanelHeader
+        title="WHAT SUPPORTERS UNLOCK"
+        badgeContent={<span className="hov-header-badge hov-pitch-cost-badge">{cost}</span>}
+      />
+
+      <div className="hov-pitch-list">
+        {highlights.map(({ key, title, teaser }) => (
+          <div key={key} className="hov-pitch-row">
+            <span className="hov-pitch-title">{title}</span>
+            <span className="hov-pitch-teaser">{teaser}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="hov-pitch-foot">
+        <span className="hov-pitch-terms">
+          We look for <strong>{cost}</strong> sent to the donation address within the last year.
+        </span>
+        <button type="button" className="hov-pitch-demo" onClick={() => navigate('/demo')}>
+          See it on the demo wallet
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ── Main export ───────────────────────────────────────────────────────────────
 
 export function HomeOverview({
@@ -574,6 +662,7 @@ export function HomeOverview({
 }) {
   return (
     <div className="home-overview">
+      <RewardReductionBand gstore={gstore} />
       <div className="home-overview-row">
         <NetworkStatsPanel gstore={gstore} gpuPrices={gpuPrices} />
         <NetworkResourcesPanel gstore={gstore} />
@@ -584,6 +673,7 @@ export function HomeOverview({
         donationsSettled={donationsSettled}
         donationsFailed={donationsFailed}
       />
+      <DonorPitchPanel gstore={gstore} countryCounts={countryCounts} />
       <TopHostedApps gstore={gstore} />
       {SHOW_FLUX_AI_PANEL && <FluxAIPanel gpuPrices={gpuPrices} />}
       <GeoDistributionPanel

--- a/client/src/home/HomeOverview/index.scss
+++ b/client/src/home/HomeOverview/index.scss
@@ -655,3 +655,160 @@
     }
   }
 }
+
+// ── Reward reduction band (issue #242) ───────────────────────────────────────
+// Full-width strip above the panel row. Borrows the panel chrome so it reads as
+// part of the same family, but centres its contents rather than laying out a
+// header + body, because the countdown is the whole point of it.
+
+.hov-panel--reward-band {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+
+  // space-between across a full-width page would fling the four digits into
+  // the corners. The clock reads as a unit at this width.
+  .rwc-timer {
+    margin: 0;
+    width: 100%;
+    max-width: 560px;
+    // It already sits inside .hov-panel's border; a second one around the
+    // clock is chrome for its own sake.
+    border: none;
+  }
+
+  // PayoutTimer's spacing is built for a panel of its own on the node page,
+  // where the clock is the subject. Here it is a band above the real content,
+  // and at its native size it stood 247px tall and pushed everything below the
+  // fold. Scoped to this band so the node page and the Analytics donor tab
+  // keep the original rhythm.
+  .timer-header {
+    padding: 10px 14px 2px;
+  }
+
+  .timer-number {
+    margin-top: 4px;
+  }
+
+  .timer-info {
+    margin-top: 2px;
+    margin-bottom: 8px;
+  }
+
+  .v-rule {
+    margin: 8px 5px;
+  }
+
+  .hov-reward-delta {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    text-align: center;
+
+    strong {
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      color: var(--text-primary, inherit);
+    }
+  }
+}
+
+// ── What supporters unlock (issue #242) ──────────────────────────────────────
+// Informational, not promotional: no accent fills, no oversized CTA. The rows
+// are a two-column list -- what you get on the left, how big it is on the
+// right -- so the eye can scan either column on its own.
+
+.hov-panel--pitch {
+  margin-top: 12px;
+
+  .hov-pitch-cost-badge {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .hov-pitch-list {
+    display: flex;
+    flex-direction: column;
+    padding-top: 4px;
+  }
+
+  .hov-pitch-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 7px 0;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid rgba(128, 128, 128, 0.12);
+    }
+  }
+
+  .hov-pitch-title {
+    font-size: 0.84rem;
+    font-weight: 600;
+  }
+
+  .hov-pitch-teaser {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hov-pitch-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(128, 128, 128, 0.14);
+  }
+
+  .hov-pitch-terms {
+    font-size: 0.76rem;
+    color: var(--text-secondary);
+
+    strong {
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      color: var(--text-primary, inherit);
+    }
+  }
+
+  // A link that happens to be a button, not a call-to-action slab.
+  .hov-pitch-demo {
+    flex: 0 0 auto;
+    font-size: 0.76rem;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-primary);
+    background: var(--surface-inset);
+    color: var(--text-secondary, inherit);
+    cursor: pointer;
+    transition: border-color var(--transition-base), color var(--transition-base);
+
+    &:hover {
+      border-color: var(--border-hover);
+      color: var(--text-primary, inherit);
+    }
+  }
+
+  // Stacking the rows keeps both columns readable instead of crushing the
+  // teaser into two words a line.
+  @media (max-width: 720px) {
+    .hov-pitch-row {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 2px;
+    }
+
+    .hov-pitch-teaser {
+      text-align: left;
+    }
+  }
+}

--- a/client/src/rewards/RewardCountdown/index.scss
+++ b/client/src/rewards/RewardCountdown/index.scss
@@ -1,9 +1,22 @@
 // Countdown to the next block-reward reduction (issue #240).
 //
-// The .timer / .timer-blocks / .timer-block / .v-rule structure is inherited
-// from main/PayoutTimer's stylesheet, which is already global. Only the
-// differences live here: this clock counts down to a cut rather than a payout,
-// so it carries a warning accent instead of the payout styling.
+// The .timer / .timer-blocks / .timer-block / .v-rule structure comes from
+// main/PayoutTimer's stylesheet. That sheet was assumed to be global; it is
+// not. It ships in the route chunk of the only component that imports it
+// (main/MainApp -> PayoutTimer), so on /home -- which never loads that chunk --
+// every one of those rules was missing and the clock rendered as four stacked
+// numbers against the left edge (issue #242).
+//
+// Importing it here makes the dependency explicit and travels with the
+// component wherever it is mounted. The alternative, hoisting the rules into
+// styles/_global.scss, would put `.timer-header .title` (payout pink) into an
+// equal-specificity, source-order fight with `.rwc-title` (amber) -- a cascade
+// risk on the node page for no gain. The duplicated rules are byte-identical,
+// so the node page's cascade is untouched.
+@import 'main/PayoutTimer/index.scss';
+
+// Only the differences live below: this clock counts down to a cut rather than
+// a payout, so it carries a warning accent instead of the payout styling.
 
 .rwc-timer {
   width: 100%;
@@ -13,6 +26,18 @@
     align-items: center;
     gap: 6px;
     color: var(--accent-amber, #f59e0b);
+  }
+
+  // PayoutTimer styles its title payout-pink through a dark-mode rule --
+  // `.app-mode-dark .timer-header .title`, which is (0,3,0) and outranks the
+  // (0,2,0) declaration above. The title carries BOTH classes, so in dark mode
+  // this clock inherited the payout colour and announced a reward cut in the
+  // same pink as a reward arriving. Matching the specificity puts the warning
+  // accent back.
+  @include rule-mode-dark() {
+    .rwc-title {
+      color: var(--accent-amber, #f59e0b);
+    }
   }
 
   // The reduction is bad news for the operator; the digits say so without


### PR DESCRIPTION
Closes #242.

Two additions to Home, both reusing what already exists rather than building
parallel versions of it.

## Reward-reduction countdown

A full-width band directly under the wallet input, above the panel row — the
placement you picked. It mounts `rewards/RewardCountdown`, the same component
the Analytics donor tab renders, so there is still only one clock in the
codebase.

It states the two reward figures and deliberately **does not** restate them as
a percentage. 14 → 12.6 is both a 10% cut and 11.1% higher than the new figure
depending on which way you read it; `rewards/rewardReduction` carries a long
note on exactly that confusion, and Analytics' REWARD REDUCTION IMPACT panel is
where the derived numbers belong. The band removes itself once no reduction is
scheduled, so it cannot outlive the event.

## What supporters unlock

Informational rather than promotional, as you asked — it sits on a public page
that is otherwise all data.

Five rows naming what is behind the donor gate, each carrying a figure that
shows the **size** of it rather than the thing itself. "6,367 nodes across 57
countries" is a reason to want the map; it is not the map. Every number comes
from data Home already loads, so the panel adds no fetch and cannot be the
reason Home is slow. It renders nothing for someone who has already unlocked.

The cost reads **`10 FLUX ≈ $0.52`**, converted at the live FLUX price rather
than hardcoded — your explicit ask. It degrades to a bare `10 FLUX` when the
price hasn't loaded, because "≈ $0.00" is worse than no dollars at all.

The footer restates the terms plainly and links to `/demo`, which covers the
issue's "demo some of the top features using the Demo address".

New pure module `donor/donorPitch.js` (`formatDonorCost`, `donorHighlights`),
built test-first. Both mutations checked: dropping the price branch fails
exactly 2 tests, ignoring `countryCounts` fails exactly 1.

## Two latent bugs this surfaced

**`.timer` styles were never global.** `RewardCountdown`'s stylesheet asserted
that PayoutTimer's `.timer` / `.timer-blocks` / `.v-rule` rules were "already
global". They are not — that sheet ships in the route chunk of the only
component importing it (`main/MainApp` → `PayoutTimer`), so on `/home` the clock
rendered as four numbers stacked against the left edge. `RewardCountdown` now
imports the sheet itself, so the dependency is explicit and travels with the
component. Hoisting the rules into `styles/_global.scss` was the alternative and
was rejected: it would put `.timer-header .title` (payout pink) into a
specificity fight with `.rwc-title` on the node page, for no gain.

**The countdown was pink in dark mode.** That import then exposed a
pre-existing defect: PayoutTimer colours its title through
`.app-mode-dark .timer-header .title`, which at (0,3,0) outranks
`.rwc-timer .rwc-title` at (0,2,0). The title carries both classes, so in dark
mode this clock announced a reward **cut** in the same pink as a reward
**arriving**. Matching the specificity restores the warning accent — on the
Analytics donor tab too, where it was presumably also wrong.

## Verification

Against a production container:

- Band and panel both render with live data — countdown at 44d, cost
  `10 FLUX ≈ $0.52`, `6,367 nodes across 57 countries`, `7,952 app instances
  running right now`.
- Fallbacks confirmed on a cold load: bare `10 FLUX`, generic teaser copy, and
  no band at block 0.
- Countdown title and digits amber in dark mode (`rgb(224,146,5)`) and in light.
- **Node page unchanged**: payout timer still pink (`rgb(245,73,139)`),
  `.timer-blocks` still `inline-flex`, no band on `/nodes`.
- **Node page regression**, wallet `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`:
  settles at **127 rows, all NIMBUS**, Cumulus 0 / Stratus 0, Total Nodes 127.
- 0 horizontal bleed at 390 and 1440; rows stack on mobile.
- **D1 calculation audit: AGREE**, `compare.py` exit 0.
- Client suite **776 passed, 5 skipped, 0 failed** (+13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
