### PR TITLE
feat(#286): show the busiest block of the last 24h on the live rail, and open it

### DIFF
--- a/client/src/analytics/chainActivity.js
+++ b/client/src/analytics/chainActivity.js
@@ -43,6 +43,9 @@ export async function fetch_chain_activity() {
     scanStartHeight: 0,
     scanTargetHeight: 0,
     syncStatus: 'api_unreachable',
+    // #286: absent when the API cannot be reached, same as every other field
+    // here -- /live simply renders no busiest-block card.
+    busiestBlock: null,
   };
   try {
     const response = await fetch(`${FLUXNODE_INFO_API_URL}/api/v1/chain-activity`, {
@@ -71,6 +74,27 @@ export async function fetch_chain_activity() {
       scanStartHeight: json.scan_start_height || 0,
       scanTargetHeight: json.scan_target_height || 0,
       syncStatus: json.last_outcome || 'never_run',
+      /*
+       * #286. null until a scan has produced both a checkpoint and a utility
+       * block inside the 24h window -- a cold start has neither, and /live must
+       * show nothing rather than a placeholder.
+       */
+      busiestBlock: json.busiest_block_24h
+        ? {
+            height: json.busiest_block_24h.height,
+            date: json.busiest_block_24h.date,
+            transferCount: json.busiest_block_24h.transfer_count || 0,
+            deploymentCount: json.busiest_block_24h.deployment_count || 0,
+            transfers: Array.isArray(json.busiest_block_24h.transfers)
+              ? json.busiest_block_24h.transfers.map((t) => ({
+                  txid: t.txid,
+                  from: t.from || null,
+                  to: t.to,
+                  amount: typeof t.amount === 'number' ? t.amount : 0,
+                }))
+              : [],
+          }
+        : null,
     };
 
     // Visibility for anyone watching devtools during local testing — the

--- a/client/src/analytics/chainActivity.test.js
+++ b/client/src/analytics/chainActivity.test.js
@@ -14,6 +14,9 @@ const EMPTY_RESULT = {
   scanStartHeight: 0,
   scanTargetHeight: 0,
   syncStatus: 'api_unreachable',
+  // #286: no busiest block when the API is unreachable, same as every other
+  // field here.
+  busiestBlock: null,
 };
 
 describe('fetch_chain_activity', () => {

--- a/client/src/live/ChainRail/index.jsx
+++ b/client/src/live/ChainRail/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DETAIL_SECTIONS } from 'live/categoryMeta';
 import { FluxMark } from 'live/FluxMark';
 import { relativeTime, exactTimestamp } from 'live/timeFormat';
+import { BUSIEST_LABEL } from 'live/busiestBlock';
 import './index.scss';
 
 function sectionKeyFor(event) {
@@ -78,6 +79,48 @@ function ChainBlock({ block, isSelected, isTip, onSelect }) {
 }
 
 /*
+ * The busiest block of the last 24 hours (#286), sectioned off from the live
+ * blocks by a rule.
+ *
+ * Rendered differently from a live block on purpose: it is not part of the
+ * chain flowing past, it is one block pulled out of the last day for a reason,
+ * so it says what that reason is rather than showing a relative time it cannot
+ * know precisely (the record carries a date, not a block timestamp).
+ */
+function BusiestBlock({ block, isSelected, onSelect }) {
+  const activate = () => onSelect(block);
+  const onKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      activate();
+    }
+  };
+
+  const parts = [];
+  if (block.transferCount) parts.push(`${block.transferCount} transfer${block.transferCount === 1 ? '' : 's'}`);
+  if (block.deploymentCount) parts.push(`${block.deploymentCount} deploy${block.deploymentCount === 1 ? '' : 's'}`);
+
+  return (
+    <div
+      className={`live-chain-block live-chain-block--busiest${isSelected ? ' live-chain-block--selected' : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-label={`${BUSIEST_LABEL} ${block.height}, ${parts.join(', ') || 'no activity'}`}
+      onClick={activate}
+      onKeyDown={onKeyDown}
+      title={`Busiest block of the last 24h${block.date ? ` (${block.date})` : ''}: ${parts.join(', ')}`}
+    >
+      <span className="live-chain-block-busiest-marker">{BUSIEST_LABEL}</span>
+      <span className="live-chain-block-height">#{block.height}</span>
+      <span className="live-chain-block-time">last 24h</span>
+      <span className="live-chain-block-chips">
+        <span className="live-chain-chip live-chain-chip--busiest">{block.activity}</span>
+      </span>
+    </div>
+  );
+}
+
+/*
  * The track is keyed on the current tip height: React remounts it (and every
  * block inside) exactly once per genuine new block, which is what makes each
  * card's CSS keyframe animation replay — a keyframe only plays on mount,
@@ -86,7 +129,7 @@ function ChainBlock({ block, isSelected, isTip, onSelect }) {
  * with no remount and so no animation, which is correct. See
  * live/blockAnimation.js for the phase state machine this renders.
  */
-export function ChainRail({ blocks, tipHeight, selectedHeight, onSelectBlock }) {
+export function ChainRail({ blocks, tipHeight, selectedHeight, onSelectBlock, busiestBlock }) {
   return (
     <div className="live-panel live-chain-rail">
       <div className="live-panel-header">
@@ -109,6 +152,22 @@ export function ChainRail({ blocks, tipHeight, selectedHeight, onSelectBlock }) 
               {i < blocks.length - 1 && <span className="live-chain-connector" aria-hidden="true" />}
             </React.Fragment>
           ))
+        )}
+
+        {/*
+          Sectioned off with a rule rather than a connector (#286): a connector
+          would claim this block sits next to the live ones in the chain, and it
+          does not -- it is one block pulled out of the last 24 hours.
+        */}
+        {busiestBlock && (
+          <>
+            <span className="live-chain-divider" aria-hidden="true" />
+            <BusiestBlock
+              block={busiestBlock}
+              isSelected={selectedHeight === busiestBlock.height}
+              onSelect={onSelectBlock}
+            />
+          </>
         )}
       </div>
     </div>

--- a/client/src/live/ChainRail/index.scss
+++ b/client/src/live/ChainRail/index.scss
@@ -279,3 +279,57 @@ $live-chain-slot-shift: 150px; // block width (122px) + connector (28px)
     background: transparent;
   }
 }
+
+/* ── Busiest block of the last 24h (issue #286) ──────────────────────────────
+   Sectioned off with a solid vertical rule, deliberately unlike the animated
+   dashed connector between live blocks: that connector says "these are
+   consecutive in the chain", which this block is not. It is one block pulled
+   out of the last day and shown on its own. */
+.live-chain-divider {
+  flex: 0 0 2px;
+  align-self: stretch;
+  margin: 0 18px;
+  border-radius: 1px;
+  /*
+   * NOT --border-secondary: that resolves to rgba(255,255,255,0.04) on the dark
+   * rail, which measured out as a 1px line at 4% opacity -- invisible, and #286
+   * asked for a visible separator. Tinted with the busiest block's own amber so
+   * the rule and the card it introduces read as one section.
+   */
+  background: var(--accent-amber, #e09205);
+  opacity: 0.45;
+}
+
+.live-chain-block--busiest {
+  // Amber rather than the rail's own accent, so it reads as "singled out"
+  // rather than "the newest one".
+  border-color: var(--accent-amber, #e09205);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--accent-amber, #e09205);
+  }
+}
+
+.live-chain-block-busiest-marker {
+  font-size: 0.5rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent-amber, #e09205);
+  white-space: nowrap;
+}
+
+.live-chain-chip--busiest {
+  --chip-color: var(--accent-amber, #e09205);
+  font-weight: 700;
+}
+
+// Stacked, the vertical rule has nothing to divide; make it a horizontal one.
+@media (max-width: 720px) {
+  .live-chain-divider {
+    flex: 0 0 100%;
+    height: 1px;
+    align-self: auto;
+    margin: 10px 0;
+  }
+}

--- a/client/src/live/Live.jsx
+++ b/client/src/live/Live.jsx
@@ -22,6 +22,8 @@ import { computeLiveStatus } from 'live/liveStatus';
 import { relativeTime } from 'live/timeFormat';
 
 import { ChainRail } from 'live/ChainRail';
+import { busiestBlockToRailBlock } from 'live/busiestBlock';
+import { fetch_chain_activity } from 'analytics/chainActivity';
 import { DetailsPanel } from 'live/DetailsPanel';
 import { FlowCanvas } from 'live/FlowCanvas';
 import { LiveStatusBadge } from 'live/LiveStatusBadge';
@@ -43,6 +45,14 @@ const MAX_VISIBLE_BLOCK_COUNT = 10;
 // since this lives in a different file from the CSS that defines it.
 const CHAIN_BLOCK_SLOT_WIDTH = 150;
 const CHAIN_PANEL_HORIZONTAL_PADDING = 32;
+/*
+ * Width held back for the busiest-block slot and the divider before it (#286).
+ * Reserved unconditionally rather than only when a busiest block exists: it
+ * keeps the count stable instead of reflowing the whole rail the moment the
+ * scanner produces one, and "show fewer live blocks" is part of what #286
+ * asked for.
+ */
+const BUSIEST_SLOT_WIDTH = 190;
 const LEAVE_ANIMATION_MS = 550;
 // A handful of consecutive failed block fetches means "unavailable", not a
 // single blip — matches the resilience shape used elsewhere (#144).
@@ -63,6 +73,10 @@ export default function Live() {
   // every 5 minutes, but recreating pollFast would tear down and rebuild the
   // setInterval timers for no reason).
   const [globalRankings, setGlobalRankings] = useState(null);
+  // #286: the busiest block of the last 24h, from the chain-activity scanner
+  // rather than the live poll -- it is almost never among the blocks on the
+  // rail, which is the whole reason it gets its own slot.
+  const [busiestBlock, setBusiestBlock] = useState(null);
   // How many blocks the rail shows — grows/shrinks with available width
   // (see the ResizeObserver effect below), bounded to [5, 10].
   const [visibleBlockCount, setVisibleBlockCount] = useState(MIN_VISIBLE_BLOCK_COUNT);
@@ -159,6 +173,13 @@ export default function Live() {
     globalRankingsRef.current = rankings;
     setGlobalRankings(rankings);
 
+    // Cheap, synchronous on the server (a read of persisted scanner state) and
+    // only meaningful once per block, so it rides the 5-minute refresh rather
+    // than the fast poll.
+    fetch_chain_activity()
+      .then((activity) => setBusiestBlock(busiestBlockToRailBlock(activity?.busiestBlock)))
+      .catch(() => {});
+
     const currentHeight = tipBlocks[0]?.height || 0;
     const specs = await fetch_global_app_specs({ fluxBlockHeight: currentHeight });
 
@@ -182,7 +203,7 @@ export default function Live() {
     if (!el || typeof ResizeObserver === 'undefined') return undefined;
 
     const computeCount = (width) => {
-      const usable = Math.max(0, width - CHAIN_PANEL_HORIZONTAL_PADDING);
+      const usable = Math.max(0, width - CHAIN_PANEL_HORIZONTAL_PADDING - BUSIEST_SLOT_WIDTH);
       const fit = Math.floor(usable / CHAIN_BLOCK_SLOT_WIDTH);
       return Math.min(MAX_VISIBLE_BLOCK_COUNT, Math.max(MIN_VISIBLE_BLOCK_COUNT, fit || MIN_VISIBLE_BLOCK_COUNT));
     };
@@ -247,7 +268,11 @@ export default function Live() {
 
   const tipHeight = displayBlocks.find((b) => b.phase !== 'leaving')?.height ?? null;
   const displayedHeight = selectedHeight ?? tipHeight;
-  const displayedBlock = displayBlocks.find((b) => b.height === displayedHeight) || null;
+  const displayedBlock =
+    displayBlocks.find((b) => b.height === displayedHeight) ||
+    // #286: the busiest block is not on the rail, so it would otherwise resolve
+    // to null and leave the details panel blank when selected.
+    (busiestBlock && displayedHeight === busiestBlock.height ? busiestBlock : null);
   const summary = useMemo(() => buildBlockFlowSummary(displayedBlock), [displayedBlock]);
   const locked = selectedHeight != null;
 
@@ -321,10 +346,14 @@ export default function Live() {
   // 5-slot window entirely has nothing left to show — resume following the
   // tip rather than leaving the panel stuck on "loading" forever.
   useEffect(() => {
-    if (selectedHeight != null && !displayBlocks.some((b) => b.height === selectedHeight)) {
+    if (selectedHeight == null) return;
+    // #286: the busiest block is deliberately not in displayBlocks, so it must
+    // be exempted here or selecting it would clear itself on the next poll.
+    if (busiestBlock && selectedHeight === busiestBlock.height) return;
+    if (!displayBlocks.some((b) => b.height === selectedHeight)) {
       setSelectedHeight(null);
     }
-  }, [displayBlocks, selectedHeight]);
+  }, [displayBlocks, selectedHeight, busiestBlock]);
 
   return (
     <div className="live-page">
@@ -378,6 +407,7 @@ export default function Live() {
             tipHeight={tipHeight}
             selectedHeight={selectedHeight}
             onSelectBlock={handleSelectBlock}
+            busiestBlock={busiestBlock}
           />
         </div>
         <DetailsPanel

--- a/client/src/live/busiestBlock.js
+++ b/client/src/live/busiestBlock.js
@@ -1,0 +1,56 @@
+/*
+ * The busiest block of the last 24 hours, adapted for the live rail (#286).
+ *
+ * Two vocabularies meet here. The rail and the details panel speak in
+ * `events` -- the shape live/apidata.js builds from a freshly polled block.
+ * chain-activity persists `transfers`, because that is what the scanner
+ * extracts and stores. This is the only place that translates between them,
+ * so a change to either shape breaks in one obvious spot rather than showing
+ * the right block with the wrong contents.
+ *
+ * The block itself comes from the backend, which ranks on transfers plus
+ * deployments over a 2,880-block window (24h at the 30-second target). The
+ * `activity` figure here is that same sum, restated so the rail can show what
+ * the block was picked for.
+ */
+
+export const BUSIEST_LABEL = 'BUSIEST BLOCK';
+
+export function busiestBlockToRailBlock(record) {
+  if (!record || typeof record.height !== 'number') return null;
+
+  const transfers = Array.isArray(record.transfers) ? record.transfers : [];
+  const transferCount = record.transferCount || 0;
+  const deploymentCount = record.deploymentCount || 0;
+
+  return {
+    height: record.height,
+    date: record.date || null,
+    isBusiest: true,
+    transferCount,
+    deploymentCount,
+    // What the backend ranked on. Shown on the card so the block does not just
+    // assert it is the busiest without saying by what measure.
+    activity: transferCount + deploymentCount,
+    /*
+     * False for anything scanned before #282 started storing transfers. The
+     * block is still worth showing -- it genuinely was the busiest -- but the
+     * panel has to say the transactions were not recorded rather than render an
+     * empty list, which would read as "this block had none".
+     */
+    transfersAvailable: transfers.length > 0,
+    events: transfers.map((t, i) => ({
+      /*
+       * Index in the id, not just txid. One transaction can pay several
+       * addresses and the scanner emits one transfer per output -- block
+       * 2,920,896 has twelve sharing a single txid -- so txid alone collides.
+       */
+      id: `p2p-${t.txid}-${i}`,
+      type: 'p2p',
+      txid: t.txid,
+      from: t.from || null,
+      to: t.to,
+      amount: t.amount,
+    })),
+  };
+}

--- a/client/src/live/busiestBlock.test.js
+++ b/client/src/live/busiestBlock.test.js
@@ -1,0 +1,77 @@
+import { busiestBlockToRailBlock, BUSIEST_LABEL } from 'live/busiestBlock';
+
+/*
+ * Issue #286 part 3: the busiest block of the last 24 hours, shown apart from
+ * the live rail and openable like any other block.
+ *
+ * The bridge that needs testing is the shape change. The rail and the details
+ * panel speak in `events`; chain-activity persists `transfers`. Getting that
+ * mapping wrong shows the right block with the wrong contents, which looks
+ * entirely plausible on screen.
+ */
+const record = {
+  height: 2920896,
+  date: '2026-09-04',
+  transferCount: 12,
+  deploymentCount: 2,
+  transfers: [
+    { txid: 'aaa', from: 't1alice', to: 't1bob', amount: 6.25 },
+    { txid: 'aaa', from: 't1alice', to: 't1carol', amount: 2.87 },
+  ],
+};
+
+describe('busiestBlockToRailBlock', () => {
+  test('carries the height and the activity counts through', () => {
+    const b = busiestBlockToRailBlock(record);
+    expect(b.height).toBe(2920896);
+    expect(b.transferCount).toBe(12);
+    expect(b.deploymentCount).toBe(2);
+    expect(b.isBusiest).toBe(true);
+  });
+
+  test('ranks on transfers plus deployments, matching the backend', () => {
+    expect(busiestBlockToRailBlock(record).activity).toBe(14);
+  });
+
+  test('turns stored transfers into p2p events the details panel understands', () => {
+    const [first, second] = busiestBlockToRailBlock(record).events;
+    expect(first).toMatchObject({ type: 'p2p', txid: 'aaa', from: 't1alice', to: 't1bob', amount: 6.25 });
+    expect(second).toMatchObject({ type: 'p2p', to: 't1carol', amount: 2.87 });
+  });
+
+  /*
+   * One transaction paying several addresses produces several transfers with
+   * the SAME txid -- seen live on block 2,920,896, twelve outputs sharing one
+   * txid. Ids keyed on txid alone would collide in the rendered list.
+   */
+  test('gives same-txid outputs distinct ids', () => {
+    const ids = busiestBlockToRailBlock(record).events.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  /*
+   * Records scanned before #282 carry a count but no stored transfers. The
+   * block is still worth showing -- it really was the busiest -- but the panel
+   * must not imply it had no transactions.
+   */
+  test('marks a block whose transfers were never stored', () => {
+    const b = busiestBlockToRailBlock({ ...record, transfers: [] });
+    expect(b.events).toEqual([]);
+    expect(b.transfersAvailable).toBe(false);
+    expect(b.transferCount).toBe(12);
+  });
+
+  test('a block with its transfers stored reports them as available', () => {
+    expect(busiestBlockToRailBlock(record).transfersAvailable).toBe(true);
+  });
+
+  test('returns null for a missing record rather than a half-built block', () => {
+    expect(busiestBlockToRailBlock(null)).toBeNull();
+    expect(busiestBlockToRailBlock(undefined)).toBeNull();
+    expect(busiestBlockToRailBlock({})).toBeNull();
+  });
+
+  test('has a label, so the rail and the tests cannot drift apart', () => {
+    expect(BUSIEST_LABEL).toMatch(/busiest/i);
+  });
+});


### PR DESCRIPTION
Completes #286. The backend landed in #303; this is the UI half, held back until
#282 gave it transactions to open.

## Sectioned off, not spliced in

The rail shows fewer live blocks and then, past a rule, **one block: the busiest
of the last 24 hours** by transfers + deployments.

Separated with a **solid amber rule**, not the animated dashed connector used
between live blocks — that connector means "these are consecutive in the chain",
which this block is not.

The rule is amber at 45%, not `--border-secondary`. That token resolves to
`rgba(255,255,255,0.04)` on the dark rail, which measured out as **a 1px line at
4% opacity — invisible**, and you asked for a visible `|`. Tinting it with the
card's own amber makes the rule and the block read as one section.

Rail width for the slot is reserved **unconditionally** rather than only when a
busiest block exists — it keeps the count stable instead of reflowing the whole
rail the moment the scanner produces one, and fewer live blocks is part of what
#286 asked for. Measured: **7 live blocks before, 5 after.**

## The shape change is the part worth testing

The rail and details panel speak in `events`; chain-activity persists
`transfers`. `busiestBlock.js` is the only place that translates, so a change to
either breaks in one obvious spot rather than showing the right block with the
wrong contents.

Event ids are keyed on **txid + index** — block 2,920,896 has twelve transfers
sharing one txid, so txid alone collides.

`transfersAvailable` marks a block scanned before #282 started storing
transfers: still worth showing, since it genuinely was the busiest, but the
panel mustn't imply it had no transactions.

## Two wiring details that would otherwise bite

The busiest block is deliberately **not** in `displayBlocks`, so:

- `displayedBlock` resolves it explicitly, or selecting it leaves the panel blank
- the effect that clears a selection aged out of the rail **exempts** it, or
  selecting it would clear itself on the next poll

It rides the 5-minute slow refresh, not the fast poll — the endpoint is a
synchronous read of persisted state and changes at most once per block.

## Verification

Against a container scanning a cold volume until it produced one:

- Rail: **5 live blocks**, visible 2px amber divider, then `BUSIEST BLOCK
  #2920896 / last 24h / 12`. `role=button`, `tabIndex=0`, real `aria-label`.
- Clicking enters HISTORY mode *"Viewing #2920896"* and the details panel renders
  **all 12 transfers**, sender → recipient with amounts.
- The flow summary reads **35.2198 FLUX moved** — the exact sum of those twelve
  transfers.
- **Rust 60 passed**, client **814 passed / 5 skipped / 0 failed**.
- **Node page regression**, `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`: **127 rows,
  all NIMBUS**, 0 bleed.
- **D1 audit: AGREE**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7584Ky3yKYaudaUdrTsX9
