### PR TITLE
Home: list the individual donations, not just the total (#315)

### DIFF
--- a/client/src/api/globalStats.js
+++ b/client/src/api/globalStats.js
@@ -30,7 +30,7 @@ import { fetch_global_app_specs_raw } from 'api/specs';
 import { categorizeRunningApps } from 'runningAppsCategorized';
 import { explorerFetchJson } from 'explorer';
 import { OLD_ADDRESS_FLUX } from 'donor/config';
-import { aggregateDonations } from 'donor/donationTotals';
+import { aggregateDonations, buildDonationRows } from 'donor/donationTotals';
 import { richListRank } from 'wallet/richList';
 import {
   fetch_node_benchmarks,
@@ -334,10 +334,17 @@ async function scanBothDonationAddresses() {
  */
 export async function fetch_donation_totals() {
   const scans = await scanBothDonationAddresses();
-  if (scans.every((txs) => txs === null)) return { ok: false, totals: null };
+  if (scans.every((txs) => txs === null)) return { ok: false, totals: null, rows: [] };
 
   const txs = scans.filter(Boolean).flat();
-  return { ok: true, totals: aggregateDonations(txs) };
+  /*
+   * `rows` rides along rather than getting its own fetch (issue #315). The
+   * individual donations were always in these bytes and were being reduced to
+   * a sum and discarded; listing them is a second reading of one scan, not a
+   * second scan. Given #314, adding a fourth caller to the explorer would have
+   * undone the fix that made this panel affordable in the first place.
+   */
+  return { ok: true, totals: aggregateDonations(txs), rows: buildDonationRows(txs) };
 }
 
 /*

--- a/client/src/donor/donationTotals.js
+++ b/client/src/donor/donationTotals.js
@@ -122,3 +122,83 @@ export function relativeAge(timeSec, nowMs = Date.now()) {
   const months = Math.round(days / 30);
   return months === 1 ? '1 month ago' : `${months} months ago`;
 }
+
+/*
+ * The same donations, one row each, for the Home list (issue #315).
+ *
+ * Shares paidToDonationAddress, senderOf and the window with
+ * aggregateDonations above, deliberately: the list and the total sit in the
+ * same panel, and if they disagreed about what counts as a donation the panel
+ * would contradict itself on screen. A test pins that they agree.
+ *
+ * The ONE difference is project-owned transfers. aggregateDonations drops them
+ * from the total -- that is the whole point of EXCLUDED_FROM_DONATION_TOTALS,
+ * and it stays true. This lists them with `isProjectTransfer` set instead of
+ * dropping them, so the panel can label them. Hiding them would leave the list
+ * unable to reconcile against the address's on-chain balance with nothing on
+ * screen to explain the gap; showing them unlabelled would headline a project
+ * transfer as community backing, which is the exact hazard the exclusion list
+ * was created for.
+ *
+ * Sorted by block height, descending -- latest first.
+ */
+export function buildDonationRows(txs, { nowMs = Date.now(), excluded } = {}) {
+  if (!Array.isArray(txs)) return [];
+
+  const addresses = donationAddresses();
+  const projectWallets = new Set(excluded || EXCLUDED_FROM_DONATION_TOTALS);
+  const cutoffSec = Math.floor(nowMs / 1000) - WINDOW_SEC;
+
+  const seen = new Set();
+  const rows = [];
+
+  for (const tx of txs) {
+    if (!tx?.txid || seen.has(tx.txid)) continue;
+    if (typeof tx.time !== 'number' || tx.time < cutoffSec) continue;
+
+    const amount = paidToDonationAddress(tx, addresses);
+    if (amount <= 0) continue;
+
+    const from = senderOf(tx, addresses);
+    if (!from) continue;
+
+    seen.add(tx.txid);
+    rows.push({
+      txid: tx.txid,
+      from,
+      // Rounded for the same reason the total is: binary floating point must
+      // not put 0.30000000000000004 on the front page.
+      amount: Math.round(amount * 1e8) / 1e8,
+      blockHeight: tx.blockheight || 0,
+      timeSec: tx.time,
+      isProjectTransfer: projectWallets.has(from)
+    });
+  }
+
+  return rows.sort((a, b) => b.blockHeight - a.blockHeight);
+}
+
+/*
+ * Enough of each end to match a row against the explorer by eye, which is the
+ * only thing the shortened form has to support. Middle-elided rather than
+ * truncated: the tail is what distinguishes two transactions in the same block.
+ */
+export function shortTxid(txid) {
+  if (typeof txid !== 'string' || !txid) return '';
+  if (txid.length <= 14) return txid;
+  return `${txid.slice(0, 6)}..${txid.slice(-6)}`;
+}
+
+/*
+ * The explorer is a HASH-routed SPA, and the obvious-looking path is the broken
+ * one. Measured 2026-09-13:
+ *
+ *   https://explorer.runonflux.io/tx/<txid>    -> 404
+ *   https://explorer.runonflux.io/#/tx/<txid>  -> 200
+ *
+ * Written as a function with a test rather than inlined at the call site, so
+ * a whole panel of dead links cannot be introduced by someone tidying the URL.
+ */
+export function explorerTxUrl(txid) {
+  return `https://explorer.runonflux.io/#/tx/${txid}`;
+}

--- a/client/src/donor/donationTotals.test.js
+++ b/client/src/donor/donationTotals.test.js
@@ -137,3 +137,141 @@ describe('relativeAge', () => {
     expect(relativeAge(null, NOW)).toBeNull();
   });
 });
+
+/*
+ * Issue #315 -- the same transactions, listed individually rather than summed.
+ */
+import { buildDonationRows, shortTxid, explorerTxUrl } from './donationTotals';
+
+const PROJECT_WALLET = 't1gesjNJGfzU8shfMZj6DVDatRKA3LQj8Nh'; // EXCLUDED_FROM_DONATION_TOTALS
+
+function txAt({ txid, from, amount, daysAgo, blockheight, to = DONATION_ADDR, change = 0 }) {
+  return { ...tx({ txid, from, to, amount, daysAgo, change }), blockheight };
+}
+
+describe('buildDonationRows', () => {
+  const rows = () =>
+    buildDonationRows(
+      [
+        txAt({ txid: 'a', from: 't1alice', amount: 10, daysAgo: 5, blockheight: 300 }),
+        txAt({ txid: 'b', from: 't1bob', amount: 50, daysAgo: 30, blockheight: 200 }),
+        txAt({ txid: 'c', from: 't1alice', amount: 5, daysAgo: 1, blockheight: 400 }),
+      ],
+      { nowMs: NOW }
+    );
+
+  it('returns one row per donation, with the fields the panel renders', () => {
+    const [first] = rows();
+
+    expect(first).toMatchObject({
+      txid: 'c',
+      from: 't1alice',
+      amount: 5,
+      blockHeight: 400,
+      isProjectTransfer: false,
+    });
+    expect(typeof first.timeSec).toBe('number');
+  });
+
+  it('sorts by block height descending — latest first', () => {
+    expect(rows().map((r) => r.blockHeight)).toEqual([400, 300, 200]);
+  });
+
+  it('ignores change outputs, exactly as the total does', () => {
+    // Same trap as aggregateDonations: a 50 FLUX donation funded by a larger
+    // input returns change to the sender in the same transaction.
+    const [row] = buildDonationRows(
+      [txAt({ txid: 'a', from: 't1alice', amount: 50, change: 150, daysAgo: 1, blockheight: 10 })],
+      { nowMs: NOW }
+    );
+
+    expect(row.amount).toBe(50);
+  });
+
+  it('does not list the same transaction twice when it paid both addresses', () => {
+    // Callers concatenate one scan per donation address.
+    const shared = txAt({ txid: 'dup', from: 't1alice', amount: 10, daysAgo: 1, blockheight: 10 });
+
+    expect(buildDonationRows([shared, shared], { nowMs: NOW })).toHaveLength(1);
+  });
+
+  /*
+   * #315: project-owned transfers are SHOWN and LABELLED rather than hidden.
+   * aggregateDonations drops them from the total -- that stays true -- but a
+   * list that silently omitted them would not reconcile against the address's
+   * on-chain balance, and nothing on screen would explain the gap.
+   */
+  it('includes a project transfer, flagged, rather than dropping it', () => {
+    const out = buildDonationRows(
+      [
+        txAt({ txid: 'a', from: 't1alice', amount: 10, daysAgo: 1, blockheight: 20 }),
+        txAt({ txid: 'p', from: PROJECT_WALLET, amount: 900, daysAgo: 1, blockheight: 10 }),
+      ],
+      { nowMs: NOW }
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out.find((r) => r.txid === 'p').isProjectTransfer).toBe(true);
+    expect(out.find((r) => r.txid === 'a').isProjectTransfer).toBe(false);
+  });
+
+  it('agrees with aggregateDonations about what counts as a donation', () => {
+    // The list and the total sit in the same panel. If they disagree about the
+    // window or about change, the panel contradicts itself on screen.
+    const txs = [
+      txAt({ txid: 'recent', from: 't1alice', amount: 10, daysAgo: 5, blockheight: 300 }),
+      txAt({ txid: 'ancient', from: 't1bob', amount: 999, daysAgo: 500, blockheight: 1 }),
+    ];
+
+    const listed = buildDonationRows(txs, { nowMs: NOW }).filter((r) => !r.isProjectTransfer);
+    const summed = aggregateDonations(txs, { nowMs: NOW });
+
+    expect(listed).toHaveLength(summed.donationCount);
+    expect(listed.reduce((s, r) => s + r.amount, 0)).toBeCloseTo(summed.totalFlux, 8);
+  });
+
+  it('skips transactions that paid a donation address nothing', () => {
+    const unrelated = {
+      txid: 'x',
+      time: sec(1),
+      blockheight: 5,
+      vin: [{ addr: 't1alice' }],
+      vout: [{ value: '5', scriptPubKey: { addresses: ['t1someoneelse'] } }],
+    };
+
+    expect(buildDonationRows([unrelated], { nowMs: NOW })).toEqual([]);
+  });
+
+  it('returns an empty list for junk input rather than throwing', () => {
+    expect(buildDonationRows(null, { nowMs: NOW })).toEqual([]);
+    expect(buildDonationRows([], { nowMs: NOW })).toEqual([]);
+    expect(buildDonationRows([{}], { nowMs: NOW })).toEqual([]);
+  });
+});
+
+describe('shortTxid', () => {
+  it('keeps both ends so a reader can match it against the explorer', () => {
+    expect(shortTxid('a694d0a592bab79798767c11619a943bd5d28c4667c2c1734cea9f6e199812da'))
+      .toBe('a694d0..9812da');
+  });
+
+  it('leaves an already-short id alone rather than padding it', () => {
+    expect(shortTxid('abc')).toBe('abc');
+  });
+
+  it('tolerates a missing id', () => {
+    expect(shortTxid(null)).toBe('');
+  });
+});
+
+describe('explorerTxUrl', () => {
+  /*
+   * The explorer is a HASH-routed SPA. Measured 2026-09-13:
+   *   https://explorer.runonflux.io/tx/<txid>    -> 404
+   *   https://explorer.runonflux.io/#/tx/<txid>  -> 200
+   * The obvious-looking path is the broken one, so it is pinned here.
+   */
+  it('uses the hash route, because the plain path 404s', () => {
+    expect(explorerTxUrl('abc123')).toBe('https://explorer.runonflux.io/#/tx/abc123');
+  });
+});

--- a/client/src/home/Home.jsx
+++ b/client/src/home/Home.jsx
@@ -82,6 +82,7 @@ class Home extends React.Component {
 
       countryCounts: [],
       donations: null,
+      donationRows: [],
       donationsSettled: false,
       donationsFailed: false,
     };
@@ -256,8 +257,8 @@ class Home extends React.Component {
     // #258: community donation totals. Network-wide, so it belongs here with
     // the other panels that describe the network rather than the wallet.
     fetch_donation_totals()
-      .then(({ ok, totals }) =>
-        this.setState({ donations: totals, donationsSettled: true, donationsFailed: !ok })
+      .then(({ ok, totals, rows }) =>
+        this.setState({ donations: totals, donationRows: rows || [], donationsSettled: true, donationsFailed: !ok })
       )
       .catch(() => this.setState({ donationsSettled: true, donationsFailed: true }));
   }
@@ -674,6 +675,7 @@ class Home extends React.Component {
                 gstore={this.state.gstore}
                 countryCounts={this.state.countryCounts}
                 donations={this.state.donations}
+                donationRows={this.state.donationRows}
                 donationsSettled={this.state.donationsSettled}
                 donationsFailed={this.state.donationsFailed}
               />

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -3,7 +3,7 @@ import './index.scss';
 
 import { Spinner } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import { relativeAge } from 'donor/donationTotals';
+import { relativeAge, shortTxid, explorerTxUrl } from 'donor/donationTotals';
 import { FaHeart } from 'react-icons/fa';
 import { BsCheckLg, BsClipboard } from 'react-icons/bs';
 import { useCopyAddress } from 'donor/useCopyAddress';
@@ -98,7 +98,134 @@ function SupportCta({ address, shortAddress, standalone = false }) {
   );
 }
 
-function CommunitySupportPanel({ donations, donationsSettled, donationsFailed }) {
+
+/*
+ * The donations themselves, not just the total (issue #315).
+ *
+ * The rows come from the SAME scan the total above is computed from -- see
+ * fetch_donation_totals -- so the list cannot disagree with the headline
+ * figure about what counted, and it costs no extra explorer traffic (which
+ * #314 had just finished making expensive to spend).
+ *
+ * Project-owned transfers are shown and LABELLED rather than hidden. They stay
+ * out of the total, as EXCLUDED_FROM_DONATION_TOTALS has always ensured; but a
+ * list that silently omitted them would not reconcile against the address's
+ * on-chain balance and nothing on screen would say why. Labelling is what lets
+ * the panel be both complete and honest.
+ */
+const SORTS = {
+  block: { label: 'Block', get: (r) => r.blockHeight },
+  amount: { label: 'Amount', get: (r) => r.amount },
+  donor: { label: 'Donor', get: (r) => r.from },
+};
+
+function DonationList({ rows }) {
+  const [query, setQuery] = useState('');
+  const [sortKey, setSortKey] = useState('block');
+  const [ascending, setAscending] = useState(false);
+
+  if (!rows || rows.length === 0) return null;
+
+  /*
+   * Search runs over the WHOLE row set, not the rendered slice -- the list is
+   * capped by scroll height, not by count, so there is no hidden tail for a
+   * match to fall into.
+   */
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? rows.filter(
+        (r) =>
+          r.from.toLowerCase().includes(q) ||
+          String(r.amount).includes(q) ||
+          r.txid.toLowerCase().includes(q)
+      )
+    : rows;
+
+  const get = SORTS[sortKey].get;
+  const sorted = [...filtered].sort((a, b) => {
+    const av = get(a);
+    const bv = get(b);
+    const cmp = typeof av === 'string' ? av.localeCompare(bv) : av - bv;
+    return ascending ? cmp : -cmp;
+  });
+
+  const toggleSort = (key) => {
+    if (key === sortKey) {
+      setAscending((prev) => !prev);
+    } else {
+      setSortKey(key);
+      // Block and Amount are most useful highest-first; a donor address is not.
+      setAscending(key === 'donor');
+    }
+  };
+
+  const arrow = (key) => (key === sortKey ? (ascending ? ' ↑' : ' ↓') : '');
+
+  return (
+    <div className="hov-donations">
+      <div className="hov-donations-head">
+        <span className="hov-donations-title">
+          Donations
+          <span className="hov-donations-count">
+            {q ? `${sorted.length} / ${rows.length}` : rows.length}
+          </span>
+        </span>
+        <input
+          className="hov-donations-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search wallet or amount"
+          aria-label="Search donations by wallet or amount"
+        />
+      </div>
+
+      <div className="hov-donations-row hov-donations-row--header">
+        <button type="button" onClick={() => toggleSort('donor')}>Donor{arrow('donor')}</button>
+        <span>Transaction</span>
+        <button type="button" className="hov-num" onClick={() => toggleSort('amount')}>Amount{arrow('amount')}</button>
+        <button type="button" className="hov-num" onClick={() => toggleSort('block')}>Block{arrow('block')}</button>
+        <span className="hov-num">When</span>
+      </div>
+
+      <div className="hov-donations-list">
+        {sorted.length === 0 ? (
+          <div className="hov-empty">No donation matches that search</div>
+        ) : (
+          sorted.map((r) => (
+            <div
+              key={r.txid}
+              className={`hov-donations-row${r.isProjectTransfer ? ' hov-donations-row--project' : ''}`}
+            >
+              <span className="hov-donations-donor" title={r.from}>
+                {shortTxid(r.from)}
+                {r.isProjectTransfer && (
+                  <span className="hov-donations-tag" title="Sent from a project-owned wallet, so it is not counted in the community total above">
+                    project
+                  </span>
+                )}
+              </span>
+              <a
+                className="hov-donations-tx"
+                href={explorerTxUrl(r.txid)}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={r.txid}
+              >
+                {shortTxid(r.txid)}
+              </a>
+              <span className="hov-num hov-donations-amount">{fmtNum(r.amount, 2)}</span>
+              <span className="hov-num hov-donations-block">{fmtNum(r.blockHeight)}</span>
+              <span className="hov-num hov-donations-age">{relativeAge(r.timeSec)}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CommunitySupportPanel({ donations, donationRows, donationsSettled, donationsFailed }) {
   if (!donationsSettled) {
     return (
       <div className="hov-panel hov-panel-center hov-panel--support">
@@ -160,6 +287,8 @@ function CommunitySupportPanel({ donations, donationsSettled, donationsFailed })
           </div>
         </>
       )}
+
+      {donationCount > 0 && <DonationList rows={donationRows} />}
 
       {/* With no donations there is no band to hang the address off, so it
           gets its own row rather than disappearing. */}
@@ -273,6 +402,7 @@ export function HomeOverview({
   gstore,
   countryCounts,
   donations,
+  donationRows,
   donationsSettled,
   donationsFailed
 }) {
@@ -281,6 +411,7 @@ export function HomeOverview({
       <div className="home-overview-row home-overview-row--support">
         <CommunitySupportPanel
           donations={donations}
+          donationRows={donationRows}
           donationsSettled={donationsSettled}
           donationsFailed={donationsFailed}
         />

--- a/client/src/home/HomeOverview/index.scss
+++ b/client/src/home/HomeOverview/index.scss
@@ -888,3 +888,170 @@
     }
   }
 }
+
+/* ── The donations themselves (issue #315) ───────────────────────────────── */
+
+.hov-donations {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-secondary);
+}
+
+.hov-donations-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.hov-donations-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.hov-donations-count {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: rgba(128, 128, 128, 0.14);
+  color: var(--text-secondary);
+}
+
+.hov-donations-search {
+  flex: 0 1 220px;
+  min-width: 0;
+  font-size: 0.76rem;
+  padding: 4px 9px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border-primary);
+  background: var(--surface-inset);
+  color: var(--text-primary);
+
+  &::placeholder { color: var(--text-tertiary); }
+  &:focus { outline: none; border-color: var(--accent-green); }
+}
+
+.hov-donations-row {
+  display: grid;
+  align-items: center;
+  gap: 10px;
+  /* Donor and transaction get the room; the three numeric columns are fixed
+     so they line up as columns rather than drifting with content width. */
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) 92px 86px 92px;
+  padding: 5px 4px;
+  font-size: 0.76rem;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.07);
+
+  &:last-child { border-bottom: none; }
+}
+
+.hov-donations-row--header {
+  border-bottom: 1px solid var(--border-secondary);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  padding-bottom: 5px;
+  /* Matches .hov-donations-list's scrollbar gutter (4px row padding + 10px),
+     or the header columns sit 10px left of the rows they label. */
+  padding-right: 14px;
+
+  button,
+  span {
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  button {
+    cursor: pointer;
+    text-align: left;
+
+    &:hover { color: var(--text-secondary); }
+  }
+
+  .hov-num { text-align: right; }
+}
+
+.hov-donations-list {
+  max-height: 260px;
+  overflow-y: auto;
+  /* Same reason as #318: right-aligned numbers under a scrollbar. */
+  padding-right: 10px;
+}
+
+.hov-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.hov-donations-donor,
+.hov-donations-tx {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hov-donations-donor {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-primary);
+}
+
+.hov-donations-tx {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  color: var(--accent-green);
+  text-decoration: none;
+
+  &:hover { text-decoration: underline; }
+}
+
+.hov-donations-amount { color: var(--text-primary); font-weight: 600; }
+.hov-donations-block,
+.hov-donations-age { color: var(--text-tertiary); }
+
+/*
+ * A project-owned transfer. Visibly set apart rather than hidden: it is real
+ * money that arrived, so the list must show it, but it is not community
+ * backing and must never read as though it were.
+ */
+.hov-donations-row--project {
+  opacity: 0.72;
+}
+
+.hov-donations-tag {
+  flex-shrink: 0;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--accent-amber, #e09205);
+  color: var(--accent-amber, #e09205);
+}
+
+@media (max-width: 700px) {
+  /* The block height is the first thing to go: it is the least useful column
+     on a phone and the only one nobody scans by eye. */
+  .hov-donations-row {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) 80px 80px;
+  }
+
+  .hov-donations-block { display: none; }
+}


### PR DESCRIPTION
Closes #315.

Home showed one figure — *785 FLUX from 9 supporters*. The individual transactions were already being fetched, reduced to that sum, and discarded.

```
DONATIONS  17                                        [ Search wallet or amount ]
DONOR              TRANSACTION        AMOUNT     BLOCK ↓        WHEN
t1RPtT..hQ4Li9     d71957..193636          1   2,846,708   5 weeks ago
t1RPtT..hQ4Li9     b053c2..7fdbeb          1   2,846,640   5 weeks ago
t1X1hK..uV7Tbb     8bc0d3..4d88d7         45   2,653,478   3 months ago
t1ez3h..MzNqWE     0f5d2b..58df80          1   2,380,410   7 months ago
```

Sorted by block descending (latest first), sortable on Donor / Amount / Block, searchable by wallet, amount or txid, and transaction ids link to the explorer.

## Three decisions worth reviewing

**No new explorer traffic.** The rows ride along on the scan `fetch_donation_totals` already runs — a second *reading* of the same bytes, not a second scan. #314 had just finished making that scan affordable by sharing it between three callers; adding a fourth would have undone exactly that fix.

**Capped by scroll height, not by row count.** That's what lets search run over the **whole** set. A "first 25 with show-more" list would have had to decide whether search covers the hidden tail — and either answer reads as a bug.

**Project transfers are shown and labelled, not hidden.** `aggregateDonations` still drops them from the headline total — that's what `EXCLUDED_FROM_DONATION_TOTALS` is for and it doesn't change. But a list that silently omitted them wouldn't reconcile against the address's on-chain balance, with nothing on screen to explain the gap; and showing them unlabelled would headline a project transfer as community backing, which is the precise hazard that list was created for. Labelled is the only option that's both complete and honest.

*(There are no such transfers in the window today, so this path is covered by unit tests rather than by what's on screen.)*

## One trap caught before shipping

`explorerTxUrl` is a tested function rather than an inlined template string, because **the obvious URL is the broken one**. Measured 2026-09-13:

```
https://explorer.runonflux.io/tx/<txid>    -> 404
https://explorer.runonflux.io/#/tx/<txid>  -> 200
```

The explorer is a hash-routed SPA. Inlining the natural-looking path would have shipped a panel full of dead links that still looked right in review.

## Consistency with the total above it

`buildDonationRows` shares `paidToDonationAddress`, `senderOf` and the 365-day window with `aggregateDonations` rather than reimplementing them — the list and the total sit in the same panel, and if they disagreed about change outputs or the window the panel would contradict itself on screen. A test asserts the two agree on both count and sum.

## Verification

- **893 tests / 61 suites pass** (was 881). 12 new, written before the code.
- `yarn build` clean — no new warnings.
- Browser-verified against live data: 17 donations, block-descending by default, header aligned with the scrolled rows, wallet search 5/17, amount sort 500/100/50 and back again, no-match empty state, links resolving to the hash route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu