### PR TITLE
Donor tab: filterable nodes and apps, a real apps table, one clock band (#299, #300, #301)

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
 import { Lock } from 'lucide-react';
 import { useDonorStatus } from 'contexts/DonorContext';
@@ -6,14 +6,24 @@ import { PremiumUnlock } from 'donor/PremiumUnlock';
 import { fetch_global_stats, fetch_total_network_utils, fetch_global_app_specs_raw } from 'apidata';
 import { buildSpecIndex } from 'appSpecs';
 import { fetch_donor_nodes, sortByRank, mostRecentPayout } from 'analytics/donorNodes';
-import { fetch_donor_utilization } from 'analytics/donorUtilization';
-import { aggregateDonorAppsByCategory } from 'analytics/donorApps';
+import { fetch_donor_utilization_source, aggregateDonorUtilization } from 'analytics/donorUtilization';
+import { buildDonorAppRows, tallyRowCategories } from 'analytics/donorAppRows';
+import { buildDonorNodeRows } from 'analytics/donorNodeRows';
+import { filterAppRows, utilizationAddresses } from 'analytics/donorFilters';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { tierMeta } from 'content/nodeTierMeta';
 import { fetch_wallet_tx_history } from 'analytics/walletTxFetch';
 import { counterpartyDisplay, WINDOW_DAYS } from 'analytics/walletTxHistory';
 import { RewardCountdown } from 'rewards/RewardCountdown';
 import { rewardImpact, tallyWalletTiers } from 'rewards/rewardReduction';
 import './index.scss';
+
+const EMPTY_UTILIZATION = {
+  nodesWithCapacity: 0,
+  cores: { utilized: 0, total: 0, percentage: 0 },
+  ram: { utilized: 0, total: 0, percentage: 0 },
+  ssd: { utilized: 0, total: 0, percentage: 0 },
+};
 
 function fmtNum(n) {
   if (!n && n !== 0) return '—';
@@ -26,12 +36,12 @@ function fmtPct(n) {
 
 
 function fmtFlux(n) {
-  if (n == null) return '\u2014';
+  if (n == null) return '—';
   return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function txTime(unixSeconds) {
-  if (!unixSeconds) return '\u2014';
+  if (!unixSeconds) return '—';
   return new Date(unixSeconds * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
@@ -112,7 +122,7 @@ function WalletActivityPanel({ walletAddress }) {
       </div>
 
       <div className={`dt-activity-net${net >= 0 ? ' dt-activity-net--up' : ' dt-activity-net--down'}`}>
-        net {net >= 0 ? '+' : '\u2212'}{fmtFlux(Math.abs(net))} FLUX over {WINDOW_DAYS} days
+        net {net >= 0 ? '+' : '−'}{fmtFlux(Math.abs(net))} FLUX over {WINDOW_DAYS} days
       </div>
 
       <div className="dt-activity-list">
@@ -126,7 +136,7 @@ function WalletActivityPanel({ walletAddress }) {
                 {counterpartyDisplay(row)}
               </span>
               <span className={`dt-activity-amount dt-activity-amount--${row.direction}`}>
-                {row.direction === 'in' ? '+' : '\u2212'}{fmtFlux(row.amount)}
+                {row.direction === 'in' ? '+' : '−'}{fmtFlux(row.amount)}
               </span>
             </div>
           ))
@@ -231,7 +241,7 @@ function RewardImpactPanel({ nodes, gstore }) {
       <div className="dt-impact-tiers">
         {Object.entries(impact.perTier).map(([tier, t]) => (
           <span key={tier} className="dt-impact-chip">
-            {tier.charAt(0) + tier.slice(1).toLowerCase()} &times;{t.nodes}
+            {tierMeta(tier).label} &times;{t.nodes}
             <strong>{fmtSigned(t.deltaDaily)}</strong>
             <small>FLUX/day</small>
           </span>
@@ -249,14 +259,14 @@ function RewardImpactPanel({ nodes, gstore }) {
 }
 
 /*
- * The three time-based facts on this tab, in one band (issue #288).
+ * Last payout, next payout, and the reward countdown, in one band.
  *
- * The two payout stats had a full-width panel to themselves and the reward
- * countdown had another below it, so the tab opened with two mostly-empty rows
- * -- each stat was given half a 2,100px panel to hold about 300px of text.
- * Putting the countdown in alongside them fills the row with the thing that
- * belongs there anyway: when you were last paid, when you are next paid, and
- * when the reward itself changes.
+ * #288 already merged these three -- this is that component unchanged, moved
+ * INTO the panel grid so it can sit beside REWARD REDUCTION IMPACT, which is
+ * the half of #300 that was still outstanding. The tab's separate hero, which
+ * rendered "57 mins / NEXT PAYOUT" directly above this card's own
+ * "NEXT PAYOUT / 57 mins", is deleted rather than restyled: it was duplication,
+ * not emphasis.
  */
 function PayoutCard({ nextNode, lastPaidNode, currentBlock }) {
   return (
@@ -284,24 +294,82 @@ function PayoutCard({ nextNode, lastPaidNode, currentBlock }) {
 
 // ── Your nodes ────────────────────────────────────────────────────────────
 
-function DonorNodesList({ nodes }) {
+function fmtEps(eps) {
+  if (eps == null) return '—';
+  return Math.round(eps).toLocaleString();
+}
+
+/*
+ * The donor's nodes, and the tab's primary filter (issues #299, #301).
+ *
+ * Selecting a row narrows the apps table, the category tally and the
+ * utilisation panel to that one machine; the count badge clears it. The badge
+ * doubles as the reset because that is where #299 asked for it, and because a
+ * separate "clear" control would be one more thing on a row that is already
+ * carrying five columns.
+ *
+ * EPS is deliberately NOT scored against a pass mark. Flux publishes no per-tier
+ * EPS floor that could be cited here, and inventing thresholds would dress a
+ * guess up as a verdict -- so the bar is relative to the best reading in this
+ * wallet's own list, which is a comparison the data actually supports. Only a
+ * genuinely absent reading is called out, and as absent rather than as bad.
+ */
+function DonorNodesList({ rows, selectedNode, onSelect, onReset }) {
+  const maxEps = rows.reduce((max, n) => (n.eps != null && n.eps > max ? n.eps : max), 0);
+
   return (
     <div className="hov-panel dt-nodes-panel">
       <div className="hov-header">
         <span className="hov-header-title">YOUR NODES</span>
-        <span className="hov-header-badge">{nodes.length}</span>
+        <button
+          type="button"
+          className={`hov-header-badge dt-badge-reset${selectedNode ? ' dt-badge-reset--active' : ''}`}
+          onClick={onReset}
+          title={selectedNode ? 'Show all nodes again' : 'All nodes'}
+        >
+          {selectedNode ? `1 / ${rows.length}` : rows.length}
+        </button>
       </div>
-      <div className="hov-ranked-list">
-        {nodes.length === 0 ? (
+      <div className="dt-nodes-head">
+        <span>Tier</span>
+        <span>Address</span>
+        <span className="dt-num">Rank</span>
+        <span className="dt-num">Window</span>
+        <span className="dt-num">EPS</span>
+      </div>
+      <div className="hov-ranked-list dt-nodes-list">
+        {rows.length === 0 ? (
           <div className="hov-empty">No nodes found for this wallet</div>
         ) : (
-          nodes.map((n) => (
-            <div key={n.id} className="hov-ranked-row">
-              <span className="dt-node-tier">{n.tier}</span>
-              <span className="hov-ranked-name" title={n.ip_display}>{n.ip_display}</span>
-              <span className="hov-badge">Rank {fmtNum(n.rank)}</span>
-            </div>
-          ))
+          rows.map((n) => {
+            const meta = tierMeta(n.tier);
+            const selected = selectedNode === n.ip_display;
+            return (
+              <button
+                type="button"
+                key={n.id}
+                className={`hov-ranked-row dt-node-row${selected ? ' dt-node-row--selected' : ''}`}
+                onClick={() => onSelect(n.ip_display)}
+                title={selected ? 'Selected — click the count to show all' : `Show only ${n.ip_display}`}
+              >
+                <span className="dt-node-tier" style={{ color: meta.color, borderColor: `${meta.color}55` }}>
+                  {meta.label}
+                </span>
+                <span className="hov-ranked-name" title={n.ip_display}>{n.ip_display}</span>
+                <span className="dt-num dt-node-rank">{fmtNum(n.rank)}</span>
+                <span className={`dt-num dt-node-window${n.mtnWindow === 'Closed' ? ' dt-node-window--closed' : ''}`}>
+                  {n.mtnWindow || '—'}
+                </span>
+                <span className={`dt-num dt-node-eps${n.eps == null ? ' dt-node-eps--none' : ''}`}>
+                  {fmtEps(n.eps)}
+                  <i
+                    className="dt-node-eps-bar"
+                    style={{ width: maxEps > 0 && n.eps != null ? `${(n.eps / maxEps) * 100}%` : 0 }}
+                  />
+                </span>
+              </button>
+            );
+          })
         )}
       </div>
     </div>
@@ -310,14 +378,28 @@ function DonorNodesList({ nodes }) {
 
 // ── Apps by category ─────────────────────────────────────────────────────
 
-function AppsByCategoryPanel({ categories, totalApps }) {
+/*
+ * Renamed from "Apps on your Nodes" (issue #299): it was never a list of apps,
+ * it was a tally of their categories, and the name was taken by the table that
+ * now sits below. Its rows filter the table the same way a node row does.
+ */
+function AppCategoriesPanel({ categories, totalApps, selectedCategory, onSelect, onReset }) {
   const maxVal = categories[0]?.count || 1;
 
   return (
     <div className="hov-panel dt-apps-panel">
       <div className="hov-header">
-        <span className="hov-header-title">APPS ON YOUR NODES</span>
-        {totalApps > 0 && <span className="hov-header-badge">{totalApps}</span>}
+        <span className="hov-header-title">APP CATEGORIES</span>
+        {totalApps > 0 && (
+          <button
+            type="button"
+            className={`hov-header-badge dt-badge-reset${selectedCategory ? ' dt-badge-reset--active' : ''}`}
+            onClick={onReset}
+            title={selectedCategory ? 'Show all categories again' : 'All categories'}
+          >
+            {totalApps}
+          </button>
+        )}
       </div>
       <div className="dt-apps-list">
         {categories.length === 0 ? (
@@ -327,8 +409,15 @@ function AppsByCategoryPanel({ categories, totalApps }) {
             const meta = APP_CATEGORY_META[category] || APP_CATEGORY_META.other;
             const { label, Icon, color } = meta;
             const barPct = (count / maxVal) * 100;
+            const selected = selectedCategory === category;
             return (
-              <div key={category} className="dt-apps-row">
+              <button
+                type="button"
+                key={category}
+                className={`dt-apps-row${selected ? ' dt-apps-row--selected' : ''}`}
+                onClick={() => onSelect(category)}
+                title={selected ? 'Selected — click the count to show all' : `Show only ${label} apps`}
+              >
                 <span className="dt-apps-icon" style={{ color }}>
                   <Icon size={11} />
                 </span>
@@ -337,10 +426,93 @@ function AppsByCategoryPanel({ categories, totalApps }) {
                   <div className="dt-apps-bar-fill" style={{ width: `${barPct}%`, background: color }} />
                 </div>
                 <span className="hov-badge">{fmtNum(count)}</span>
-              </div>
+              </button>
             );
           })
         )}
+      </div>
+    </div>
+  );
+}
+
+// ── The apps themselves ──────────────────────────────────────────────────
+
+/*
+ * A resource cell. null is "not knowable" (an enterprise app's compose is
+ * encrypted; an unresolvable spec has no figures at all) and must not render as
+ * 0 -- nor as "— GB", which reads as a unit attached to a missing number rather
+ * than as no answer, so the unit goes with the value or not at all.
+ */
+function ResCell({ value, digits = 1, unit }) {
+  if (value == null) return <>—</>;
+  return (
+    <>
+      {value.toLocaleString(undefined, { maximumFractionDigits: digits })}
+      {unit && <small> {unit}</small>}
+    </>
+  );
+}
+
+/*
+ * APPS ON YOUR NODES, as an actual list of apps (issue #299).
+ *
+ * One row per running container, so an app deployed to three of the wallet's
+ * nodes appears three times -- that is what is running, and collapsing it would
+ * hide exactly the thing a node filter is for. The repo column is the image of
+ * the specific component this container is, not the app's primary image.
+ */
+function DonorAppsTable({ rows, totalRows, filtered }) {
+  return (
+    <div className="hov-panel dt-appstable-panel">
+      <div className="hov-header">
+        <span className="hov-header-title">APPS ON YOUR NODES</span>
+        <span className="hov-header-badge">{filtered ? `${rows.length} / ${totalRows}` : rows.length}</span>
+      </div>
+      {rows.length === 0 ? (
+        <div className="hov-empty">
+          {totalRows === 0 ? 'No running apps found' : 'No apps match the current selection'}
+        </div>
+      ) : (
+        <div className="dt-appstable-scroll">
+          <table className="dt-appstable">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Repo</th>
+                <th>Node</th>
+                <th className="dt-num">CPU</th>
+                <th className="dt-num">RAM</th>
+                <th className="dt-num">SSD</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const meta = APP_CATEGORY_META[row.category] || APP_CATEGORY_META.other;
+                return (
+                  <tr key={row.key}>
+                    <td className="dt-appstable-name" title={row.name}>
+                      <span className="dt-appstable-dot" style={{ background: meta.color }} />
+                      {row.name}
+                      {row.component && <small className="dt-appstable-component">/{row.component}</small>}
+                    </td>
+                    <td className="dt-appstable-repo" title={row.repotag || 'Image not published'}>
+                      {row.repotag || '—'}
+                    </td>
+                    <td className="dt-appstable-node" title={row.nodeAddress}>{row.nodeAddress}</td>
+                    <td className="dt-num"><ResCell value={row.cpu} /></td>
+                    <td className="dt-num"><ResCell value={row.ramGB} unit="GB" /></td>
+                    <td className="dt-num"><ResCell value={row.ssdGB} digits={0} unit="GB" /></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <div className="dt-appstable-caption">
+        One row per running container. Resources are what the specification
+        reserves per instance; an enterprise app&apos;s specification is
+        encrypted, so its figures read as unknown rather than zero.
       </div>
     </div>
   );
@@ -354,11 +526,12 @@ const RESOURCE_ROWS = [
   { key: 'ssd', label: 'SSD' },
 ];
 
-function UtilizationPanel({ donorUtil, networkPct }) {
+function UtilizationPanel({ donorUtil, networkPct, selectedNode }) {
   return (
     <div className="hov-panel dt-util-panel">
       <div className="hov-header">
         <span className="hov-header-title">UTILIZATION VS NETWORK AVERAGE</span>
+        {selectedNode && <span className="hov-header-badge">{selectedNode}</span>}
       </div>
       {donorUtil.nodesWithCapacity === 0 ? (
         <div className="hov-empty">No capacity data available for your nodes</div>
@@ -413,13 +586,16 @@ export function DonorTab() {
 
   const [loading, setLoading] = useState(true);
   const [nodes, setNodes] = useState([]);
-  const [utilization, setUtilization] = useState({
-    nodesWithCapacity: 0,
-    cores: { utilized: 0, total: 0, percentage: 0 },
-    ram: { utilized: 0, total: 0, percentage: 0 },
-    ssd: { utilized: 0, total: 0, percentage: 0 },
-  });
-  const [appCategories, setAppCategories] = useState({ categories: [], totalApps: 0 });
+  /*
+   * The RAW utilisation feeds, not the summed result. Selecting a node
+   * re-aggregates over that one address (issue #299), and a percentage of a
+   * subset cannot be recovered from a percentage of the whole -- so the tab has
+   * to hold the inputs. Both fetches are the shared module-level ones, so this
+   * costs no extra network traffic.
+   */
+  const [utilSource, setUtilSource] = useState({ benchmarks: [], resources: [] });
+  const [nodesByIp, setNodesByIp] = useState({});
+  const [specIndex, setSpecIndex] = useState({});
   const [networkPct, setNetworkPct] = useState({ cores: 0, ram: 0, ssd: 0 });
   /*
    * The loader already fetches the global store for utilisation and app
@@ -429,6 +605,11 @@ export function DonorTab() {
    */
   const [gstore, setGstore] = useState(null);
 
+  // The two selections (issue #299). Independent: a node narrows apps,
+  // categories and utilisation; a category narrows only the apps table.
+  const [selectedNode, setSelectedNode] = useState(null);
+  const [selectedCategory, setSelectedCategory] = useState(null);
+
   useEffect(() => {
     if (!donorWallet) {
       setLoading(false);
@@ -436,6 +617,9 @@ export function DonorTab() {
     }
 
     setLoading(true);
+    // A different wallet's node is not a selection that can survive.
+    setSelectedNode(null);
+    setSelectedCategory(null);
 
     let cancelled = false;
 
@@ -444,19 +628,17 @@ export function DonorTab() {
       if (cancelled) return;
       setNodes(donorNodes);
 
-      const addresses = donorNodes.map((n) => n.ip_display).filter(Boolean);
-
       // fetch_total_network_utils() already calls fetch_fluxinfo_aggregate()
       // internally and carries nodesByIp through onto its resolved gstore
       // (apidata.js's fetchTotalDeployedApps, Task 1) — read it from there
       // rather than fetching the ~726KB fluxinfo payload a second time.
-      const [util, stage1] = await Promise.all([
-        fetch_donor_utilization(addresses),
+      const [source, stage1] = await Promise.all([
+        fetch_donor_utilization_source(),
         fetch_global_stats(null),
       ]);
       if (cancelled) return;
 
-      setUtilization(util);
+      setUtilSource(source);
 
       // Named distinctly from the `gstore` state above: shadowing it here
       // compiles and behaves correctly, but reads as though setGstore were
@@ -467,8 +649,8 @@ export function DonorTab() {
       ]);
       if (cancelled) return;
 
-      const specIndex = buildSpecIndex(rawSpecs);
-      setAppCategories(aggregateDonorAppsByCategory(fetchedStore.nodesByIp || {}, addresses, specIndex));
+      setSpecIndex(buildSpecIndex(rawSpecs));
+      setNodesByIp(fetchedStore.nodesByIp || {});
       setGstore(fetchedStore);
       setNetworkPct({
         cores: fetchedStore.utilized.cores_percentage,
@@ -484,6 +666,39 @@ export function DonorTab() {
 
     return () => { cancelled = true; };
   }, [donorWallet]);
+
+  const addresses = useMemo(() => nodes.map((n) => n.ip_display).filter(Boolean), [nodes]);
+
+  const nodeRows = useMemo(
+    () => buildDonorNodeRows(nodes, utilSource.benchmarks, gstore?.current_block_height),
+    [nodes, utilSource, gstore]
+  );
+
+  const allAppRows = useMemo(
+    () => buildDonorAppRows(nodesByIp, addresses, specIndex),
+    [nodesByIp, addresses, specIndex]
+  );
+
+  // The apps table sees both selections; the category tally sees only the node
+  // one, or selecting a category would collapse the panel to the single row
+  // that was just clicked and there would be no way back.
+  const appRows = useMemo(
+    () => filterAppRows(allAppRows, { node: selectedNode, category: selectedCategory }),
+    [allAppRows, selectedNode, selectedCategory]
+  );
+  const categoryTally = useMemo(
+    () => tallyRowCategories(filterAppRows(allAppRows, { node: selectedNode })),
+    [allAppRows, selectedNode]
+  );
+
+  const utilization = useMemo(() => {
+    if (addresses.length === 0) return EMPTY_UTILIZATION;
+    return aggregateDonorUtilization(
+      utilizationAddresses(addresses, selectedNode),
+      utilSource.benchmarks,
+      utilSource.resources
+    );
+  }, [addresses, selectedNode, utilSource]);
 
   if (!donorWallet) {
     return (
@@ -506,20 +721,28 @@ export function DonorTab() {
 
   return (
     <div className="donor-tab">
-      <div className="dt-tab-hero">
-        <span className="dt-tab-hero-value">{nextNode ? nextNode.next_reward : '—'}</span>
-        <span className="dt-tab-hero-label">Next payout</span>
-      </div>
-      <PayoutCard
-        nextNode={nextNode}
-        lastPaidNode={lastPaidNode}
-        currentBlock={gstore?.current_block_height}
-      />
       <div className="donor-tab-panel-grid">
-        <DonorNodesList nodes={nodes} />
-        <AppsByCategoryPanel categories={appCategories.categories} totalApps={appCategories.totalApps} />
-        <UtilizationPanel donorUtil={utilization} networkPct={networkPct} />
+        <PayoutCard nextNode={nextNode} lastPaidNode={lastPaidNode} currentBlock={gstore?.current_block_height} />
         <RewardImpactPanel nodes={nodes} gstore={gstore} />
+        <DonorNodesList
+          rows={nodeRows}
+          selectedNode={selectedNode}
+          onSelect={setSelectedNode}
+          onReset={() => setSelectedNode(null)}
+        />
+        <AppCategoriesPanel
+          categories={categoryTally.categories}
+          totalApps={categoryTally.totalApps}
+          selectedCategory={selectedCategory}
+          onSelect={setSelectedCategory}
+          onReset={() => setSelectedCategory(null)}
+        />
+        <UtilizationPanel donorUtil={utilization} networkPct={networkPct} selectedNode={selectedNode} />
+        <DonorAppsTable
+          rows={appRows}
+          totalRows={allAppRows.length}
+          filtered={!!(selectedNode || selectedCategory)}
+        />
         <WalletActivityPanel walletAddress={donorWallet} />
       </div>
     </div>

--- a/client/src/analytics/DonorTab/index.scss
+++ b/client/src/analytics/DonorTab/index.scss
@@ -7,59 +7,56 @@
 }
 
 /*
- * Three columns at most (issue #288).
+ * Twelve tracks, spanned explicitly.
  *
- * This was `repeat(auto-fit, minmax(320px, 1fr))`, which sizes tracks to the
- * CONTAINER rather than to the content: on a 2125px viewport it laid out six
- * 340px tracks. Only three panels take a single track each -- the other two
- * span the full row -- so half the row was permanently empty, and the three
- * cards stayed narrow while there was 1,050px of nothing beside them.
+ * #288 took this off `repeat(auto-fit, minmax(320px, 1fr))` and onto three
+ * equal columns, which fixed the empty tracks. Twelve is the same idea with
+ * one more degree of freedom: the payout band and the utilisation panel want
+ * more width than the category tally, and equal columns cannot say that. The
+ * apps table and the activity panel span the row exactly as before.
  *
- * Explicit breakpoints instead, matching apps-tab-panel-grid: the count is
- * driven by how many panels there actually are, so they always fill the row.
+ * `align-items: start` is the load-bearing line, and it is not cosmetic.
+ * A grid row stretches every item to the tallest, and YOUR NODES renders one
+ * row per node: measured on a 127-node wallet, the nodes panel was 4,197px and
+ * dragged APPS (content 203px) and UTILIZATION (content 202px) to 4,197px with
+ * it -- about 8,000px of blank panel that no column count could have fixed.
+ * Capping the node list (below) removes today's cause; this removes the
+ * mechanism, so the next long panel cannot do it again.
  */
 .donor-tab-panel-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: start;
   gap: 16px;
-
-  @media (min-width: 720px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  @media (min-width: 1100px) {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
 }
 
-/*
- * The reward countdown, sized for a place it shares (issue #288).
- *
- * `compact` shrinks the digits; this pulls in the spacing PayoutTimer's
- * stylesheet sets for a panel of its own, and caps the width so the four
- * numbers read as one clock instead of being flung into the corners by
- * space-between across a 2000px row.
- */
-.donor-tab > .rwc-timer {
-  width: 100%;
-  max-width: 520px;
-  margin: 0 auto;
+.dt-payout-card     { grid-column: span 7; }
+.dt-impact-panel    { grid-column: span 5; }
+.dt-nodes-panel     { grid-column: span 4; }
+.dt-apps-panel      { grid-column: span 3; }
+.dt-util-panel      { grid-column: span 5; }
+.dt-appstable-panel { grid-column: span 12; }
+.dt-activity-panel  { grid-column: span 12; }
 
-  .timer-header {
-    padding: 10px 14px 2px;
+// Laptop widths: the row stops being readable well before it stops fitting, so
+// the wide panels go full-width and the two narrow ones pair up.
+@media (max-width: 1400px) {
+  .dt-payout-card     { grid-column: span 12; }
+  .dt-impact-panel    { grid-column: span 12; }
+  .dt-nodes-panel     { grid-column: span 6; }
+  .dt-apps-panel      { grid-column: span 6; }
+  .dt-util-panel      { grid-column: span 12; }
+}
+
+// Single column. Scoped through `.hov-panel` so it outranks the span rules
+// above on specificity rather than on !important.
+@media (max-width: 820px) {
+  .donor-tab-panel-grid {
+    grid-template-columns: 1fr;
   }
 
-  .timer-number {
-    margin-top: 4px;
-  }
-
-  .timer-info {
-    margin-top: 2px;
-    margin-bottom: 8px;
-  }
-
-  .v-rule {
-    margin: 8px 5px;
+  .donor-tab-panel-grid > .hov-panel {
+    grid-column: 1 / -1;
   }
 }
 
@@ -294,15 +291,51 @@
 // row layout — caught in the final whole-branch review, not this task's
 // own review, because it only shows up once three tabs' stylesheets are
 // all loaded together.
+// The single biggest source of dead space on this tab: 127 rows is a 4,200px
+// panel, and until `align-items: start` landed above it stretched every panel
+// beside it to match. A scroll cap is also simply how a list this long should
+// behave.
+.dt-nodes-list {
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.dt-nodes-head,
 .dt-nodes-panel .hov-ranked-row {
   display: grid;
   align-items: center;
   gap: 6px;
-  grid-template-columns: 60px 1fr 70px;
-  padding: 4px 6px;
+  grid-template-columns: 68px minmax(0, 1fr) 46px 62px 58px;
+}
+
+.dt-nodes-head {
+  padding: 0 6px 4px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-secondary);
+  margin-bottom: 5px;
+}
+
+.dt-nodes-panel .hov-ranked-row {
+  padding: 5px 6px;
   border-radius: var(--radius-sm);
   border-bottom: 1px solid rgba(128, 128, 128, 0.07);
   transition: background var(--transition-fast);
+
+  // These are <button>s now (issue #299 makes them the tab's filter), so the
+  // browser's own button chrome has to be unwound to leave the row as it was.
+  width: 100%;
+  text-align: left;
+  background: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
 
   &:hover {
     background: var(--surface-inset);
@@ -313,11 +346,90 @@
   }
 }
 
+.dt-node-row--selected {
+  background: rgba(14, 162, 113, 0.1);
+
+  @include rule-mode-dark() {
+    background: rgba(14, 162, 113, 0.16);
+  }
+}
+
+.dt-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .dt-node-tier {
-  font-size: 0.65rem;
+  font-size: 0.62rem;
   font-weight: 700;
-  color: var(--text-tertiary);
   text-transform: uppercase;
+  border: 1px solid;
+  border-radius: 3px;
+  padding: 1px 0;
+  text-align: center;
+}
+
+.dt-node-rank,
+.dt-node-window {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+// A closed window is the actionable state -- it is why a node cannot be
+// restarted right now -- so it is the one that reads differently.
+.dt-node-window--closed {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+// EPS carries a bar rather than a verdict. Flux publishes no per-tier EPS floor
+// this could be scored against, so the bar is relative to the best reading in
+// THIS wallet's own list -- a comparison the data supports -- and only a
+// genuinely absent reading is called out, as absent rather than as bad.
+.dt-node-eps {
+  position: relative;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  padding-bottom: 4px;
+}
+
+.dt-node-eps-bar {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--accent-green);
+  opacity: 0.55;
+}
+
+.dt-node-eps--none {
+  color: var(--text-tertiary);
+}
+
+// Phone width: the same five columns, with the fixed ones pared back so the
+// address -- the only column that identifies the row -- keeps a readable share
+// of the ~330px available rather than the 60px the desktop widths leave it.
+@media (max-width: 820px) {
+  .dt-nodes-head,
+  .dt-nodes-panel .hov-ranked-row {
+    grid-template-columns: 58px minmax(0, 1fr) 38px 54px 48px;
+    gap: 4px;
+  }
+}
+
+// The count badge doubles as the filter reset (issue #299).
+.dt-badge-reset {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.dt-badge-reset--active {
+  background: rgba(14, 162, 113, 0.18);
+  color: var(--accent-green);
 }
 
 .hov-ranked-name {
@@ -358,7 +470,119 @@
   align-items: center;
   gap: 8px;
   grid-template-columns: 16px 90px 1fr 40px;
-  padding: 3px 0;
+  padding: 3px 4px;
+
+  // Also a <button> now; same unwinding as the node rows above.
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
+
+  &:hover {
+    background: var(--surface-inset);
+  }
+}
+
+.dt-apps-row--selected {
+  background: rgba(14, 162, 113, 0.1);
+
+  @include rule-mode-dark() {
+    background: rgba(14, 162, 113, 0.16);
+  }
+}
+
+// ── Apps on your nodes, the table (issue #299) ───────────────────────────
+
+.dt-appstable-scroll {
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.dt-appstable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.76rem;
+  // Measured at a 380px panel: without this the six columns compress to 330px
+  // and the repo and node columns become an ellipsis apiece. Scrolling the
+  // table sideways is the honest outcome -- the container is overflow: auto.
+  min-width: 640px;
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--surface-primary);
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    text-align: left;
+    padding: 0 8px 5px;
+    border-bottom: 1px solid var(--border-secondary);
+  }
+
+  td {
+    padding: 5px 8px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.07);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 0;
+  }
+
+  tbody tr:hover td {
+    background: var(--surface-inset);
+  }
+
+  small {
+    color: var(--text-tertiary);
+    font-size: 0.9em;
+  }
+}
+
+// The name is the column someone scans, so it gets the width and the weight.
+.dt-appstable-name {
+  width: 26%;
+  color: var(--text-primary) !important;
+  font-weight: 600;
+}
+
+.dt-appstable-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.dt-appstable-component {
+  margin-left: 2px;
+}
+
+.dt-appstable-repo {
+  width: 32%;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+}
+
+.dt-appstable-node {
+  width: 18%;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary) !important;
+}
+
+.dt-appstable-caption {
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  padding-top: 8px;
 }
 
 .dt-apps-icon {
@@ -469,47 +693,7 @@
   max-width: 360px;
 }
 
-// -- Headline stat (hero number) ------------------------------------------
-// Mirrors AppsTab/index.scss's .apps-tab-hero, with this tab's accent.
-
-.dt-tab-hero {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin-bottom: 4px;
-}
-
-.dt-tab-hero-value {
-  font-size: 2.75rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  font-variant-numeric: tabular-nums;
-  color: var(--text-primary);
-  line-height: 1.1;
-
-  @include rule-mode-dark() {
-    background: linear-gradient(135deg, var(--accent-green), #34d399);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-}
-
-.dt-tab-hero-label {
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
 // ── Recent activity (issue #211) ──────────────────────────────────
-
-// Spans the grid: two summary columns plus a transaction list need more width
-// than a single cell, and squeezing them would defeat the point.
-.dt-activity-panel {
-  grid-column: 1 / -1;
-}
 
 .dt-activity-summary {
   display: grid;
@@ -616,10 +800,6 @@
 }
 
 // ── Reward reduction impact (issue #240) ─────────────────────────────────────
-
-.dt-impact-panel {
-  grid-column: 1 / -1;
-}
 
 .dt-impact-headline {
   display: flex;

--- a/client/src/analytics/NetworkTab/regionCards.jsx
+++ b/client/src/analytics/NetworkTab/regionCards.jsx
@@ -1,4 +1,5 @@
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { tierMeta } from 'content/nodeTierMeta';
 
 /*
  * The three region-scoped cards beside the Network map (issue #254).
@@ -9,8 +10,6 @@ import { APP_CATEGORY_META } from 'content/appCategoryMeta';
  * aggregation can be tested without React, which is where the real risk is:
  * a region total that is wrong looks exactly like a region total that is right.
  */
-
-const TIER_COLORS = { CUMULUS: '#2686d0', NIMBUS: '#e8a33d', STRATUS: '#e05263' };
 
 function fmtNum(n, decimals = 0) {
   if (!n && n !== 0) return '—';
@@ -36,8 +35,8 @@ export function TotalNetworkCard({ stats, label }) {
         {['CUMULUS', 'NIMBUS', 'STRATUS'].map((tier) => (
           <div key={tier} className="hov-kv-row">
             <span className="hov-kv-label">
-              <span className="nt-tier-dot" style={{ background: TIER_COLORS[tier] }} />
-              {tier.charAt(0) + tier.slice(1).toLowerCase()}
+              <span className="nt-tier-dot" style={{ background: tierMeta(tier).color }} />
+              {tierMeta(tier).label}
             </span>
             <span className="hov-kv-value">{fmtNum(t[tier] || 0)}</span>
           </div>

--- a/client/src/analytics/donorAppRows.js
+++ b/client/src/analytics/donorAppRows.js
@@ -1,0 +1,89 @@
+import { addressOf } from 'networkNodes';
+import { repotagForComponent } from 'appSpecs';
+
+/*
+ * One row per running container on the donor's own nodes (issue #299).
+ *
+ * This is the level the Donor tab's "Apps on your Nodes" table renders, and it
+ * is also what the App Categories panel is now tallied from — see
+ * tallyRowCategories below and donorApps.js. Keeping one producer means a node
+ * filter narrows the table and the category counts through the same list, so
+ * the two can never disagree about what is running where.
+ *
+ * The join is the same one aggregateDonorAppsByCategory always did: fluxinfo
+ * reports a running container's app NAME but no docker image (issue #187), so
+ * category and resources are recovered by looking that name up in the
+ * globalappsspecifications index. The repotag is resolved per COMPONENT rather
+ * than per app — a multi-component app runs several distinct images, and the
+ * table is showing the one this container actually is.
+ *
+ * Unknown resources are null, never 0. specResources() is careful to return
+ * nulls for enterprise apps (their compose is encrypted, so there is nothing to
+ * sum) and a "0.00 cores" in the table would read as a confident zero rather
+ * than "not knowable". A missing spec is treated the same way: the app is real
+ * enough to list, but nothing about its size is known.
+ */
+export function buildDonorAppRows(nodesByIp, donorAddresses, specIndex) {
+  const index = specIndex || {};
+  const rows = [];
+
+  for (const rawAddr of donorAddresses || []) {
+    const nodeAddress = addressOf(rawAddr);
+    const node = nodesByIp?.[nodeAddress];
+    if (!node) continue;
+
+    const names = node.containerAppNames || [];
+    // Index-aligned with names (fluxinfo.js), but absent on older cached
+    // payloads — a missing array means "no component", not a crash.
+    const components = node.containerComponents || [];
+
+    names.forEach((name, i) => {
+      const spec = index[name];
+      const component = components[i] ?? null;
+      const repotag = spec ? repotagForComponent(spec, component) : '';
+
+      // Every Flux node runs watchtower to auto-update its own containers. It
+      // is infrastructure the node runs for itself, not something the donor
+      // deployed, so it is excluded here exactly as it was from the tally.
+      if (repotag.toLowerCase().includes('containrrr/watchtower')) return;
+
+      rows.push({
+        // Two containers of one app can run on a single node, so neither the
+        // name nor the name+component pair is unique. The container's index
+        // within the node is what distinguishes them.
+        key: `${nodeAddress}|${i}|${name}`,
+        nodeAddress,
+        name,
+        component,
+        repotag,
+        category: spec?.category || 'other',
+        cpu: spec ? spec.cpuPerInst : null,
+        ramGB: spec ? spec.ramGBPerInst : null,
+        ssdGB: spec ? spec.ssdGBPerInst : null,
+      });
+    });
+  }
+
+  return rows;
+}
+
+/*
+ * Pure: category counts over a row list, descending. Taking rows rather than
+ * the raw lookup is what lets the Donor tab tally a FILTERED slice — the same
+ * function serves "all my apps" and "the apps on this one node".
+ */
+export function tallyRowCategories(rows) {
+  const perCategory = {};
+  let totalApps = 0;
+
+  for (const row of rows || []) {
+    perCategory[row.category] = (perCategory[row.category] || 0) + 1;
+    totalApps++;
+  }
+
+  const categories = Object.entries(perCategory)
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return { categories, totalApps };
+}

--- a/client/src/analytics/donorAppRows.test.js
+++ b/client/src/analytics/donorAppRows.test.js
@@ -1,0 +1,176 @@
+import { buildDonorAppRows, tallyRowCategories } from './donorAppRows';
+
+/*
+ * Spec entries are the shape buildSpecIndex() produces: specResources() fields
+ * spread flat, plus category/instances/compose. Enterprise entries carry null
+ * resources rather than zeros — that distinction is the whole point of
+ * specResources(), and the table must not turn it back into "0.00 cores".
+ */
+const specIndex = {
+  folding1: {
+    repotag: 'yurinnick/folding-at-home:latest',
+    category: 'computing',
+    cpuPerInst: 4,
+    ramGBPerInst: 8,
+    ssdGBPerInst: 50,
+    isEnterprise: false,
+    compose: null,
+  },
+  wp1: {
+    repotag: 'runonflux/wp-nginx:latest',
+    category: 'web',
+    cpuPerInst: 1.5,
+    ramGBPerInst: 2,
+    ssdGBPerInst: 10,
+    isEnterprise: false,
+    compose: [
+      { name: 'nginx', repotag: 'runonflux/wp-nginx:latest' },
+      { name: 'mysql', repotag: 'runonflux/wp-mysql:8' },
+    ],
+  },
+  ent1: {
+    repotag: '',
+    category: 'enterprise',
+    cpuPerInst: null,
+    ramGBPerInst: null,
+    ssdGBPerInst: null,
+    isEnterprise: true,
+    compose: null,
+  },
+  watchtower: {
+    repotag: 'containrrr/watchtower:latest',
+    category: 'other',
+    cpuPerInst: 0.1,
+    ramGBPerInst: 0.1,
+    ssdGBPerInst: 1,
+    isEnterprise: false,
+    compose: null,
+  },
+};
+
+const nodesByIp = {
+  '1.2.3.4:16127': { containerAppNames: ['folding1', 'wp1'], containerComponents: [null, 'mysql'] },
+  '5.6.7.8:16127': { containerAppNames: ['ent1'], containerComponents: [null] },
+  '9.9.9.9:16127': { containerAppNames: ['unrelated'], containerComponents: [null] },
+};
+
+const ALL = ['1.2.3.4:16127', '5.6.7.8:16127'];
+
+describe('buildDonorAppRows', () => {
+  it('emits one row per running container on the donor\'s own nodes', () => {
+    const rows = buildDonorAppRows(nodesByIp, ALL, specIndex);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.name).sort()).toEqual(['ent1', 'folding1', 'wp1']);
+  });
+
+  it('tags every row with the node it runs on, so a node selection can filter it', () => {
+    const rows = buildDonorAppRows(nodesByIp, ALL, specIndex);
+
+    const onFirst = rows.filter((r) => r.nodeAddress === '1.2.3.4:16127');
+    expect(onFirst.map((r) => r.name).sort()).toEqual(['folding1', 'wp1']);
+  });
+
+  it('carries the per-instance resources off the spec', () => {
+    const [folding] = buildDonorAppRows(nodesByIp, ['1.2.3.4:16127'], specIndex);
+
+    expect(folding).toMatchObject({ name: 'folding1', cpu: 4, ramGB: 8, ssdGB: 50, category: 'computing' });
+  });
+
+  it('resolves the repotag of the exact component a container is running', () => {
+    const rows = buildDonorAppRows(nodesByIp, ['1.2.3.4:16127'], specIndex);
+    const wp = rows.find((r) => r.name === 'wp1');
+
+    // The container is wp1's `mysql` component, not its primary nginx image.
+    expect(wp.repotag).toBe('runonflux/wp-mysql:8');
+  });
+
+  it('reports unknown resources as null rather than zero for an enterprise app', () => {
+    const [ent] = buildDonorAppRows(nodesByIp, ['5.6.7.8:16127'], specIndex);
+
+    expect(ent.cpu).toBeNull();
+    expect(ent.ramGB).toBeNull();
+    expect(ent.ssdGB).toBeNull();
+  });
+
+  it('falls back to "other" with unknown resources when the spec is missing', () => {
+    const [row] = buildDonorAppRows(nodesByIp, ['9.9.9.9:16127'], specIndex);
+
+    expect(row).toMatchObject({ name: 'unrelated', category: 'other', repotag: '', cpu: null, ramGB: null, ssdGB: null });
+  });
+
+  it('excludes containrrr/watchtower by resolved repotag', () => {
+    const withWatchtower = {
+      '1.1.1.1:1': { containerAppNames: ['folding1', 'watchtower'], containerComponents: [null, null] },
+    };
+
+    const rows = buildDonorAppRows(withWatchtower, ['1.1.1.1:1'], specIndex);
+
+    expect(rows.map((r) => r.name)).toEqual(['folding1']);
+  });
+
+  it('gives two containers of the same app on one node distinct keys', () => {
+    const twice = {
+      '1.1.1.1:1': { containerAppNames: ['folding1', 'folding1'], containerComponents: [null, null] },
+    };
+
+    const rows = buildDonorAppRows(twice, ['1.1.1.1:1'], specIndex);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].key).not.toBe(rows[1].key);
+  });
+
+  it('normalizes the donor address before lookup', () => {
+    const rows = buildDonorAppRows(nodesByIp, [' 1.2.3.4:16127 '], specIndex);
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it('returns an empty list for missing nodes, empty input or an absent lookup', () => {
+    expect(buildDonorAppRows(nodesByIp, ['0.0.0.0:0'], specIndex)).toEqual([]);
+    expect(buildDonorAppRows(nodesByIp, [], specIndex)).toEqual([]);
+    expect(buildDonorAppRows(undefined, undefined, specIndex)).toEqual([]);
+  });
+
+  it('tolerates a node entry with no index-aligned components array', () => {
+    const noComponents = { '1.1.1.1:1': { containerAppNames: ['folding1'] } };
+
+    const rows = buildDonorAppRows(noComponents, ['1.1.1.1:1'], specIndex);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].component).toBeNull();
+    expect(rows[0].repotag).toBe('yurinnick/folding-at-home:latest');
+  });
+});
+
+describe('tallyRowCategories', () => {
+  it('counts rows by category, descending', () => {
+    const rows = [
+      { category: 'computing' },
+      { category: 'web' },
+      { category: 'computing' },
+    ];
+
+    expect(tallyRowCategories(rows)).toEqual({
+      categories: [
+        { category: 'computing', count: 2 },
+        { category: 'web', count: 1 },
+      ],
+      totalApps: 3,
+    });
+  });
+
+  it('returns an empty tally for no rows', () => {
+    expect(tallyRowCategories([])).toEqual({ categories: [], totalApps: 0 });
+    expect(tallyRowCategories(undefined)).toEqual({ categories: [], totalApps: 0 });
+  });
+
+  it('tallies a filtered slice of rows, so a node selection narrows the categories', () => {
+    const rows = buildDonorAppRows(nodesByIp, ALL, specIndex);
+
+    const justFirstNode = rows.filter((r) => r.nodeAddress === '1.2.3.4:16127');
+
+    expect(tallyRowCategories(justFirstNode).totalApps).toBe(2);
+    expect(tallyRowCategories(rows).totalApps).toBe(3);
+  });
+});

--- a/client/src/analytics/donorApps.js
+++ b/client/src/analytics/donorApps.js
@@ -1,46 +1,19 @@
-import { addressOf } from 'networkNodes';
+import { buildDonorAppRows, tallyRowCategories } from 'analytics/donorAppRows';
 
 /*
- * Pure: tally the donor's own running apps by category, from the IP-keyed
- * lookup fetch_fluxinfo_aggregate() carries as nodesByIp, joined against a
- * name-keyed spec index (appSpecs.js's buildSpecIndex) for category —
- * fluxinfo no longer reports a docker image (issue #187), so category can
- * only be recovered by joining the running app's name to its
- * globalappsspecifications repotag, same as runningAppsCategorized.js does
- * network-wide. A running app whose spec can't be found (e.g. it expired
- * between the two independent fetches) falls back to 'other' rather than
- * being dropped from the tally.
+ * Tally the donor's own running apps by category.
  *
- * containrrr/watchtower is excluded from the tally by its resolved repotag:
- * every Flux node runs it to auto-update its own containers, so it's
- * infrastructure the node runs for itself, not something the donor deployed.
+ * The join this used to do inline now lives in donorAppRows.js, which produces
+ * one row per running container; this is a fold over those rows. The Donor tab
+ * renders both the category tally and a per-app table off the same list, and
+ * when a node filter is applied it narrows the rows once and re-tallies (see
+ * tallyRowCategories) — so the two panels cannot drift apart or disagree about
+ * which node an app is on.
  *
- * Addresses are normalized via addressOf() before lookup, matching
- * donorUtilization.js's own normalization.
+ * Behaviour is unchanged: one entry per running container, joined to the spec
+ * index by name, watchtower excluded by resolved repotag, an unresolvable spec
+ * falling back to 'other' rather than being dropped.
  */
 export function aggregateDonorAppsByCategory(nodesByIp, donorAddresses, specIndex) {
-  const perCategory = {};
-  let totalApps = 0;
-  const index = specIndex || {};
-
-  for (const rawAddr of donorAddresses || []) {
-    const node = nodesByIp?.[addressOf(rawAddr)];
-    if (!node) continue;
-
-    for (const name of node.containerAppNames || []) {
-      const spec = index[name];
-      const repotag = spec?.repotag || '';
-      if (repotag.toLowerCase().includes('containrrr/watchtower')) continue;
-
-      const cat = spec?.category || 'other';
-      perCategory[cat] = (perCategory[cat] || 0) + 1;
-      totalApps++;
-    }
-  }
-
-  const categories = Object.entries(perCategory)
-    .map(([category, count]) => ({ category, count }))
-    .sort((a, b) => b.count - a.count);
-
-  return { categories, totalApps };
+  return tallyRowCategories(buildDonorAppRows(nodesByIp, donorAddresses, specIndex));
 }

--- a/client/src/analytics/donorFilters.js
+++ b/client/src/analytics/donorFilters.js
@@ -1,0 +1,28 @@
+/*
+ * The Donor tab's two selections (issue #299), kept out of the component so the
+ * rules are testable without rendering.
+ *
+ * They are deliberately NOT symmetrical. A node selection propagates all the
+ * way through — apps, categories and utilisation — because a node is a real
+ * machine and every one of those figures can be honestly restated for it. A
+ * category selection stops at the app list, because "the capacity behind my
+ * gaming apps" is not a quantity that exists: one node's cores serve every app
+ * running on it, so there is nothing to divide.
+ */
+
+/** Rows matching both selections. A null/absent selection matches everything. */
+export function filterAppRows(rows, { node = null, category = null } = {}) {
+  return (rows || []).filter(
+    (row) => (!node || row.nodeAddress === node) && (!category || row.category === category)
+  );
+}
+
+/**
+ * The addresses the utilisation panel should aggregate over. Takes the category
+ * as a third argument only to make its irrelevance explicit at the call site —
+ * see the note above, and the test that pins it.
+ */
+export function utilizationAddresses(allAddresses, node /*, category */) {
+  if (node) return [node];
+  return allAddresses || [];
+}

--- a/client/src/analytics/donorFilters.test.js
+++ b/client/src/analytics/donorFilters.test.js
@@ -1,0 +1,64 @@
+import { filterAppRows, utilizationAddresses } from './donorFilters';
+
+const rows = [
+  { key: '1', nodeAddress: '1.2.3.4:16127', name: 'folding1', category: 'computing' },
+  { key: '2', nodeAddress: '1.2.3.4:16127', name: 'wp1', category: 'web' },
+  { key: '3', nodeAddress: '5.6.7.8:16127', name: 'mc1', category: 'gaming' },
+  { key: '4', nodeAddress: '5.6.7.8:16127', name: 'boinc1', category: 'computing' },
+];
+
+const ALL_ADDRESSES = ['1.2.3.4:16127', '5.6.7.8:16127', '9.9.9.9:16127'];
+
+describe('filterAppRows', () => {
+  it('returns every row when nothing is selected', () => {
+    expect(filterAppRows(rows, {})).toHaveLength(4);
+    expect(filterAppRows(rows, { node: null, category: null })).toHaveLength(4);
+  });
+
+  it('narrows to one node', () => {
+    expect(filterAppRows(rows, { node: '1.2.3.4:16127' }).map((r) => r.name)).toEqual(['folding1', 'wp1']);
+  });
+
+  it('narrows to one category', () => {
+    expect(filterAppRows(rows, { category: 'computing' }).map((r) => r.name)).toEqual(['folding1', 'boinc1']);
+  });
+
+  it('applies both selections together, not one or the other', () => {
+    const both = filterAppRows(rows, { node: '5.6.7.8:16127', category: 'computing' });
+
+    expect(both.map((r) => r.name)).toEqual(['boinc1']);
+  });
+
+  it('returns nothing when the two selections do not intersect', () => {
+    expect(filterAppRows(rows, { node: '1.2.3.4:16127', category: 'gaming' })).toEqual([]);
+  });
+
+  it('does not throw on an absent row list', () => {
+    expect(filterAppRows(undefined, { node: '1.2.3.4:16127' })).toEqual([]);
+  });
+});
+
+describe('utilizationAddresses', () => {
+  it('is every address when no node is selected', () => {
+    expect(utilizationAddresses(ALL_ADDRESSES, null)).toEqual(ALL_ADDRESSES);
+  });
+
+  it('is just the selected node when one is selected', () => {
+    expect(utilizationAddresses(ALL_ADDRESSES, '5.6.7.8:16127')).toEqual(['5.6.7.8:16127']);
+  });
+
+  /*
+   * A category is not a set of machines. Utilisation is a percentage of a
+   * node's capacity, and "the capacity backing my gaming apps" is not a
+   * quantity that exists -- one node's cores serve every app on it. Narrowing
+   * the panel by category would put a number on screen that means nothing.
+   */
+  it('ignores a category selection entirely', () => {
+    expect(utilizationAddresses(ALL_ADDRESSES, null, 'gaming')).toEqual(ALL_ADDRESSES);
+  });
+
+  it('does not throw on an absent address list', () => {
+    expect(utilizationAddresses(undefined, null)).toEqual([]);
+    expect(utilizationAddresses(undefined, '1.2.3.4:16127')).toEqual(['1.2.3.4:16127']);
+  });
+});

--- a/client/src/analytics/donorNodeRows.js
+++ b/client/src/analytics/donorNodeRows.js
@@ -1,0 +1,45 @@
+import { hostOf, addressOf } from 'networkNodes';
+import { calc_mtn_window } from 'apidata';
+
+/*
+ * The donor's own nodes, with the two figures issue #301 asks for beside rank:
+ * the maintenance window and the benchmark reading.
+ *
+ * Neither costs a fetch. transformRawNode already keeps last_confirmed_height,
+ * which is all calc_mtn_window needs given the chain tip the tab already holds
+ * for the reward countdown; and the benchmark feed is the same shared one the
+ * utilisation panel aggregates, so it is in memory by the time this runs.
+ *
+ * EPS is matched by HOST, not by address. A benchmark is a measurement of a
+ * MACHINE -- when a donor runs two nodes on one box (different ports) both
+ * genuinely have the same reading, and keying by address would leave the second
+ * one blank. This is the same host/address distinction donorUtilization.js
+ * makes for capacity, for the same reason.
+ */
+export function buildDonorNodeRows(nodes, benchmarks, currentBlockHeight) {
+  const epsByHost = {};
+  for (const entry of benchmarks || []) {
+    const bench = entry?.benchmark?.bench;
+    const host = hostOf(bench?.ipaddress);
+    if (host && bench?.eps != null) epsByHost[host] = bench.eps;
+  }
+
+  return (nodes || []).map((node) => {
+    const host = hostOf(addressOf(node.ip_display));
+    const eps = host != null ? epsByHost[host] : undefined;
+
+    return {
+      ...node,
+      /*
+       * null rather than a computed string when the tip is unknown: the window
+       * is `480 - (tip - last_confirmed)`, so a missing tip does not make the
+       * window long, it makes it unknowable. Rendering "Closed" or a duration
+       * off a zero tip would be a confident wrong answer.
+       */
+      mtnWindow: currentBlockHeight ? calc_mtn_window(node.last_confirmed_height, currentBlockHeight) : null,
+      // Likewise null, never 0 -- a node with no benchmark reading has not
+      // scored zero, it has not reported.
+      eps: eps == null ? null : eps,
+    };
+  });
+}

--- a/client/src/analytics/donorNodeRows.test.js
+++ b/client/src/analytics/donorNodeRows.test.js
@@ -1,0 +1,76 @@
+import { buildDonorNodeRows } from './donorNodeRows';
+
+const nodes = [
+  { id: 'a', ip_display: '1.2.3.4:16127', tier: 'NIMBUS', rank: 10, last_confirmed_height: 2_941_800 },
+  { id: 'b', ip_display: '5.6.7.8:16127', tier: 'CUMULUS', rank: 20, last_confirmed_height: 2_941_000 },
+];
+
+const benchmarks = [
+  { benchmark: { bench: { ipaddress: '1.2.3.4:16127', eps: 512.4 } } },
+  { benchmark: { bench: { ipaddress: '5.6.7.8:16127', eps: 128 } } },
+];
+
+const CURRENT_HEIGHT = 2_942_000;
+
+describe('buildDonorNodeRows', () => {
+  it('keeps every field the node already carried', () => {
+    const [first] = buildDonorNodeRows(nodes, benchmarks, CURRENT_HEIGHT);
+
+    expect(first).toMatchObject({ id: 'a', ip_display: '1.2.3.4:16127', tier: 'NIMBUS', rank: 10 });
+  });
+
+  it('derives the maintenance window from the node\'s last confirmed height', () => {
+    const [first] = buildDonorNodeRows(nodes, benchmarks, CURRENT_HEIGHT);
+
+    // 480 - (2,942,000 - 2,941,800) = 280 blocks left, at 2 blocks/minute =
+    // 140 minutes. format_minutes() renders whole hours once past one hour —
+    // the same lossy formatting the main node table already shows.
+    expect(first.mtnWindow).toBe('2 Hrs');
+  });
+
+  it('reports a window that has run out as Closed', () => {
+    const [, second] = buildDonorNodeRows(nodes, benchmarks, CURRENT_HEIGHT);
+
+    // 480 - (2,942,000 - 2,941,000) is negative.
+    expect(second.mtnWindow).toBe('Closed');
+  });
+
+  it('leaves the window unknown rather than wrong when the chain height is missing', () => {
+    for (const height of [0, null, undefined]) {
+      const [first] = buildDonorNodeRows(nodes, benchmarks, height);
+      expect(first.mtnWindow).toBeNull();
+    }
+  });
+
+  it('joins the benchmark EPS reading onto the node', () => {
+    const rows = buildDonorNodeRows(nodes, benchmarks, CURRENT_HEIGHT);
+
+    expect(rows.map((r) => r.eps)).toEqual([512.4, 128]);
+  });
+
+  it('matches a benchmark by HOST, since the reading is per-machine not per-port', () => {
+    const twoNodesOneHost = [
+      { id: 'a', ip_display: '1.2.3.4:16127', tier: 'NIMBUS', rank: 1, last_confirmed_height: 2_941_900 },
+      { id: 'b', ip_display: '1.2.3.4:16137', tier: 'NIMBUS', rank: 2, last_confirmed_height: 2_941_900 },
+    ];
+
+    const rows = buildDonorNodeRows(twoNodesOneHost, benchmarks, CURRENT_HEIGHT);
+
+    expect(rows.map((r) => r.eps)).toEqual([512.4, 512.4]);
+  });
+
+  it('reports EPS as null, never 0, when the node has no benchmark reading', () => {
+    const unbenched = [{ id: 'c', ip_display: '9.9.9.9:16127', tier: 'STRATUS', rank: 3, last_confirmed_height: 2_941_900 }];
+
+    const [row] = buildDonorNodeRows(unbenched, benchmarks, CURRENT_HEIGHT);
+
+    expect(row.eps).toBeNull();
+  });
+
+  it('returns an empty list for no nodes, and does not throw on missing benchmarks', () => {
+    expect(buildDonorNodeRows([], benchmarks, CURRENT_HEIGHT)).toEqual([]);
+    expect(buildDonorNodeRows(undefined, undefined, CURRENT_HEIGHT)).toEqual([]);
+    expect(() => buildDonorNodeRows(nodes, undefined, CURRENT_HEIGHT)).not.toThrow();
+    expect(buildDonorNodeRows(nodes, undefined, CURRENT_HEIGHT).map((r) => r.eps)).toEqual([null, null]);
+  });
+});

--- a/client/src/analytics/donorUtilization.js
+++ b/client/src/analytics/donorUtilization.js
@@ -78,7 +78,21 @@ export function aggregateDonorUtilization(donorAddresses, benchmarks, resources)
   };
 }
 
-export async function fetch_donor_utilization(donorAddresses) {
+/*
+ * The raw feeds behind the aggregation above.
+ *
+ * The Donor tab re-aggregates when a node is selected (issue #299), so it needs
+ * the inputs rather than one pre-summed answer — filtering the RESULT is not
+ * possible, since a percentage of a subset cannot be recovered from a
+ * percentage of the whole. Both fetches are the module-level shared ones, so
+ * asking for the source costs nothing on top of fetch_donor_utilization.
+ */
+export async function fetch_donor_utilization_source() {
   const [benchmarks, resources] = await Promise.all([fetch_node_benchmarks(), fetch_node_resources()]);
+  return { benchmarks, resources };
+}
+
+export async function fetch_donor_utilization(donorAddresses) {
+  const { benchmarks, resources } = await fetch_donor_utilization_source();
   return aggregateDonorUtilization(donorAddresses, benchmarks, resources);
 }

--- a/client/src/analytics/donorUtilization.test.js
+++ b/client/src/analytics/donorUtilization.test.js
@@ -1,4 +1,4 @@
-import { aggregateDonorUtilization } from './donorUtilization';
+import { aggregateDonorUtilization, fetch_donor_utilization_source } from './donorUtilization';
 
 const benchmarks = [
   { benchmark: { bench: { ipaddress: '1.2.3.4:16127', cores: 8, ram: 32, totalstorage: 440 } } },
@@ -74,5 +74,35 @@ describe('aggregateDonorUtilization', () => {
     expect(result.cores.utilized).toBe(3);
     expect(result.ram.utilized).toBe(3); // (2048+1024)/1024
     expect(result.ssd.utilized).toBe(30);
+  });
+});
+
+/*
+ * The Donor tab re-aggregates utilisation when a node is selected (issue
+ * #299), so it needs the raw feeds, not just the summed result. This is the
+ * accessor that hands them over — the aggregation itself is already covered
+ * above and is not re-tested through the network path.
+ */
+describe('fetch_donor_utilization_source', () => {
+  const realFetch = global.fetch;
+  afterEach(() => { global.fetch = realFetch; });
+
+  it('returns the raw benchmark and resource feeds, so a caller can re-aggregate a subset', async () => {
+    global.fetch = jest.fn((url) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ status: 'success', data: String(url).includes('benchmark') ? benchmarks : resources }),
+      })
+    );
+
+    const source = await fetch_donor_utilization_source();
+
+    expect(Array.isArray(source.benchmarks)).toBe(true);
+    expect(Array.isArray(source.resources)).toBe(true);
+    // Proves the halves are not swapped: only the benchmark feed is shaped
+    // { benchmark: { bench } }, only the resource feed carries a bare `ip`.
+    expect(source.benchmarks[0]).toHaveProperty('benchmark.bench.ipaddress');
+    expect(source.resources[0]).toHaveProperty('ip');
   });
 });

--- a/client/src/content/nodeTierMeta.js
+++ b/client/src/content/nodeTierMeta.js
@@ -1,0 +1,43 @@
+/*
+ * One definition of what a node tier is called and what colour it wears.
+ *
+ * There were two, and they disagreed: NetworkTab/regionCards.jsx used
+ * #e8a33d / #e05263 for Nimbus and Stratus, home/WorkhorsePanel used
+ * #d07e26 / #c92641 for the same two tiers. Nobody chose that — the second
+ * copy was written from the first by eye. Issue #301 wants tier names
+ * colour-coded in a third place, which is the point at which a third copy
+ * stops being affordable.
+ *
+ * The brighter pair wins: these are read as small text and chips against the
+ * dark theme's near-black panels, where #c92641 in particular sits too close
+ * to the background to register as a colour at all.
+ *
+ * FRACTUS has no incumbent colour (neither copy had one) and is given a teal
+ * that collides with nothing else here.
+ */
+export const NODE_TIER_META = {
+  CUMULUS: { label: 'Cumulus', color: '#2686d0' },
+  NIMBUS:  { label: 'Nimbus',  color: '#e8a33d' },
+  STRATUS: { label: 'Stratus', color: '#e05263' },
+  FRACTUS: { label: 'Fractus', color: '#2bb3a3' },
+};
+
+/*
+ * Deliberately a real colour rather than a CSS variable: callers put this
+ * straight into an inline `style`, and the tests can only assert that a tier
+ * without a colour is visibly neutral if the neutral value is a colour too.
+ */
+export const TIER_FALLBACK_COLOR = '#8a8f98';
+
+const FALLBACK = { label: 'Unknown', color: TIER_FALLBACK_COLOR };
+
+/**
+ * Meta for a tier name, case-insensitively. Feeds disagree on casing — the
+ * daemon list is lowercase, transformRawNode upper-cases it, and fluxinfo
+ * passes through whatever it was given — so normalising here keeps every call
+ * site from having to.
+ */
+export function tierMeta(tier) {
+  if (typeof tier !== 'string') return FALLBACK;
+  return NODE_TIER_META[tier.trim().toUpperCase()] || FALLBACK;
+}

--- a/client/src/content/nodeTierMeta.test.js
+++ b/client/src/content/nodeTierMeta.test.js
@@ -1,0 +1,40 @@
+import { NODE_TIER_META, TIER_FALLBACK_COLOR, tierMeta } from './nodeTierMeta';
+
+describe('NODE_TIER_META', () => {
+  it('covers every tier the app can render', () => {
+    expect(Object.keys(NODE_TIER_META).sort()).toEqual(['CUMULUS', 'FRACTUS', 'NIMBUS', 'STRATUS']);
+  });
+
+  it('gives every tier a label and a hex colour', () => {
+    for (const [tier, meta] of Object.entries(NODE_TIER_META)) {
+      expect(typeof meta.label).toBe('string');
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.color).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(meta.label.toUpperCase()).toBe(tier);
+    }
+  });
+
+  it('gives each tier a distinct colour, so a colour identifies a tier on sight', () => {
+    const colors = Object.values(NODE_TIER_META).map((m) => m.color.toLowerCase());
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+});
+
+describe('tierMeta', () => {
+  it('resolves a tier name', () => {
+    expect(tierMeta('NIMBUS')).toBe(NODE_TIER_META.NIMBUS);
+  });
+
+  it('resolves case-insensitively, since feeds disagree on casing', () => {
+    expect(tierMeta('nimbus')).toBe(NODE_TIER_META.NIMBUS);
+    expect(tierMeta('Nimbus')).toBe(NODE_TIER_META.NIMBUS);
+  });
+
+  it('falls back to a neutral entry for an unknown, missing or malformed tier', () => {
+    for (const input of ['UNKNOWN', '', null, undefined, 42]) {
+      const meta = tierMeta(input);
+      expect(meta.color).toBe(TIER_FALLBACK_COLOR);
+      expect(typeof meta.label).toBe('string');
+    }
+  });
+});

--- a/client/src/home/WorkhorsePanel/index.jsx
+++ b/client/src/home/WorkhorsePanel/index.jsx
@@ -5,16 +5,11 @@ import { Tooltip2 } from '@blueprintjs/popover2';
 import { FiCpu, FiHardDrive, FiDownload, FiUpload, FiBox } from 'react-icons/fi';
 
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { tierMeta } from 'content/nodeTierMeta';
 import { CategoryTooltip } from 'components/CategoryTooltip';
 import { buildSpecIndex } from 'appSpecs';
 
 const ROTATE_MS = 8000;
-
-const TIER_COLOR = {
-  CUMULUS: '#2686d0',
-  NIMBUS: '#d07e26',
-  STRATUS: '#c92641'
-};
 
 /*
  * Utilisation is the whole point of the card, so the bar carries the reading
@@ -94,7 +89,7 @@ function NodeCard({ node, specsByName }) {
     return Object.entries(counts).sort((a, b) => b[1] - a[1]);
   }, [node.containerAppNames, specsByName]);
 
-  const tierColor = TIER_COLOR[node.tier] || 'var(--text-tertiary)';
+  const tierColor = tierMeta(node.tier).color;
   const b = node.benchmark;
 
   return (


### PR DESCRIPTION
Closes #299, #300 and #301. They are one surface and rewrite the same grid, so they are one PR.

Builds directly on #288, which already fixed the other half of the layout problem.

## The measurement

Taken on `main` as it stands today (with #288 applied), at a 2,292px viewport with a 127-node wallet:

| | on main today |
|---|---|
| `.donor-tab` total height | **5,304px** |
| grid | 3 × 734px — **no empty tracks, #288 did this** |
| `.dt-nodes-panel` | **4,197px** (one row per node, no scroll cap) |
| `.dt-apps-panel` | stretched to 4,197px, **content 203px** |
| `.dt-util-panel` | stretched to 4,197px, **content 202px** |

#288 sized the *tracks* correctly, but a grid row still stretches every item to the tallest, and `YOUR NODES` renders one row per node. That is ~8,000px of blank panel that no column count could have fixed.

Both halves are handled here: the node list gets a **420px scroll cap** (the cause today) and the grid gets **`align-items: start`** (the mechanism, so the next long panel cannot repeat it). Twelve tracks rather than three, because the payout band and the utilisation panel want more width than the category tally and equal columns cannot say so.

**After: 1,906px, every track filled, no stretched panel.**

## What changed

**#299 — the tab is interactive.** `YOUR NODES` rows and `APP CATEGORIES` rows are filters. Selecting a node narrows the apps table, the category tally *and* the utilisation panel; the count badge doubles as the reset and reads `1 / 127` while filtered. Selecting a category narrows only the apps table. "Apps on Your Nodes" is renamed **APP CATEGORIES** — it was never a list of apps — and the name is taken by a real table: Name, Repo, Node, CPU, RAM, SSD, one row per running container.

**#300 — the remainder.** #288 already merged the two timers into one band, so what was left is: `REWARD REDUCTION IMPACT` moves up beside that band instead of sitting full-width at the bottom, and the separate hero is deleted rather than restyled — it rendered `57 mins / NEXT PAYOUT` directly above a card rendering `NEXT PAYOUT / 57 mins`. **`PayoutCard` itself is #288's component unchanged**, only relocated into the grid.

**#301 — node rows carry Tier · Address · Rank · Window · EPS.** Neither new column costs a fetch: the window comes from `calc_mtn_window()` against the chain tip the tab already holds, EPS from the benchmark feed already fetched for utilisation. EPS is matched by *host*, not address — a benchmark measures a machine, so two nodes on one box genuinely share a reading.

## Two decisions worth reviewing

**EPS is not scored against a pass mark.** Flux publishes no per-tier EPS floor that could be cited, so the bar is relative to the best reading in *this wallet's own* list — a comparison the data supports — and only a genuinely absent reading is called out, as absent rather than as bad. If the real thresholds exist somewhere, this is the place to say so.

**The two filters are deliberately not symmetrical.** A node propagates everywhere; a category stops at the app list, because "the capacity behind my gaming apps" is not a quantity that exists — one node's cores serve every app on it. Pinned by a test.

## Incidental fix

There were **two disagreeing node-tier palettes** (`NetworkTab/regionCards.jsx` `#e8a33d`/`#e05263` vs `home/WorkhorsePanel` `#d07e26`/`#c92641`). #301 wanted tier colours in a third place, so they are consolidated into `content/nodeTierMeta.js` and both call sites move over. The brighter pair wins — these are small text on near-black, where `#c92641` barely registers.

## Verification

- **858 tests / 60 suites pass.** 38 new, all written before the code they cover.
- `yarn build` clean — no new warnings.
- `tools/audit/` D1: **AGREE, exit 0**.
- Node page settles at **127 rows, all NIMBUS** for `t1bAB8f6HykLMtL2mvFZvUU7uBjCaUK7Uwr`.
- Browser-verified against that wallet on the rebased branch: node selection takes apps 20 → 1, categories 7 → 1, utilisation 27.1% → 75.0%; the badge resets all three; a category selection gives 4/20 with utilisation untouched. Light and dark both checked.
- At a 380px panel the apps table scrolls sideways (640 > 330) instead of crushing six columns into an ellipsis apiece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu