### PR TITLE
feat(#288): close the empty space on the Donor tab and shrink the clock

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -248,7 +248,17 @@ function RewardImpactPanel({ nodes, gstore }) {
   );
 }
 
-function PayoutCard({ nextNode, lastPaidNode }) {
+/*
+ * The three time-based facts on this tab, in one band (issue #288).
+ *
+ * The two payout stats had a full-width panel to themselves and the reward
+ * countdown had another below it, so the tab opened with two mostly-empty rows
+ * -- each stat was given half a 2,100px panel to hold about 300px of text.
+ * Putting the countdown in alongside them fills the row with the thing that
+ * belongs there anyway: when you were last paid, when you are next paid, and
+ * when the reward itself changes.
+ */
+function PayoutCard({ nextNode, lastPaidNode, currentBlock }) {
   return (
     <div className="hov-panel dt-payout-card">
       <div className="dt-payout-stat">
@@ -262,6 +272,12 @@ function PayoutCard({ nextNode, lastPaidNode }) {
         <span className="dt-payout-value">{nextNode ? nextNode.next_reward : '—'}</span>
         {nextNode && <span className="dt-payout-caption">{nextNode.ip_display}</span>}
       </div>
+      {/*
+        RewardCountdown removes itself when no reduction is scheduled, so the
+        divider is rendered by the clock's own wrapper rather than here -- an
+        absent clock must not leave a dangling rule behind it.
+      */}
+      <RewardCountdown currentBlock={currentBlock} compact />
     </div>
   );
 }
@@ -494,8 +510,11 @@ export function DonorTab() {
         <span className="dt-tab-hero-value">{nextNode ? nextNode.next_reward : '—'}</span>
         <span className="dt-tab-hero-label">Next payout</span>
       </div>
-      <PayoutCard nextNode={nextNode} lastPaidNode={lastPaidNode} />
-      <RewardCountdown currentBlock={gstore?.current_block_height} />
+      <PayoutCard
+        nextNode={nextNode}
+        lastPaidNode={lastPaidNode}
+        currentBlock={gstore?.current_block_height}
+      />
       <div className="donor-tab-panel-grid">
         <DonorNodesList nodes={nodes} />
         <AppsByCategoryPanel categories={appCategories.categories} totalApps={appCategories.totalApps} />

--- a/client/src/analytics/DonorTab/index.scss
+++ b/client/src/analytics/DonorTab/index.scss
@@ -6,10 +6,61 @@
   gap: 20px;
 }
 
+/*
+ * Three columns at most (issue #288).
+ *
+ * This was `repeat(auto-fit, minmax(320px, 1fr))`, which sizes tracks to the
+ * CONTAINER rather than to the content: on a 2125px viewport it laid out six
+ * 340px tracks. Only three panels take a single track each -- the other two
+ * span the full row -- so half the row was permanently empty, and the three
+ * cards stayed narrow while there was 1,050px of nothing beside them.
+ *
+ * Explicit breakpoints instead, matching apps-tab-panel-grid: the count is
+ * driven by how many panels there actually are, so they always fill the row.
+ */
 .donor-tab-panel-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
+
+  @media (min-width: 720px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1100px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/*
+ * The reward countdown, sized for a place it shares (issue #288).
+ *
+ * `compact` shrinks the digits; this pulls in the spacing PayoutTimer's
+ * stylesheet sets for a panel of its own, and caps the width so the four
+ * numbers read as one clock instead of being flung into the corners by
+ * space-between across a 2000px row.
+ */
+.donor-tab > .rwc-timer {
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+
+  .timer-header {
+    padding: 10px 14px 2px;
+  }
+
+  .timer-number {
+    margin-top: 4px;
+  }
+
+  .timer-info {
+    margin-top: 2px;
+    margin-bottom: 8px;
+  }
+
+  .v-rule {
+    margin: 8px 5px;
+  }
 }
 
 .hov-panel {
@@ -52,16 +103,91 @@
   background: linear-gradient(90deg, rgba(14, 162, 113, 0.04) 0%, transparent 60%);
 }
 
+/*
+ * Last payout, next payout, and the reward countdown, in one band (#288).
+ *
+ * Previously two stats with `flex: 1` in a panel of their own -- each given
+ * half a 2,100px row to hold about 300px of text -- with the countdown in a
+ * second full-width row below. Two mostly-empty bands opened the tab.
+ *
+ * The stats now size to their content and the clock takes the remaining space,
+ * so the row fills out instead of stretching apart as the viewport grows.
+ */
 .dt-payout-card {
   display: flex;
   align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
 }
 
 .dt-payout-stat {
-  flex: 1;
+  flex: 0 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+/*
+ * The clock sits inside the panel now, so it drops its own border and takes
+ * the space the two stats do not need. The leading rule is on the clock rather
+ * than a sibling divider element: RewardCountdown removes itself entirely when
+ * no reduction is scheduled, and a separate divider would be left behind
+ * pointing at nothing.
+ */
+.dt-payout-card > .rwc-timer {
+  flex: 1 1 320px;
+  width: auto;
+  min-width: 0;
+  max-width: 560px;
+  margin: 0 0 0 auto;
+  border: none;
+  border-left: 1px solid var(--border-secondary);
+  border-radius: 0;
+  padding-left: 20px;
+
+  .timer-header {
+    padding: 0 0 2px;
+  }
+
+  .timer-number {
+    margin-top: 2px;
+  }
+
+  .timer-info {
+    margin-top: 2px;
+    margin-bottom: 0;
+  }
+
+  .v-rule {
+    margin: 6px 5px;
+  }
+
+  .rwc-caption {
+    padding-top: 4px;
+  }
+}
+
+/*
+ * Stacked, every vertical rule in this band is stranded: the stats sit above
+ * one another rather than side by side, so the divider between them becomes a
+ * short line pointing nowhere, and the clock's left rule the same. Each stat
+ * carries its own label, so dropping the divider loses nothing.
+ */
+@media (max-width: 900px) {
+  .dt-payout-divider {
+    display: none;
+  }
+
+  .dt-payout-card > .rwc-timer {
+    flex-basis: 100%;
+    max-width: none;
+    margin-left: 0;
+    border-left: none;
+    border-top: 1px solid var(--border-secondary);
+    padding-left: 0;
+    padding-top: 12px;
+  }
 }
 
 .dt-payout-value {


### PR DESCRIPTION
Closes #288.

I couldn't read the screenshot on the issue from here, so I measured the layout
in a browser instead. Two things were doing the damage, both worse the wider the
screen:

## 1. The grid sized tracks to the container, not the content

`repeat(auto-fit, minmax(320px, 1fr))` laid out **six** 340px tracks on a
2,125px viewport. Only three panels take a single track each — REWARD REDUCTION
IMPACT and RECENT ACTIVITY span the whole row — so **three tracks sat
permanently empty: 1,050px of nothing** beside three narrow cards.

Explicit breakpoints now, capped at three columns, matching
`apps-tab-panel-grid`'s shape. Cards went **341px → 699px** and the row fills.

## 2. The clock had a full-width panel to itself

**2,125 × 226px for four two-digit numbers** — the largest thing on a page about
the reader's own nodes, counting down to a date six weeks away. Now `compact`,
and merged into the payout band.

### Merging rather than just shrinking

I tried centring the payout stats first and it only *moved* the emptiness — a
full-width panel holding two short stats is empty whatever you do with the
alignment. The fix is to put more in it.

Last payout, next payout and the reward countdown are the three time-based facts
on this tab, so they now share one band: when you were last paid, when you're
next paid, and when the reward itself changes. **Two mostly-empty rows became
one that fills out — ~336px of vertical space down to 135px.**

The clock's leading rule is a border on the clock rather than a sibling divider
element, because `RewardCountdown` removes itself entirely when no reduction is
scheduled — a separate divider would be left pointing at nothing.

## Narrow screens

Below 900px the band wraps and every vertical rule in it is stranded — the stats
sit above one another, so the divider between them becomes a short line pointing
nowhere. Divider hidden, clock's left rule becomes a top rule. **Caught by
looking at 390px, not by reasoning about it.**

## Verification

- Donor tab is **3 rows, not 4**. Grid 3 × 699px, last card flush with the row's
  right edge — no dead space. Clock **560 × 103** inside the band.
- **390px**: 0 bleed, band stacks, clock border switches left → top, grid single
  column.
- **Node page regression**, `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`: **127 rows,
  all NIMBUS**, Total Nodes 127, 0 bleed.
- **D1 audit: AGREE**, exit 0. Suite **799 passed, 5 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
