### PR TITLE
Finish the dedicated-site prefix table: Hermes, n8n, WordPress

### DIFF
--- a/client/src/main/Gamification/dedicatedSites.js
+++ b/client/src/main/Gamification/dedicatedSites.js
@@ -33,9 +33,11 @@
  * java/bedrock, Rust vanilla/oxide), means a new entry both there and here.
  * fluxview's file is the place to check.
  *
- * Only the games are listed. The non-game sites (Hermes, n8n, WordPress,
- * OpenClaw) have the same problem -- about 20 more specs -- but #309 is about
- * games, and widening the table is a separate call to make.
+ * Every site fluxview lists is here, games and not. The non-game ones were left
+ * out of the first pass and hit the identical branch for the identical reason:
+ * Hermes 11 encrypted specs, n8n 5, WordPress 4. Each is categorised by what the
+ * app IS, not by the fact that it came from a hosting site -- a site prefix is
+ * evidence about the app, not a category in its own right.
  */
 export const DEDICATED_SITE_PREFIXES = {
   palworld: 'gaming',
@@ -57,6 +59,32 @@ export const DEDICATED_SITE_PREFIXES = {
   // which is "DragonWilds" -- there is no "runescape" anywhere in the deployed
   // name, so that is not the string to match on.
   dragonwilds: 'gaming',
+  // OpenClaw is a game (an open-source Captain Claw) even though fluxview files
+  // it under its own subdomain rather than the games hub. No encrypted
+  // deployment exists on-network today; listed so that one is right when it
+  // does, and because this table's job is to mirror fluxview.
+  openclaw: 'gaming',
+  openclawpro: 'gaming',
+
+  /*
+   * The non-game sites. Categorised by what the app is:
+   *
+   *   Hermes    "Hermes Agent, the self-improving AI agent by Nous Research"
+   *             -- straight off the spec's own description, not inferred.
+   *   n8n       "n8n automation server with PostgreSQL on Flux". 'n8n' is
+   *             already a devops keyword, so this only makes the encrypted
+   *             deployments agree with the plain ones.
+   *   WordPress only the 4 ENCRYPTED deployments need this. The other 29 on
+   *             network ship a readable compose and already resolve through
+   *             the 'wp-nginx' keyword -- the enterprise branch is the only
+   *             place this table is consulted, so those are untouched.
+   */
+  hermesagent: 'ai',
+  hermesagentpro: 'ai',
+  n8nstarter: 'devops',
+  n8nstandard: 'devops',
+  n8npro: 'devops',
+  wordpress: 'web',
 };
 
 /*

--- a/client/src/main/Gamification/dedicatedSites.test.js
+++ b/client/src/main/Gamification/dedicatedSites.test.js
@@ -1,6 +1,21 @@
 import { DEDICATED_SITE_PREFIXES, categorizeDedicatedSiteApp } from './dedicatedSites';
 
 describe('DEDICATED_SITE_PREFIXES', () => {
+  it('covers every NON-game site fluxview lists, with the category the app is', () => {
+    // Hermes is "the self-improving AI agent by Nous Research" (its own spec
+    // description says so), n8n is an automation server, WordPress is a CMS.
+    // Each encrypted deployment of these hit the enterprise branch exactly as
+    // the games did.
+    expect(DEDICATED_SITE_PREFIXES.hermesagent).toBe('ai');
+    expect(DEDICATED_SITE_PREFIXES.hermesagentpro).toBe('ai');
+    expect(DEDICATED_SITE_PREFIXES.n8nstarter).toBe('devops');
+    expect(DEDICATED_SITE_PREFIXES.n8nstandard).toBe('devops');
+    expect(DEDICATED_SITE_PREFIXES.n8npro).toBe('devops');
+    expect(DEDICATED_SITE_PREFIXES.wordpress).toBe('web');
+    expect(DEDICATED_SITE_PREFIXES.openclaw).toBe('gaming');
+    expect(DEDICATED_SITE_PREFIXES.openclawpro).toBe('gaming');
+  });
+
   it('covers every game RunOnFlux/fluxview lists as a dedicated hosting site', () => {
     for (const prefix of [
       'palworld',
@@ -63,6 +78,19 @@ describe('categorizeDedicatedSiteApp', () => {
   it('matches regardless of casing, unlike fluxview', () => {
     expect(categorizeDedicatedSiteApp('Valheim1787327994881')).toBe('gaming');
     expect(categorizeDedicatedSiteApp('DRAGONWILDS1789155733040')).toBe('gaming');
+  });
+
+  it('categorizes the non-game sites by what the app actually is', () => {
+    expect(categorizeDedicatedSiteApp('hermesagentpro1781078593777')).toBe('ai');
+    expect(categorizeDedicatedSiteApp('n8nstarter1784743517187')).toBe('devops');
+    expect(categorizeDedicatedSiteApp('wordpress1772009796289')).toBe('web');
+  });
+
+  it('does not let a shorter non-game prefix swallow a longer one', () => {
+    // n8nstarter / n8nstandard / n8npro share no prefix with each other, but
+    // hermesagent IS a prefix of hermesagentpro and both must resolve.
+    expect(categorizeDedicatedSiteApp('hermesagent1787341182483')).toBe('ai');
+    expect(categorizeDedicatedSiteApp('openclawpro1787341182483')).toBe('gaming');
   });
 
   it('returns null for an unrelated name, so the caller can fall through', () => {


### PR DESCRIPTION
Follow-up to #311, which fixed the games and deliberately stopped there.

The non-game dedicated sites hit the **identical** branch for the identical reason: an encrypted spec (`enterprise` set, `compose` empty) is answered before any keyword is read. Same table, no mechanism change.

## What moves, measured over live spec data

| prefix | specs | → |
|---|---|---|
| `hermesagent` / `hermesagentpro` | 11 | **ai** |
| `n8nstarter` | 5 | **devops** |
| `wordpress` | 4 | **web** |

```
ai           4 ->  15 specs   ( 14 ->  36 instances)
devops      17 ->  22 specs   ( 64 ->  79 instances)
web        105 -> 109 specs   (347 -> 359 instances)
enterprise 278 -> 258 specs   (1787 -> 1569 instances)
```

Nothing else moves. **Gaming is untouched by this PR** — that was #311.

## The categories are read, not guessed

Both come straight off the live specs' own `description` field:

- Hermes — *"Hermes Agent, the self-improving AI agent by Nous Research"* → `ai`
- n8n — *"n8n automation server with PostgreSQL on Flux"* → `devops` (and `n8n` is already a devops keyword, so this only makes the encrypted deployments agree with the plain ones)

## WordPress has a much smaller blast radius than it looks

`wordpress` as a bare prefix looks alarming. It isn't: only **4 of its 33** deployments are encrypted. The other 29 ship a readable compose and already resolve through the `wp-nginx` keyword, and since this table is consulted *only inside the enterprise branch*, those 29 cannot be touched by the entry. Worth saying out loud, because the entry reads wider than it acts.

## OpenClaw

Listed at `gaming` — it's a game (an open-source Captain Claw), even though fluxview files it under its own subdomain rather than the games hub. **No encrypted OpenClaw deployment exists on-network today**; it's here so one is right when it appears, and because this table's job is to mirror fluxview.

## Verification

- **868 tests / 59 suites pass** (was 865). 3 new, written before the entries.
- `yarn build` clean — no new warnings.
- `tools/audit/` D1: **AGREE, exit 0**.
- Before/after measured by running the branch's own table over a live `globalappsspecifications` pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu