### PR TITLE
feat(#282): persist each utility block's transactions, and open them from the drill-down

### DIFF
--- a/api/src/services/chain_activity.rs
+++ b/api/src/services/chain_activity.rs
@@ -226,7 +226,7 @@ pub struct RawTx {
 
 // ── Classification output shapes ─────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TxTransfer {
     pub txid: String,
     pub from: Option<String>,
@@ -250,6 +250,9 @@ pub struct BlockScanResult {
     pub deployment_count: u32,
     pub date: String,
     pub team_txs: Vec<TeamTx>,
+    // Capped at MAX_STORED_TRANSFERS; transfer_count above stays the true
+    // total (issue #282).
+    pub transfers: Vec<TxTransfer>,
 }
 
 /*
@@ -279,6 +282,18 @@ pub struct UtilityBlockRecord {
      */
     #[serde(default)]
     pub deployment_count: u32,
+    /*
+     * The block's P2P transfers, capped at MAX_STORED_TRANSFERS (issue #282).
+     *
+     * `serde(default)` for the same reason as deployment_count above: this file
+     * is already on disk everywhere without the field, and a missing-field
+     * error fails the whole read -- discarding the retained window and forcing
+     * a ~23,040-block rescan on upgrade. Records written before this change
+     * report an empty list, which is honest: the transfers were never stored
+     * for them. They refill as the scanner moves on.
+     */
+    #[serde(default)]
+    pub transfers: Vec<TxTransfer>,
 }
 
 // ── Persisted shapes ──────────────────────────────────────────────────────────
@@ -560,6 +575,7 @@ pub fn fold_contiguous_results(
                         is_dapp: r.is_dapp,
                         transfer_count: r.transfer_count,
                         deployment_count: r.deployment_count,
+                        transfers: r.transfers.clone(),
                     });
                 }
                 checkpoint = height;
@@ -656,6 +672,35 @@ pub async fn fetch_tip_height(client: &Client) -> Option<i64> {
     let res = explorer_get(client, "/blocks?limit=1").await?;
     let parsed: RecentBlocksResponse = res.json().await.ok()?;
     parsed.blocks.get(0).map(|b| b.height)
+}
+
+/*
+ * How many of a block's transfers are kept (issue #282).
+ *
+ * Chosen against measured data, not a guess. Over the 80 utility blocks
+ * retained at the time: 121 transfers in total, mean 1.51, median 1, p90 2,
+ * max 13, and 71 of the 80 held exactly one. So 25 is a bound on a pathological
+ * block rather than a limit anything ordinary reaches.
+ *
+ * It matters because this file is retained for 23,040 blocks (8 days). At the
+ * measured rate the transfers add roughly 1.6 MB; an uncapped run on a block
+ * stuffed with transactions could add far more, and this directory is rebuilt
+ * from the explorer on every restart, so a runaway file costs a slow start for
+ * nobody's benefit.
+ */
+pub const MAX_STORED_TRANSFERS: usize = 25;
+
+/*
+ * The transfers to persist for a block.
+ *
+ * The caller keeps `transfers.len()` as transfer_count BEFORE calling this:
+ * the count must stay true even when the list is capped, because busiest_block
+ * ranks on it (#286) and the UI needs it to say "showing 25 of 40" rather than
+ * silently under-reporting the block.
+ */
+pub fn cap_transfers(mut transfers: Vec<TxTransfer>) -> Vec<TxTransfer> {
+    transfers.truncate(MAX_STORED_TRANSFERS);
+    transfers
 }
 
 /*
@@ -786,6 +831,8 @@ pub async fn scan_one_block(client: &Client, height: i64, deployment_heights: &H
     let transfer_count = transfers.len() as u32;
     let is_utility = is_block_utility(height, &transfers, deployment_heights);
     let team_txs = extract_team_txs(height, &transfers);
+    // After transfer_count is taken above, so the count stays true.
+    let stored_transfers = cap_transfers(transfers);
     // Every tx in a block shares (approximately) the same blocktime — prefer
     // the coinbase's (always present, page 0, item 0 in practice) but fall
     // back to any tx if that lookup ever comes up empty.
@@ -796,7 +843,7 @@ pub async fn scan_one_block(client: &Client, height: i64, deployment_heights: &H
         .or_else(|| txs.first().and_then(|t| t.time))
         .unwrap_or(0);
     let date = unix_to_utc_date(block_time);
-    Some(BlockScanResult { height, is_utility, is_p2p, is_dapp, transfer_count, deployment_count, date, team_txs })
+    Some(BlockScanResult { height, is_utility, is_p2p, is_dapp, transfer_count, deployment_count, date, team_txs, transfers: stored_transfers })
 }
 
 /*
@@ -1105,6 +1152,67 @@ mod tests {
         assert_eq!(parsed[0].deployment_count, 0);
     }
 
+    /*
+     * Issue #282: clicking a utility block should show its transactions, and
+     * they were never stored -- scan_one_block computed the full list and kept
+     * only `.len()`.
+     *
+     * Measured before choosing a cap, over the 80 utility blocks retained at
+     * the time: 121 transfers total, mean 1.51, median 1, p90 2, max 13, with
+     * 71 of 80 blocks holding exactly one. The cap is a bound on a pathological
+     * block, not a limit anything normal reaches.
+     */
+    #[test]
+    fn keeps_a_blocks_transfers_up_to_the_cap() {
+        let transfers: Vec<TxTransfer> = (0..5).map(|i| transfer(i)).collect();
+        let kept = cap_transfers(transfers);
+        assert_eq!(kept.len(), 5);
+        assert_eq!(kept[0].txid, "tx0");
+        assert_eq!(kept[4].txid, "tx4");
+    }
+
+    #[test]
+    fn caps_a_pathological_block_rather_than_storing_it_whole() {
+        let transfers: Vec<TxTransfer> = (0..(MAX_STORED_TRANSFERS + 40)).map(|i| transfer(i as i32)).collect();
+        assert_eq!(cap_transfers(transfers).len(), MAX_STORED_TRANSFERS);
+    }
+
+    /*
+     * transfer_count must stay the TRUE count even when the stored list is
+     * capped: it is what busiest_block ranks on (#286), and it is what lets the
+     * UI say "showing N of M" instead of quietly under-reporting the block.
+     */
+    #[test]
+    fn capping_does_not_change_the_reported_transfer_count() {
+        let total = MAX_STORED_TRANSFERS + 7;
+        let transfers: Vec<TxTransfer> = (0..total).map(|i| transfer(i as i32)).collect();
+        let count = transfers.len() as u32;
+        let stored = cap_transfers(transfers);
+        assert_eq!(count, total as u32);
+        assert!(stored.len() < count as usize);
+    }
+
+    #[test]
+    fn a_block_with_no_transfers_stores_an_empty_list() {
+        assert!(cap_transfers(vec![]).is_empty());
+    }
+
+    /*
+     * The upgrade path, same shape as #286's deployment_count: the retained
+     * file is already on disk everywhere WITHOUT this field, and a
+     * missing-field error would fail the whole read and force a ~23,040-block
+     * rescan.
+     */
+    #[test]
+    fn reads_records_written_before_transfers_were_stored() {
+        let old = r#"[{"height":7,"date":"2026-09-01","is_p2p":true,"is_dapp":false,"transfer_count":4}]"#;
+        let parsed: Vec<UtilityBlockRecord> =
+            serde_json::from_str(old).expect("pre-#282 records must still deserialize");
+        assert_eq!(parsed[0].transfer_count, 4);
+        // The count survives; the list is simply unavailable for old records.
+        assert!(parsed[0].transfers.is_empty());
+    }
+
     #[test]
     fn busiest_block_in_window_ignores_blocks_older_than_the_window() {
         let blocks = vec![
@@ -1334,6 +1442,16 @@ mod tests {
      * scan_one_block computes it -- a helper that let those drift apart would
      * make every test below meaningless.
      */
+    /// A distinct transfer, for cap tests.
+    fn transfer(i: i32) -> TxTransfer {
+        TxTransfer {
+            txid: format!("tx{}", i),
+            from: Some(format!("t1from{}", i)),
+            to: format!("t1to{}", i),
+            amount: 1.0 + i as f64,
+        }
+    }
+
     /// A retained utility block with a given transfer and deployment count.
     fn utility_record(height: i64, transfers: u32, deployments: u32) -> UtilityBlockRecord {
         UtilityBlockRecord {
@@ -1343,6 +1461,7 @@ mod tests {
             is_dapp: deployments > 0,
             transfer_count: transfers,
             deployment_count: deployments,
+            transfers: vec![],
         }
     }
 
@@ -1354,6 +1473,7 @@ mod tests {
             is_dapp,
             transfer_count: if is_p2p { 2 } else { 0 },
             deployment_count: if is_dapp { 1 } else { 0 },
+            transfers: vec![],
             date: date.into(),
             team_txs: vec![],
         }
@@ -1423,9 +1543,9 @@ mod tests {
     #[test]
     fn trim_utility_blocks_drops_everything_below_the_window_edge() {
         let mut blocks = vec![
-            UtilityBlockRecord { height: 100, date: "a".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0 },
-            UtilityBlockRecord { height: 200, date: "b".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0 },
-            UtilityBlockRecord { height: 300, date: "c".into(), is_p2p: false, is_dapp: true, transfer_count: 0, deployment_count: 1 },
+            UtilityBlockRecord { height: 100, date: "a".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0, transfers: vec![] },
+            UtilityBlockRecord { height: 200, date: "b".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0, transfers: vec![] },
+            UtilityBlockRecord { height: 300, date: "c".into(), is_p2p: false, is_dapp: true, transfer_count: 0, deployment_count: 1, transfers: vec![] },
         ];
         trim_utility_blocks(&mut blocks, 200);
         // Boundary is inclusive, matching trim_team_txs: a block exactly at the
@@ -1439,10 +1559,10 @@ mod tests {
         // total -- overlapping "any P2P" / "any Dapp" counts would not add up
         // and would read as a bug on screen.
         let blocks = vec![
-            UtilityBlockRecord { height: 1, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 3, deployment_count: 0 },
-            UtilityBlockRecord { height: 2, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0 },
-            UtilityBlockRecord { height: 3, date: "d".into(), is_p2p: false, is_dapp: true, transfer_count: 0, deployment_count: 1 },
-            UtilityBlockRecord { height: 4, date: "d".into(), is_p2p: true, is_dapp: true, transfer_count: 2, deployment_count: 1 },
+            UtilityBlockRecord { height: 1, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 3, deployment_count: 0, transfers: vec![] },
+            UtilityBlockRecord { height: 2, date: "d".into(), is_p2p: true, is_dapp: false, transfer_count: 1, deployment_count: 0, transfers: vec![] },
+            UtilityBlockRecord { height: 3, date: "d".into(), is_p2p: false, is_dapp: true, transfer_count: 0, deployment_count: 1, transfers: vec![] },
+            UtilityBlockRecord { height: 4, date: "d".into(), is_p2p: true, is_dapp: true, transfer_count: 2, deployment_count: 1, transfers: vec![] },
         ];
         let p2p_only = blocks.iter().filter(|b| b.is_p2p && !b.is_dapp).count();
         let dapp_only = blocks.iter().filter(|b| !b.is_p2p && b.is_dapp).count();

--- a/client/src/analytics/ChainActivityTab/index.jsx
+++ b/client/src/analytics/ChainActivityTab/index.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, blocksRemainingInScan, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel, shouldPollSync, SYNC_POLL_INTERVAL_MS } from 'analytics/chainActivity';
+import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, blocksRemainingInScan, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel, blockTransfersState, shouldPollSync, SYNC_POLL_INTERVAL_MS } from 'analytics/chainActivity';
 import { shouldFetchDrilldown, stateAfterCancel } from './drilldownState';
 import './index.scss';
 
@@ -86,6 +86,92 @@ function SyncStatusBanner({ syncStatus, lastSuccessAt, lastScannedHeight, scanSt
   );
 }
 
+/*
+ * One block in the drill-down, openable to show its transactions (issue #282).
+ *
+ * These rows already highlighted on hover but did nothing when clicked -- they
+ * looked interactive and were not, which is how #282 started. Real buttons now:
+ * keyboard reachable, with aria-expanded, rather than a div with a listener.
+ */
+function BlockRow({ block, open, onToggle }) {
+  const state = blockTransfersState(block);
+  const canOpen = state.kind !== 'empty';
+
+  return (
+    <div className={`ca-drilldown-item${open ? ' ca-drilldown-item--open' : ''}`}>
+      <button
+        type="button"
+        className="ca-drilldown-row"
+        onClick={() => onToggle(open ? null : block.height)}
+        disabled={!canOpen}
+        aria-expanded={canOpen ? open : undefined}
+        aria-label={`Block ${block.height}, ${blockCategoryLabel(block)}`}
+      >
+        <span className="ca-drilldown-height">#{fmtNum(block.height)}</span>
+        <span className={`ca-drilldown-cat${block.isP2p && block.isDapp ? ' ca-drilldown-cat--both' : ''}`}>
+          {blockCategoryLabel(block)}
+        </span>
+        <span className="ca-drilldown-txs">
+          {block.transferCount > 0 ? `${fmtNum(block.transferCount)} tx` : '—'}
+        </span>
+        <span className="ca-drilldown-date">{block.date}</span>
+        {canOpen && <span className="ca-drilldown-caret" aria-hidden="true">{open ? '▴' : '▾'}</span>}
+      </button>
+
+      {open && <BlockTransfers state={state} transfers={block.transfers} />}
+    </div>
+  );
+}
+
+function BlockTransfers({ state, transfers }) {
+  /*
+   * "unavailable" is not "none". A record written before #282 carries a
+   * transfer count but no list, and saying "no transactions" about a block that
+   * had four would be a lie -- so it says what is actually true instead.
+   */
+  if (state.kind === 'unavailable') {
+    return (
+      <div className="ca-tx-panel ca-tx-panel--note">
+        {fmtNum(state.total)} transactions in this block, but they were not recorded &mdash; it was
+        scanned before transaction detail was stored. It refills as the scanner passes it again.
+      </div>
+    );
+  }
+
+  return (
+    <div className="ca-tx-panel">
+      <div className="ca-tx-list">
+        {/*
+          Keyed on txid + index, NOT txid alone. One transaction can pay several
+          addresses, and extract_p2p_transfers emits one entry per output -- so
+          a block legitimately contains repeated txids. Seen live on block
+          2,920,896: two rows sharing d1d5d4a8…, paying different wallets.
+        */}
+        {(transfers || []).map((t, i) => (
+          <div key={`${t.txid}-${i}`} className="ca-tx-row">
+            <code className="ca-tx-id" title={t.txid}>{t.txid.slice(0, 12)}…</code>
+            <span className="ca-tx-addr" title={t.from || 'unknown sender'}>
+              {t.from ? `${t.from.slice(0, 8)}…${t.from.slice(-4)}` : '—'}
+            </span>
+            <span className="ca-tx-arrow" aria-hidden="true">→</span>
+            <span className="ca-tx-addr" title={t.to}>
+              {`${t.to.slice(0, 8)}…${t.to.slice(-4)}`}
+            </span>
+            <span className="ca-tx-amount">
+              {t.amount.toLocaleString(undefined, { maximumFractionDigits: 8 })} FLUX
+            </span>
+          </div>
+        ))}
+      </div>
+      {state.kind === 'capped' && (
+        <div className="ca-tx-foot">
+          showing {fmtNum(state.shown)} of {fmtNum(state.total)} transactions in this block
+        </div>
+      )}
+    </div>
+  );
+}
+
 function fmtNum(n) {
   if (!n && n !== 0) return '—';
   return n.toLocaleString();
@@ -112,6 +198,9 @@ const DRILLDOWN_LIMIT = 50;
  */
 function UtilityDrilldown({ open, expectedTotal }) {
   const [state, setState] = useState({ status: 'idle', data: null });
+  // Which block is expanded, or null. One at a time: the list is long and
+  // several open at once turns it into a wall (#282).
+  const [openHeight, setOpenHeight] = useState(null);
 
   /*
    * Status is mirrored in a ref so it can gate the fetch WITHOUT being an
@@ -209,16 +298,7 @@ function UtilityDrilldown({ open, expectedTotal }) {
 
       <div className="ca-drilldown-list">
         {blocks.map((b) => (
-          <div key={b.height} className="ca-drilldown-row">
-            <span className="ca-drilldown-height">#{fmtNum(b.height)}</span>
-            <span className={`ca-drilldown-cat${b.isP2p && b.isDapp ? ' ca-drilldown-cat--both' : ''}`}>
-              {blockCategoryLabel(b)}
-            </span>
-            <span className="ca-drilldown-txs">
-              {b.transferCount > 0 ? `${fmtNum(b.transferCount)} tx` : '\u2014'}
-            </span>
-            <span className="ca-drilldown-date">{b.date}</span>
-          </div>
+          <BlockRow key={b.height} block={b} open={openHeight === b.height} onToggle={setOpenHeight} />
         ))}
       </div>
 

--- a/client/src/analytics/ChainActivityTab/index.scss
+++ b/client/src/analytics/ChainActivityTab/index.scss
@@ -369,17 +369,118 @@
   gap: 2px;
 }
 
+/*
+ * A real button since #282. It highlighted on hover and did nothing when
+ * clicked, which is how that issue started -- so the hover affordance is now
+ * backed by an actual control rather than removed.
+ */
 .ca-drilldown-row {
   display: grid;
-  grid-template-columns: 90px 1fr 60px 90px;
+  grid-template-columns: 90px 1fr 60px 90px 16px;
   align-items: center;
   gap: 8px;
+  width: 100%;
   font-size: 0.74rem;
+  font-family: inherit;
+  text-align: left;
   padding: 3px 6px;
+  border: 0;
   border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text-secondary);
+  cursor: pointer;
 
-  &:hover { background: var(--surface-inset); }
+  &:hover:not(:disabled) { background: var(--surface-inset); }
+
+  // A block with no transfers has nothing to open; it keeps the row shape but
+  // drops the affordance rather than opening an empty panel.
+  &:disabled {
+    cursor: default;
+    grid-template-columns: 90px 1fr 60px 90px 16px;
+  }
+}
+
+.ca-drilldown-item--open > .ca-drilldown-row {
+  background: var(--surface-inset);
+}
+
+.ca-drilldown-caret {
+  font-size: 0.6rem;
+  opacity: 0.6;
+}
+
+/* ── A block's transactions (issue #282) ─────────────────────────────────── */
+
+.ca-tx-panel {
+  margin: 2px 0 8px 6px;
+  padding: 8px 10px;
+  border-left: 2px solid var(--border-secondary);
+  background: var(--surface-inset);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.ca-tx-panel--note {
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+
+.ca-tx-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ca-tx-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 12px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ca-tx-id {
+  color: var(--text-tertiary);
+  font-size: 0.68rem;
+}
+
+.ca-tx-addr {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ca-tx-arrow {
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.ca-tx-amount {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.ca-tx-foot {
+  margin-top: 6px;
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+}
+
+// Five columns of addresses and amounts do not survive a phone; stack them and
+// let the amount carry the weight.
+@media (max-width: 720px) {
+  .ca-tx-row {
+    grid-template-columns: 1fr auto;
+    gap: 2px 8px;
+  }
+
+  .ca-tx-id,
+  .ca-tx-arrow {
+    display: none;
+  }
 }
 
 .ca-drilldown-height {

--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -247,6 +247,17 @@ export async function fetch_chain_activity_blocks(limit = 50) {
             isP2p: !!b.is_p2p,
             isDapp: !!b.is_dapp,
             transferCount: b.transfer_count || 0,
+            // #282: the block's own transfers, capped server-side. transferCount
+            // stays the TRUE total, so the two can legitimately disagree -- see
+            // blockTransfersState below.
+            transfers: Array.isArray(b.transfers)
+              ? b.transfers.map((t) => ({
+                  txid: t.txid,
+                  from: t.from || null,
+                  to: t.to,
+                  amount: typeof t.amount === 'number' ? t.amount : 0,
+                }))
+              : [],
           }))
         : [],
     };
@@ -254,6 +265,32 @@ export async function fetch_chain_activity_blocks(limit = 50) {
     console.log('[ChainActivity] blocks fetch failed:', error?.message || error);
     return empty;
   }
+}
+
+/*
+ * What a block can actually show when opened (issue #282).
+ *
+ * Four states, and the third is the reason this is a function rather than a
+ * `transfers.length` check at the call site:
+ *
+ * - complete    every transfer is stored
+ * - capped      the block had more than the server stores per block; `total`
+ *               is the real number so the UI can say "25 of 40"
+ * - unavailable the block has a transfer COUNT but no stored transfers. This is
+ *               every record written before #282 -- the list was never kept for
+ *               them. Rendering that as "no transactions" would be a flat lie
+ *               about a block that had four. They refill as the scanner moves
+ *               past them.
+ * - empty       the block genuinely had no P2P transfers
+ */
+export function blockTransfersState(block) {
+  const total = block?.transferCount || 0;
+  const shown = Array.isArray(block?.transfers) ? block.transfers.length : 0;
+
+  if (total === 0) return { kind: 'empty', shown: 0, total: 0 };
+  if (shown === 0) return { kind: 'unavailable', shown: 0, total };
+  if (shown < total) return { kind: 'capped', shown, total };
+  return { kind: 'complete', shown, total };
 }
 
 /* "P2P", "Dapp", or "P2P + Dapp" for one block's category badges. */

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -1,5 +1,5 @@
 import { fetch_chain_activity, summarizeDaily, relativeTimeAgo, scanProgressPct, BLOCKS_PER_DAY, RETENTION_DAYS, todaysUtilityBlocks, fetch_chain_activity_blocks, blockCategoryLabel,
-  blocksRemainingInScan, shouldPollSync } from './chainActivity';
+  blocksRemainingInScan, shouldPollSync, blockTransfersState } from './chainActivity';
 
 function mockJsonResponse(body) {
   return { ok: true, json: async () => body };
@@ -262,7 +262,32 @@ describe('fetch_chain_activity_blocks', () => {
     expect(result.totals).toEqual({ p2pOnly: 462, dappOnly: 28, both: 4, utilityTotal: 494 });
     expect(result.blocks[0]).toEqual({
       height: 2939035, date: '2026-09-11', isP2p: true, isDapp: false, transferCount: 2,
+      // #282. Empty here because this fixture's payload predates the field --
+      // which is also the shape a real pre-#282 record deserializes to.
+      transfers: [],
     });
+  });
+
+  it("maps a block's stored transfers through (#282)", async () => {
+    global.fetch = jest.fn(() => ok({
+      success: true,
+      totals: { p2p_only: 1, dapp_only: 0, both: 0, utility_total: 1 },
+      blocks: [{
+        height: 42, date: '2026-09-12', is_p2p: true, is_dapp: false, transfer_count: 2,
+        transfers: [
+          { txid: 'abc', from: 't1alice', to: 't1bob', amount: 1.5 },
+          // `from` is genuinely absent on some inputs; it must map to null
+          // rather than undefined so the UI can test it.
+          { txid: 'def', to: 't1carol', amount: 0.25 },
+        ],
+      }],
+    }));
+
+    const result = await fetch_chain_activity_blocks(50);
+    expect(result.blocks[0].transfers).toEqual([
+      { txid: 'abc', from: 't1alice', to: 't1bob', amount: 1.5 },
+      { txid: 'def', from: null, to: 't1carol', amount: 0.25 },
+    ]);
   });
 
   it('the disjoint totals sum to the utility total', async () => {
@@ -384,5 +409,46 @@ describe('shouldPollSync', () => {
 
   test('stops once the scanner has caught up, because nothing further changes', () => {
     expect(shouldPollSync('caught_up')).toBe(false);
+  });
+});
+
+/*
+ * Issue #282: a utility block's transactions are now persisted, so the
+ * drill-down can open one. Three states have to be told apart, and the awkward
+ * one is the third.
+ */
+describe('blockTransfersState', () => {
+  test('a block whose transfers are all stored is complete', () => {
+    const state = blockTransfersState({ transferCount: 2, transfers: [{}, {}] });
+    expect(state).toEqual({ kind: 'complete', shown: 2, total: 2 });
+  });
+
+  test('a block past the storage cap reports how many of how many', () => {
+    const state = blockTransfersState({ transferCount: 40, transfers: new Array(25).fill({}) });
+    expect(state).toEqual({ kind: 'capped', shown: 25, total: 40 });
+  });
+
+  /*
+   * The one that matters. Records written before #282 carry a transferCount
+   * but no transfers -- the list was never stored for them. Reporting that as
+   * "no transactions" would be a flat lie about a block that had 4.
+   */
+  test('a pre-#282 record is unavailable, not empty', () => {
+    const state = blockTransfersState({ transferCount: 4, transfers: [] });
+    expect(state).toEqual({ kind: 'unavailable', shown: 0, total: 4 });
+  });
+
+  test('a block that genuinely had no transfers is empty', () => {
+    expect(blockTransfersState({ transferCount: 0, transfers: [] })).toEqual({
+      kind: 'empty',
+      shown: 0,
+      total: 0,
+    });
+  });
+
+  test('tolerates a block with no transfers field at all', () => {
+    expect(blockTransfersState({ transferCount: 0 }).kind).toBe('empty');
+    expect(blockTransfersState({}).kind).toBe('empty');
+    expect(blockTransfersState(null).kind).toBe('empty');
   });
 });


### PR DESCRIPTION
Closes #282. Persisting rather than fetching on demand, per your decision — the
explorer's rate limiting is a recurring reality here (Cloudflare `1015` during
this work, and `explorer.js` already documents 429s as normal), so a
click-to-load panel would fail exactly when people use it.

## The cap was measured, not guessed

Over the 80 utility blocks retained at the time:

| | |
|---|---|
| total transfers | 121 |
| mean / median | 1.51 / 1 |
| p90 / max | 2 / 13 |
| blocks with exactly one | 71 of 80 |

So the storage cost is **~1.6 MB across the full 23,040-block window**, not the
bloat the issue worried about, and `MAX_STORED_TRANSFERS = 25` bounds a
pathological block rather than limiting anything ordinary.

`transfer_count` stays the **true** total even when the stored list is capped —
it's what `busiest_block` ranks on (#286), and it's what lets the UI say
"showing 25 of 40" instead of quietly under-reporting a block.

## Upgrade path, same shape as #286

`#[serde(default)]`. The retained file is already on disk everywhere without the
field, and a missing-field error fails the whole read — discarding the window
and forcing a ~23,040-block rescan. Tested against a pre-#282 JSON record and
**mutation-checked**: removing the attribute fails exactly that test.

## "Unavailable" is not "none"

Records written before this change carry a transfer **count** but no list.
Saying *"no transactions"* about a block that had four would be a lie, so
`blockTransfersState` distinguishes **complete / capped / unavailable / empty**,
and the unavailable panel says the transactions weren't recorded and that the
block refills as the scanner passes it again.

## The rows are real controls now

They highlighted on hover and did nothing when clicked — which is how #282
started. They're buttons: keyboard reachable, `aria-expanded`, one open at a
time.

## A bug the real data caught

Transfers are keyed on **txid + index**, not txid. One transaction can pay
several addresses and `extract_p2p_transfers` emits one entry per output, so a
block legitimately contains repeated txids — **block 2,920,896 has twelve
transfers all sharing `d1d5d4a8d810…`, paying twelve different wallets**. Keyed
on txid alone that's a duplicate-key collision. Found by scanning live chain
data, not by the fixtures.

## Verification

Against a container scanning a cold volume:

- Transfers persist with real values: `#2920929 tc=1 stored=1`,
  `#2920898 tc=2 stored=2`, `#2920896 tc=12 stored=12`.
- Rows are `<button>`, `cursor: pointer`, `aria-expanded` toggles false → true.
- Opening 2,920,896 renders **12 transaction rows**, sender → recipient with
  amounts, the twelve same-txid outputs each on their own row.
- **Rust 60 passed**, client **806 passed / 5 skipped / 0 failed**.
- **Node page regression**, `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`: **127 rows,
  all NIMBUS**, 0 bleed.
- **D1 audit: AGREE**, exit 0.

## Follow-on

This unblocks the UI half of #286 — the "busiest block (24h)" rail element now
has transaction detail to open, which is why I held it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
