### PR TITLE
fix(#273): TOP HOSTED APPS shows 20 rows, and fills the panel it was given

### DIFF
--- a/client/src/analytics/AppsTab/index.scss
+++ b/client/src/analytics/AppsTab/index.scss
@@ -595,3 +595,16 @@
   font-size: 0.6em;
   opacity: 0.7;
 }
+
+/* Panels in a grid row stretch to the tallest of them, and TOP NODE OPERATORS
+   at 20 rows sets that height. TopHostedApps' list carries a fixed 380px
+   height chosen for its /home placement, so inside this grid it stopped short
+   and left a block of empty space below itself -- the visible half of issue
+   #273, which raising the row count alone does not fix.
+
+   Scoped to this grid so /home keeps its compact 380px scroller. */
+.apps-tab-panel-grid .hov-panel--top-apps .hov-ranked-list {
+  height: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/client/src/runningAppsCategorized.js
+++ b/client/src/runningAppsCategorized.js
@@ -100,9 +100,18 @@ export function categorizeRunningApps(aggregate, specIndex) {
     }
   }
 
+  // 20 rather than 10 (issue #273). TOP NODE OPERATORS and TOP APP OWNERS sit
+  // beside this panel at 20, and #248's uniform 665x738 sizing turned the
+  // shorter list into a visible block of empty space that read as missing data.
+  //
+  // Checked against live network data before changing it, because a longer list
+  // is only an improvement if the extra rows say something: the 20th row still
+  // carried 51 instances (mysql 119, blockbook-docker 114, alpine-mongo 66,
+  // minecraft-server 52, rusty-kaspad 51). That tail is real apps, not
+  // single-instance filler.
   const topRunningApps = Object.entries(repoCounts)
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 10)
+    .slice(0, 20)
     .map(([image, nodeCount]) => ({ image, nodeCount }));
 
   // Count streamr/presearch once per NODE that hosts them (from nodesByIp).

--- a/client/src/runningAppsCategorized.test.js
+++ b/client/src/runningAppsCategorized.test.js
@@ -50,6 +50,36 @@ describe('categorizeRunningApps', () => {
     expect(totalRunningApps).toBe(8); // sum of every nameCounts value, unknownApp included
   });
 
+  /*
+   * The list is capped so the panel has a fixed length. 20 rather than 10
+   * (issue #273): TOP NODE OPERATORS and TOP APP OWNERS sit beside it at 20,
+   * and #248's uniform 665x738 panel made the shorter list read as missing
+   * data. Checked against live network data before changing it -- the 20th
+   * row still carried 51 instances (mysql 119, blockbook 114, minecraft 52,
+   * rusty-kaspad 51), so the tail is real apps, not single-instance filler.
+   */
+  it('caps topRunningApps at 20 rows', () => {
+    const manyNames = {};
+    const manyComponents = {};
+    const manySpecs = {};
+    // 30 distinct repotags, descending popularity, so a cap of 20 is visible.
+    for (let i = 0; i < 30; i++) {
+      const name = `app${i}`;
+      manyNames[name] = 30 - i;
+      manyComponents[`${name}\u0000`] = 30 - i;
+      manySpecs[name] = { repotag: `vendor/image${i}:latest`, category: 'computing' };
+    }
+    const { topRunningApps } = categorizeRunningApps(
+      { nameCounts: manyNames, componentCounts: manyComponents, nodesByIp: {} },
+      manySpecs
+    );
+
+    expect(topRunningApps).toHaveLength(20);
+    // Still ranked, and still the most popular 20 rather than an arbitrary 20.
+    expect(topRunningApps[0].image).toBe('vendor/image0:latest');
+    expect(topRunningApps[19].image).toBe('vendor/image19:latest');
+  });
+
   it('ranks topRunningApps by repotag popularity, most-instances first', () => {
     const { topRunningApps } = categorizeRunningApps(aggregate, specIndex);
     const folding = topRunningApps.find((r) => r.image === 'yurinnick/folding-at-home:latest');


### PR DESCRIPTION
Closes #273.

The issue asked whether 10 rows was an editorial choice or a defect, and said
to look at what rows 11–20 actually contain first, since *"ten meaningful rows
may genuinely be better than twenty where half are single-instance apps"*.

## Checked against live data

| | app | instances |
|---|---|---|
| #11 | `mysql` | 119 |
| #12 | `runonflux/blockbook-docker` | 114 |
| #13 | `runonflux/wp-nginx` | 88 |
| #14 | `mvertes/alpine-mongo` | 66 |
| #15 | `teammakdi/makdi` | 61 |
| #16 | `runonflux/explorer` | 60 |
| #17 | `thijsvanloef/palworld-server-docker` | 52 |
| #18 | `itzg/minecraft-server` | 52 |
| #19 | `piwnik/themok` | 51 |
| #20 | `kaspanet/rusty-kaspad` | 51 |

The 20th row still carries **51 instances**, and the rows name things worth
knowing the network runs. Not filler — so raised to 20, matching TOP NODE
OPERATORS and TOP APP OWNERS beside it.

## The empty space had a second cause

Raising the count alone does **not** fix what the issue actually complains
about. `.hov-panel--top-apps .hov-ranked-list` carries a fixed
`height: 380px`, chosen for the panel's `/home` placement. Inside the Analytics
grid the panels stretch to the tallest in their row — 789px, set by TOP NODE
OPERATORS — so the list stopped at 380 and left ~300px empty below itself, with
10 rows *or* 20.

The list now takes the height the grid has already given the panel, scoped to
`.apps-tab-panel-grid` so `/home` keeps its compact scroller.

## Verification

- **Analytics**: all 20 rows render, list `clientHeight === scrollHeight` (no
  internal scrollbar, no gap), panel 789px matching TOP NODE OPERATORS exactly.
- **`/home`**: unchanged — still a 380px scroller in a 498px panel, with 20 rows
  now reachable by scrolling instead of 10.
- The row cap had no test; added one test-first, failing at 10-vs-20 before the
  change.
- **Node page regression**, wallet `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`:
  settles at **127 rows, all NIMBUS**, Cumulus 0 / Stratus 0, Total Nodes 127.
- **D1 calculation audit: AGREE**, `compare.py` exit 0.
- Client suite **779 passed, 5 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
