### PR TITLE
fix(#280): re-poll the Chain Activity sync status instead of freezing it at mount

### DIFF
--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, blocksRemainingInScan, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel } from 'analytics/chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, blocksRemainingInScan, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel, shouldPollSync, SYNC_POLL_INTERVAL_MS } from 'analytics/chainActivity';
 import { shouldFetchDrilldown, stateAfterCancel } from './drilldownState';
 import './index.scss';
 
@@ -330,21 +330,49 @@ export function ChainActivityTab({ theme = 'dark' }) {
   const [drilldownOpen, setDrilldownOpen] = useState(false);
   const toggleDrilldown = () => setDrilldownOpen((v) => !v);
 
+  /*
+   * Mirrors the latest sync status for the interval below to read (issue #280).
+   *
+   * A ref rather than state, with the effect kept on [] deps. Reading reactive
+   * state from a polling effect is exactly what caused the ~290,000-request
+   * runaway in the drilldown effect -- status changed, the effect re-ran, its
+   * cleanup reset status, and round it went. The shape that fixed that one is
+   * the shape used here: nothing reactive in the dependency array.
+   */
+  const syncStatusRef = useRef(null);
+
   useEffect(() => {
     let cancelled = false;
 
-    (async () => {
+    const load = async () => {
       const result = await fetch_chain_activity();
       if (cancelled) return;
+      syncStatusRef.current = result.syncStatus;
       setData(result);
       setLoading(false);
-    })().catch(() => {
+    };
+
+    load().catch(() => {
       // fetch_chain_activity() already fails soft to empty defaults — this is
       // defensive only, matching NetworkTab's own equivalent comment.
       if (!cancelled) setLoading(false);
     });
 
-    return () => { cancelled = true; };
+    /*
+     * Without this the banner asserts its mount-time status for as long as the
+     * tab stays open -- which is worst in the case it exists for, since it asks
+     * the user to wait out a backfill and then never reports the outcome.
+     * Stops for good once the scanner is caught up.
+     */
+    const id = setInterval(() => {
+      if (!shouldPollSync(syncStatusRef.current)) {
+        clearInterval(id);
+        return;
+      }
+      load().catch(() => {});
+    }, SYNC_POLL_INTERVAL_MS);
+
+    return () => { cancelled = true; clearInterval(id); };
   }, []);
 
   if (loading) {

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -125,6 +125,28 @@ export function scanProgressPct({ lastScannedHeight, scanStartHeight, scanTarget
   return Math.round((done / span) * 100);
 }
 
+/*
+ * How often the tab re-reads sync status, and whether it should bother
+ * (issue #280).
+ *
+ * The banner used to be a one-shot snapshot taken at mount, so it went on
+ * saying "Sync is running -- a first-time backfill can take several minutes"
+ * while the backend had already moved to `stalled`. Measured on a production
+ * container: the API reported `last_outcome: "stalled"` with a frozen
+ * `last_scanned_height` while the banner still showed the reassuring --info
+ * tone, ten minutes in.
+ *
+ * 'caught_up' is the one terminal state: the scanner is level with the tip and
+ * the copy will not change again, so polling past it is pure waste. Every other
+ * status -- including 'stalled' -- stays live, because a stall can recover and
+ * the user should see that without reloading the page.
+ */
+export const SYNC_POLL_INTERVAL_MS = 30_000; // one block target
+
+export function shouldPollSync(syncStatus) {
+  return syncStatus !== 'caught_up';
+}
+
 // "Xm ago"/"Xh ago"/"Xd ago" for the sync-status banner. A local helper
 // rather than reusing live/timeFormat.js's relativeTime: that one only
 // covers seconds/minutes (block timestamps are always within a couple

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,6 +1,5 @@
 import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel,
-  blocksRemainingInScan
-} from './chainActivity';
+  blocksRemainingInScan, shouldPollSync } from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
@@ -358,5 +357,32 @@ describe('blocksRemainingInScan', () => {
   it('is zero when there is no range yet', () => {
     // run_scan_cycle writes InProgress BEFORE it knows the range.
     expect(blocksRemainingInScan({ lastScannedHeight: 0, scanStartHeight: 0, scanTargetHeight: 0 })).toBe(0);
+  });
+});
+
+/*
+ * Issue #280: the banner was a one-shot snapshot, so it kept saying "Sync is
+ * running" long after the backend had moved to "stalled". Re-polling needs a
+ * rule for when to stop, and that rule is the part worth testing -- the effect
+ * around it is wiring.
+ */
+describe('shouldPollSync', () => {
+  test('keeps polling while a scan is running', () => {
+    expect(shouldPollSync('in_progress')).toBe(true);
+  });
+
+  test('keeps polling when the scan has stalled, so recovery is noticed', () => {
+    expect(shouldPollSync('stalled')).toBe(true);
+  });
+
+  test.each(['never_run', 'unreachable', 'api_unreachable', null, undefined])(
+    'keeps polling for the unsettled status %p',
+    (status) => {
+      expect(shouldPollSync(status)).toBe(true);
+    }
+  );
+
+  test('stops once the scanner has caught up, because nothing further changes', () => {
+    expect(shouldPollSync('caught_up')).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #280. Found by driving `/live` and Chain Activity interactively rather
than just measuring their layout.

## The bug

The sync banner was a one-shot snapshot — `useEffect(..., [])`, fetched once at
mount, never again. It kept asserting its mount-time status for as long as the
tab stayed open.

That's worst in the case the banner exists for. Its own copy says *"a
first-time backfill can take several minutes"* — it asks the user to wait, then
never reports the outcome.

Caught by leaving the tab open ~10 minutes and reading the API and the rendered
banner **in the same tick**:

```
api_last_outcome:    "stalled"
api_last_success_at: 0
api_last_scanned:    2920402      ← frozen (had gone 2920442 → 2920402)

bannerText: "Sync is running — a first-time backfill can take several
             minutes. 22,779 blocks remaining in this scan (0%)."
bannerTone: "ca-sync-banner--info"
```

Backend said **stalled**; banner said **running**, in the reassuring `--info`
tone. The block figure was stale too — `scan_start_height` and
`scan_target_height` were both 0 by then, so `blocksRemainingInScan` returns 0
and that number was left over from the mount fetch.

Everything underneath was already right: `chainActivity.js` maps `syncStatus`
straight from `last_outcome`, and the tab has distinct copy and tone per
status. The status just never arrived a second time.

## The fix

Poll every 30s (one block target), stopping for good at `caught_up` — the one
terminal state, where the copy cannot change again. Every other status stays
live, **including `stalled`**, because a stall can recover and the user should
see that without reloading.

### Written to not repeat the runaway

An earlier polling effect here caused a ~290,000-request runaway by resetting
state that was itself a dependency. This mirrors the status in a `useRef` and
keeps the effect on `[]` deps — nothing reactive in the dependency array, the
same shape that fixed that bug and the same shape as the `statusRef` already in
this file. **Request growth was measured, not assumed.**

`shouldPollSync` was built test-first; its 8 cases failed before it existed.

## Verification (browser, production container)

- **Linear request growth**: 1 call at 12s, 2 at 52s, 4 at 92s on a 30s
  interval. (A 5th was my own measurement probe, whose URL matched the counter.)
- **Transition followed without a reload**: driving the payload to `stalled`
  moved the banner within one interval from `--info` "Sync is running…" to
  `--warning` "Sync is behind, possibly rate-limited by the block explorer.
  Last successful update: 2h ago." — picking up `last_success_at` correctly.
- **Polling stops at caught_up**: 1 call across ~57s (nearly two intervals),
  and no banner renders at all, which is right — there's nothing to say.
- **Node page regression**, wallet `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`:
  settles at **127 rows, all NIMBUS**, Cumulus 0 / Stratus 0, Total Nodes 127.
- **D1 calculation audit: AGREE**, `compare.py` exit 0.
- Client suite **787 passed, 5 skipped, 0 failed** (+8).

## Also checked, no change needed

- `/live` chain rail click-through works: clicking #2943160 moved the selection
  and the detail panel to that block's real data (4 rewards, 14.00 FLUX, 9
  confirmations), matching the block's own rail badge.
- `/live`'s "Reward data temporarily unavailable — retrying automatically" on a
  just-arrived block **does** resolve on its own. Transient, not a bug — not
  filed.
- Chain Activity's `SHOW BLOCKS` drill-down opens, toggles, and lists per-block
  rows. Your original "cannot click the utility section" report is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
