### PR TITLE
feat(#285): give the footer's hosted-in location weight and the accent green

### DIFF
--- a/client/src/components/Footer/hostInfo.js
+++ b/client/src/components/Footer/hostInfo.js
@@ -53,6 +53,14 @@ export function formatUptime(seconds) {
  * than the host's kernel uptime. A redeployed app resets the former while the
  * latter keeps climbing, and "up 40 days" under a site that restarted an hour
  * ago is the sort of number nobody can act on.
+ *
+ * Each segment carries a `kind` (issue #285). They were bare strings, which
+ * left the footer no way to emphasise one of them -- "Hosted in Melbourne,
+ * Australia" is the segment that makes the app feel like it is running on
+ * somebody's actual node, and it was carrying exactly the same weight as the
+ * build timestamp. Identifying them here keeps the "a missing field removes
+ * its segment" rule in one place: the component never has to guess which dot
+ * belongs to which fact.
  */
 export function hostInfoSegments(payload) {
   const host = payload?.host;
@@ -61,10 +69,10 @@ export function hostInfoSegments(payload) {
   const segments = [];
 
   const where = formatHostLocation(host.location);
-  if (where) segments.push(`Hosted in ${where}`);
+  if (where) segments.push({ kind: 'location', text: `Hosted in ${where}` });
 
   const uptime = formatUptime(host.appUptimeSeconds);
-  if (uptime) segments.push(`Up ${uptime}`);
+  if (uptime) segments.push({ kind: 'uptime', text: `Up ${uptime}` });
 
   return segments;
 }

--- a/client/src/components/Footer/hostInfo.test.js
+++ b/client/src/components/Footer/hostInfo.test.js
@@ -78,16 +78,38 @@ describe('formatUptime', () => {
 describe('hostInfoSegments', () => {
   const full = { host: { location: { city: 'Helsinki', country: 'Finland' }, appUptimeSeconds: 90000 } };
 
-  it('produces the location and uptime segments', () => {
-    expect(hostInfoSegments(full)).toEqual(['Hosted in Helsinki, Finland', 'Up 1d 1h']);
+  /*
+   * Issue #285 wants the location emphasised, so segments carry a `kind` --
+   * the footer cannot style one of them apart while they are interchangeable
+   * strings joined by a separator.
+   */
+  it('produces the location and uptime segments, each identified', () => {
+    expect(hostInfoSegments(full)).toEqual([
+      { kind: 'location', text: 'Hosted in Helsinki, Finland' },
+      { kind: 'uptime', text: 'Up 1d 1h' },
+    ]);
   });
 
   it('drops the location segment when the lookup failed', () => {
-    expect(hostInfoSegments({ host: { location: null, appUptimeSeconds: 300 } })).toEqual(['Up 5m']);
+    expect(hostInfoSegments({ host: { location: null, appUptimeSeconds: 300 } })).toEqual([
+      { kind: 'uptime', text: 'Up 5m' },
+    ]);
   });
 
   it('drops the uptime segment when it is unavailable', () => {
-    expect(hostInfoSegments({ host: { location: { country: 'Finland' } } })).toEqual(['Hosted in Finland']);
+    expect(hostInfoSegments({ host: { location: { country: 'Finland' } } })).toEqual([
+      { kind: 'location', text: 'Hosted in Finland' },
+    ]);
+  });
+
+  /*
+   * The emphasis must not strand a separator. With no location there is no
+   * location segment at all, so the footer has nothing to hang a stray dot off.
+   */
+  it('leaves no location segment behind when only uptime is known', () => {
+    const segs = hostInfoSegments({ host: { location: {}, appUptimeSeconds: 60 } });
+    expect(segs.some((s) => s.kind === 'location')).toBe(false);
+    expect(segs).toHaveLength(1);
   });
 
   it('is empty when the endpoint gave nothing usable, so the footer is unchanged', () => {

--- a/client/src/components/Footer/index.jsx
+++ b/client/src/components/Footer/index.jsx
@@ -97,10 +97,10 @@ export function Footer() {
                 up. Empty unless the Rust API is deployed, in which case the
                 footer is unchanged.
               */}
-              {hostSegments.map((segment) => (
-                <React.Fragment key={segment}>
+              {hostSegments.map(({ kind, text }) => (
+                <React.Fragment key={kind}>
                   <span className="footer-meta__sep">·</span>
-                  <span className="footer-meta__host">{segment}</span>
+                  <span className={`footer-meta__host footer-meta__host--${kind}`}>{text}</span>
                 </React.Fragment>
               ))}
               {lastUpdated && <span className="footer-meta__sep">·</span>}

--- a/client/src/components/Footer/index.scss
+++ b/client/src/components/Footer/index.scss
@@ -124,6 +124,29 @@
   opacity: 0.4;
 }
 
+/*
+ * "Hosted in Melbourne, Australia" is the most interesting thing in this row --
+ * it is what makes the app feel like it is running on somebody's actual node --
+ * and it was carrying exactly the same weight as the build timestamp (#285).
+ *
+ * Emphasis is only on the location: doing the same to uptime would flatten the
+ * row again, just louder. The green is --accent-green, the same token the rest
+ * of the app uses for a positive value, rather than a fresh literal.
+ *
+ * No stray separator when the geolocation lookup fails: hostInfoSegments drops
+ * the whole segment, so there is no dot left hanging.
+ */
+.footer-meta__host--location {
+  font-weight: 600;
+  color: var(--accent-green);
+
+  @include rule-mode-dark() {
+    // #0ea271 is a touch dark against the footer's own dark ground; this is the
+    // same hue lifted for contrast rather than a different colour.
+    color: #12cc94;
+  }
+}
+
 .footer-meta__updated {
   white-space: nowrap;
 }


### PR DESCRIPTION
Closes #285.

"Hosted in Melbourne, Australia" is the most interesting thing in the footer —
it's what makes the app feel like it's running on somebody's actual node — and
it was rendering at exactly the same weight and colour as the build timestamp.

Now 600-weight and `--accent-green`, the token the rest of the app already uses
for a positive value, rather than a new literal. Dark mode lifts the same hue to
`#12cc94` for contrast against the footer's own dark ground.

**Only the location.** Emphasising uptime as well would flatten the row again,
just louder.

## The shape change that made it possible

`hostInfoSegments` returned bare strings joined by a separator, so the component
had no way to style one apart from the others. Each segment now carries a
`kind` (`'location'` | `'uptime'`).

Keeping that identity in `hostInfo.js` rather than inferring it in the component
also keeps the "a missing field **removes** its segment" rule in one place — the
footer never has to work out which dot belongs to which fact.

## No stray separator when geolocation fails

This was the risk worth designing against, since the location is the segment
most likely to be missing — the provider chain can fail entirely.

It can't happen by construction: the component emits separator and segment as a
**pair per entry**, so a dropped segment takes its own separator with it.
Covered from the data side by a test asserting no location segment survives when
only uptime is known, and confirmed live — 2 host segments, 4 separators across
five items (version, build name, location, uptime, updated).

## Verification

Needed a container, since the footer's host info comes from `/api/v1/header` and
a static build shows nothing there.

| | location | uptime |
|---|---|---|
| dark | weight 600, `rgb(18,204,148)` | weight 400, muted |
| light | weight 600, `rgb(14,162,113)` | muted |

- **Node page regression**, `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`: **127 rows,
  all NIMBUS**, Total Nodes 127, 0 bleed.
- **D1 audit: AGREE**, exit 0. Suite **799 passed, 5 skipped, 0 failed**.

> Top of the stack: #293 → #295 → #296 → this. Merge in that order and each
> fast-forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
