### PR TITLE
Home: stop publishing donor wallets and transaction ids (#322)

### DIFF
--- a/client/src/donor/donationTotals.js
+++ b/client/src/donor/donationTotals.js
@@ -179,26 +179,22 @@ export function buildDonationRows(txs, { nowMs = Date.now(), excluded } = {}) {
 }
 
 /*
- * Enough of each end to match a row against the explorer by eye, which is the
- * only thing the shortened form has to support. Middle-elided rather than
- * truncated: the tail is what distinguishes two transactions in the same block.
- */
-export function shortTxid(txid) {
-  if (typeof txid !== 'string' || !txid) return '';
-  if (txid.length <= 14) return txid;
-  return `${txid.slice(0, 6)}..${txid.slice(-6)}`;
-}
-
-/*
- * The explorer is a HASH-routed SPA, and the obvious-looking path is the broken
- * one. Measured 2026-09-13:
+ * Middle-elided identifiers for the Home donation list.
  *
- *   https://explorer.runonflux.io/tx/<txid>    -> 404
- *   https://explorer.runonflux.io/#/tx/<txid>  -> 200
+ * Deliberately SHORT. Home is the front page, and a full donor address or
+ * transaction id printed there publishes, to everyone who loads the site, a
+ * tidy index of who supports the project and exactly which transactions they
+ * sent. All of it is public on chain -- but public-if-you-go-looking and
+ * published-on-the-landing-page are different things, and the second is not
+ * something a donor opted into by donating.
  *
- * Written as a function with a test rather than inlined at the call site, so
- * a whole panel of dead links cannot be introduced by someone tidying the URL.
+ * What survives is enough to recognise a row and to paste into the explorer's
+ * search if you already know what you are looking for, and not enough to read
+ * the page as a directory. `head`/`tail` are explicit at each call site
+ * because the two columns are deliberately different widths.
  */
-export function explorerTxUrl(txid) {
-  return `https://explorer.runonflux.io/#/tx/${txid}`;
+export function shortId(value, head, tail) {
+  if (typeof value !== 'string' || !value) return '';
+  if (value.length <= head + tail + 2) return value;
+  return `${value.slice(0, head)}..${value.slice(-tail)}`;
 }

--- a/client/src/donor/donationTotals.test.js
+++ b/client/src/donor/donationTotals.test.js
@@ -141,7 +141,7 @@ describe('relativeAge', () => {
 /*
  * Issue #315 -- the same transactions, listed individually rather than summed.
  */
-import { buildDonationRows, shortTxid, explorerTxUrl } from './donationTotals';
+import { buildDonationRows, shortId } from './donationTotals';
 
 const PROJECT_WALLET = 't1gesjNJGfzU8shfMZj6DVDatRKA3LQj8Nh'; // EXCLUDED_FROM_DONATION_TOTALS
 
@@ -249,29 +249,30 @@ describe('buildDonationRows', () => {
   });
 });
 
-describe('shortTxid', () => {
-  it('keeps both ends so a reader can match it against the explorer', () => {
-    expect(shortTxid('a694d0a592bab79798767c11619a943bd5d28c4667c2c1734cea9f6e199812da'))
-      .toBe('a694d0..9812da');
-  });
-
-  it('leaves an already-short id alone rather than padding it', () => {
-    expect(shortTxid('abc')).toBe('abc');
-  });
-
-  it('tolerates a missing id', () => {
-    expect(shortTxid(null)).toBe('');
-  });
-});
-
-describe('explorerTxUrl', () => {
+describe('shortId', () => {
   /*
-   * The explorer is a HASH-routed SPA. Measured 2026-09-13:
-   *   https://explorer.runonflux.io/tx/<txid>    -> 404
-   *   https://explorer.runonflux.io/#/tx/<txid>  -> 200
-   * The obvious-looking path is the broken one, so it is pinned here.
+   * Issue #322. Home is the front page: a full donor address or transaction id
+   * printed there publishes a directory of who supports the project and what
+   * they sent. On-chain-and-public is not the same as published-on-the-landing-
+   * page, and a donor did not opt into the second by doing the first.
    */
-  it('uses the hash route, because the plain path 404s', () => {
-    expect(explorerTxUrl('abc123')).toBe('https://explorer.runonflux.io/#/tx/abc123');
+  it('shortens a donor wallet to 3 and 3', () => {
+    expect(shortId('t1RPtTaBcDeFgHiJkLmNoPqRsTuVwXyZhQ4Li9', 3, 3)).toBe('t1R..Li9');
+  });
+
+  it('shortens a transaction id to 4 and 4', () => {
+    expect(shortId('d71957251972737404bc8b89e70e8bf94a188865257cecae877cb00b01193636', 4, 4))
+      .toBe('d719..3636');
+  });
+
+  it('leaves a value alone when shortening would not actually shorten it', () => {
+    // No point rendering "abcd..wxyz" for a 10-character string.
+    expect(shortId('abcdefgh', 4, 4)).toBe('abcdefgh');
+  });
+
+  it('tolerates a missing or non-string value', () => {
+    expect(shortId(null, 3, 3)).toBe('');
+    expect(shortId(undefined, 4, 4)).toBe('');
+    expect(shortId(12345, 4, 4)).toBe('');
   });
 });

--- a/client/src/home/HomeOverview/index.jsx
+++ b/client/src/home/HomeOverview/index.jsx
@@ -3,7 +3,7 @@ import './index.scss';
 
 import { Spinner } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import { relativeAge, shortTxid, explorerTxUrl } from 'donor/donationTotals';
+import { relativeAge, shortId } from 'donor/donationTotals';
 import { FaHeart } from 'react-icons/fa';
 import { BsCheckLg, BsClipboard } from 'react-icons/bs';
 import { useCopyAddress } from 'donor/useCopyAddress';
@@ -132,13 +132,18 @@ function DonationList({ rows }) {
    * match to fall into.
    */
   const q = query.trim().toLowerCase();
+  /*
+   * Wallet and amount only -- deliberately NOT txid (#322).
+   *
+   * It used to match txid too, which was defensible while the full id was on
+   * screen. It is not now: searching "45" would return a 10 FLUX donation whose
+   * transaction id happens to contain "45", and with the id no longer readable
+   * there is nothing on the row to explain the match. A search that returns
+   * rows the reader cannot connect to their query reads as a bug, so the
+   * predicate matches the placeholder.
+   */
   const filtered = q
-    ? rows.filter(
-        (r) =>
-          r.from.toLowerCase().includes(q) ||
-          String(r.amount).includes(q) ||
-          r.txid.toLowerCase().includes(q)
-      )
+    ? rows.filter((r) => r.from.toLowerCase().includes(q) || String(r.amount).includes(q))
     : rows;
 
   const get = SORTS[sortKey].get;
@@ -197,23 +202,23 @@ function DonationList({ rows }) {
               key={r.txid}
               className={`hov-donations-row${r.isProjectTransfer ? ' hov-donations-row--project' : ''}`}
             >
-              <span className="hov-donations-donor" title={r.from}>
-                {shortTxid(r.from)}
+              {/*
+                #322: no `title` with the full value, and no link. A tooltip
+                carrying the whole address, or an href carrying the whole txid,
+                republishes exactly what the shortening is here to withhold --
+                one is readable on hover, the other in the status bar and on
+                copy-link. Shortening the visible text while leaking the full
+                value into an attribute would be security theatre.
+              */}
+              <span className="hov-donations-donor">
+                {shortId(r.from, 3, 3)}
                 {r.isProjectTransfer && (
                   <span className="hov-donations-tag" title="Sent from a project-owned wallet, so it is not counted in the community total above">
                     project
                   </span>
                 )}
               </span>
-              <a
-                className="hov-donations-tx"
-                href={explorerTxUrl(r.txid)}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={r.txid}
-              >
-                {shortTxid(r.txid)}
-              </a>
+              <span className="hov-donations-tx">{shortId(r.txid, 4, 4)}</span>
               <span className="hov-num hov-donations-amount">{fmtNum(r.amount, 2)}</span>
               <span className="hov-num hov-donations-block">{fmtNum(r.blockHeight)}</span>
               <span className="hov-num hov-donations-age">{relativeAge(r.timeSec)}</span>

--- a/client/src/home/HomeOverview/index.scss
+++ b/client/src/home/HomeOverview/index.scss
@@ -945,7 +945,8 @@
   gap: 10px;
   /* Donor and transaction get the room; the three numeric columns are fixed
      so they line up as columns rather than drifting with content width. */
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) 92px 86px 92px;
+  /* #322 shortened both identifiers, so these no longer need to flex wide. */
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 0.7fr) 92px 92px 100px;
   padding: 5px 4px;
   font-size: 0.76rem;
   border-bottom: 1px solid rgba(128, 128, 128, 0.07);
@@ -1012,13 +1013,15 @@
   color: var(--text-primary);
 }
 
+/*
+ * No longer a link (#322). Styled as the quiet reference it now is rather than
+ * as something to click -- an accent-green underlined string that does nothing
+ * on click is worse than plain text.
+ */
 .hov-donations-tx {
   font-family: var(--font-mono, monospace);
   font-size: 0.72rem;
-  color: var(--accent-green);
-  text-decoration: none;
-
-  &:hover { text-decoration: underline; }
+  color: var(--text-secondary);
 }
 
 .hov-donations-amount { color: var(--text-primary); font-weight: 600; }
@@ -1050,7 +1053,7 @@
   /* The block height is the first thing to go: it is the least useful column
      on a phone and the only one nobody scans by eye. */
   .hov-donations-row {
-    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) 80px 80px;
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 0.8fr) 80px 88px;
   }
 
   .hov-donations-block { display: none; }


### PR DESCRIPTION
Closes #322.

```
DONATIONS  17                                        [ Search wallet or amount ]
DONOR          TRANSACTION      AMOUNT      BLOCK ↓        WHEN
t1R..Li9       d719..3636            1   2,846,708   5 weeks ago
t1R..Li9       b053..dbeb            1   2,846,640   5 weeks ago
t1X..Tbb       8bc0..88d7           45   2,653,478   3 months ago
```

Donor wallet `3 + 3`, transaction id `4 + 4`, no links — as asked.

## Shortening the text alone would have been theatre

The rows also carried the full values in three places that are just as readable as the cell:

```
title={r.from}                the whole address, on hover
title={r.txid}                the whole id, on hover
href={explorerTxUrl(r.txid)}  the whole id, in the status bar and on copy-link
```

All three are gone. **Verified against the rendered DOM**, not by reading the JSX: no string matching a Flux address or a 40+ character hex id survives anywhere in the panel's markup, and it contains no anchors at all.

`explorerTxUrl` is deleted with them — it existed only to build those hrefs, and an unused export is what #313 had just finished clearing out. The fact it encoded (the explorer is hash-routed; `/tx/<id>` 404s) is preserved in #315's history rather than in dead code.

## One thing this broke, caught in the browser

Search also matched **txid**. That was defensible while the id was on screen; it isn't now. Searching `45` returned a 10 FLUX donation whose transaction id happened to contain `45`, with nothing on the row to explain the match — a search that returns rows the reader can't connect to their query reads as a bug.

The predicate is now wallet and amount, which is what the placeholder has always said. Confirmed after the fix: `45` → one row, amount 45; wallet search → 5 of 17; cleared → 17.

## Verification

- **893 tests / 61 suites pass.** `shortId` replaces `shortTxid`'s tests with the new widths.
- `yarn build` clean.
- Browser-verified on live data: rows render `t1R..Li9` / `d719..3636`, zero anchors, zero `title` attributes, no full identifiers in the DOM, search and sort still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu