### PR TITLE
APP ECOSYSTEM total was rendering invisibly (#317)

### DIFF
--- a/client/src/audit/invisibleText.test.js
+++ b/client/src/audit/invisibleText.test.js
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * Issue #317: a figure that rendered, occupied space, appeared in innerText --
+ * and was invisible.
+ *
+ * The pattern that does it is `-webkit-text-fill-color: transparent`, which
+ * hands the painting of the glyphs over to `background-clip: text`. When that
+ * works it is a gradient number. When the background is lost, the text is
+ * painted with nothing.
+ *
+ * On APP ECOSYSTEM the background WAS lost, to a same-specificity rule in
+ * another stylesheet, and the cascade resolves per property -- so the losing
+ * rule still supplied the transparent fill while the winning one supplied a
+ * flat pill. Nothing about the markup or the data was wrong, which is why it
+ * survived review and a DOM-text check: reading innerText proves a value is
+ * present, not that it can be seen.
+ *
+ * This pins the two halves of the lesson across every stylesheet, so the next
+ * gradient number cannot reintroduce it quietly.
+ */
+
+const SRC = path.join(__dirname, '..');
+
+function scssFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...scssFiles(full));
+    else if (entry.name.endsWith('.scss')) out.push(full);
+  }
+  return out;
+}
+
+/*
+ * Split a stylesheet into brace-balanced blocks, each paired with the selector
+ * line that opened it. Crude, but it only has to be good enough to tell "these
+ * two declarations are in the same block" -- which is the whole question.
+ */
+function blocks(source) {
+  const found = [];
+  const lines = source.split('\n');
+  const stack = [];
+  for (const line of lines) {
+    const opens = (line.match(/\{/g) || []).length;
+    const closes = (line.match(/\}/g) || []).length;
+    if (opens > 0) {
+      stack.push({ selector: line.trim().replace(/\{.*$/, '').trim(), body: [] });
+    }
+    for (const frame of stack) frame.body.push(line);
+    for (let i = 0; i < closes; i += 1) {
+      const done = stack.pop();
+      if (done) found.push({ selector: done.selector, body: done.body.join('\n') });
+    }
+  }
+  return found;
+}
+
+const files = scssFiles(SRC);
+
+describe('no stylesheet can paint text with nothing (#317)', () => {
+  it('finds stylesheets to check, so this cannot pass vacuously', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('every transparent text fill has a gradient in the SAME block to paint it', () => {
+    const offenders = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      if (!source.includes('text-fill-color')) continue;
+
+      for (const block of blocks(source)) {
+        // Only the transparent form is dangerous. `currentColor` and real
+        // colours are fallbacks, not hand-offs.
+        if (!/-webkit-text-fill-color:\s*transparent/.test(block.body)) continue;
+
+        const paints =
+          /background(-image)?:\s*[^;]*gradient/.test(block.body) &&
+          /background-clip:\s*text/.test(block.body);
+
+        if (!paints) {
+          offenders.push(`${path.relative(SRC, file)} :: ${block.selector}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  /*
+   * The specificity half. A modifier written as `&--hero` compiles to a single
+   * class, which ties its own base class -- and `.hov-header-badge` exists in
+   * seven stylesheets loaded into one chunk, so "ties" means "whichever file
+   * loads last wins". Chaining (`&.block--modifier`) is what makes the
+   * modifier unconditionally win.
+   */
+  it('a gradient-painted modifier is chained onto its base class', () => {
+    const unchained = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      if (!source.includes('text-fill-color')) continue;
+
+      for (const block of blocks(source)) {
+        if (!/-webkit-text-fill-color:\s*transparent/.test(block.body)) continue;
+
+        // Walk out to the owning selector: a bare `&--modifier` anywhere in
+        // this block's own selector chain is the hazard.
+        const bareModifier = /(^|\s)&--[\w-]+\s*$/.test(block.selector);
+        if (bareModifier) unchained.push(`${path.relative(SRC, file)} :: ${block.selector}`);
+      }
+    }
+
+    expect(unchained).toEqual([]);
+  });
+});

--- a/client/src/components/AppEcosystemBreakdown/index.scss
+++ b/client/src/components/AppEcosystemBreakdown/index.scss
@@ -109,13 +109,37 @@
     background: rgba(255, 255, 255, 0.08);
   }
 
-  &--hero {
+  /*
+   * Chained onto the base class on purpose -- `&.hov-header-badge--hero`, not
+   * `&--hero` (issue #317).
+   *
+   * `.hov-header-badge` is defined in SEVEN stylesheets, all loaded into the
+   * same /analytics chunk. `&--hero` compiles to `.hov-header-badge--hero`,
+   * which ties the plain `.hov-header-badge` on specificity, and in dark mode
+   * `.app-mode-dark .hov-header-badge--hero` ties
+   * `.app-mode-dark .hov-header-badge` -- so whichever file happened to load
+   * last won, and six of the seven are not this one.
+   *
+   * The cascade resolves per PROPERTY, which is what made the failure so
+   * strange to look at: the losing rule still supplied
+   * `-webkit-text-fill-color: transparent` (nothing else sets that property),
+   * while the base rule supplied the background. Transparent text painted with
+   * a flat grey pill instead of the gradient meant for it: the figure rendered,
+   * occupied space, was present in innerText, and was completely invisible.
+   *
+   * Chaining makes these (0,2,0) and (0,3,0), which no `.hov-header-badge`
+   * rule can reach.
+   */
+  &.hov-header-badge--hero {
     font-size: 1.4rem;
     letter-spacing: -0.02em;
     padding: 0 2px;
     background: none;
     border-radius: 0;
     color: var(--text-primary);
+    // Belt and braces: if the gradient below is ever lost again, the text
+    // falls back to a real colour rather than to invisible.
+    -webkit-text-fill-color: currentColor;
 
     @include rule-mode-dark() {
       background: linear-gradient(135deg, #60a5fa, #a78bfa);

--- a/client/src/components/TopHostedApps/index.scss
+++ b/client/src/components/TopHostedApps/index.scss
@@ -109,13 +109,19 @@
     background: rgba(255, 255, 255, 0.08);
   }
 
-  &--hero {
+  // Chained, not `&--hero` -- see the note in
+  // components/AppEcosystemBreakdown/index.scss (#317). `.hov-header-badge`
+  // lives in seven stylesheets sharing one chunk, so an unchained modifier
+  // ties its own base class and loses to whichever file loads last, leaving
+  // transparent text with no gradient to paint it.
+  &.hov-header-badge--hero {
     font-size: 1.4rem;
     letter-spacing: -0.02em;
     padding: 0 2px;
     background: none;
     border-radius: 0;
     color: var(--text-primary);
+    -webkit-text-fill-color: currentColor;
 
     @include rule-mode-dark() {
       background: linear-gradient(135deg, #60a5fa, #a78bfa);

--- a/client/src/home/HomeOverview/index.scss
+++ b/client/src/home/HomeOverview/index.scss
@@ -187,13 +187,19 @@
     background: rgba(255, 255, 255, 0.08);
   }
 
-  &--hero {
+  // Chained, not `&--hero` -- see the note in
+  // components/AppEcosystemBreakdown/index.scss (#317). `.hov-header-badge`
+  // lives in seven stylesheets sharing one chunk, so an unchained modifier
+  // ties its own base class and loses to whichever file loads last, leaving
+  // transparent text with no gradient to paint it.
+  &.hov-header-badge--hero {
     font-size: 1.4rem;
     letter-spacing: -0.02em;
     padding: 0 2px;
     background: none;
     border-radius: 0;
     color: var(--text-primary);
+    -webkit-text-fill-color: currentColor;
 
     @include rule-mode-dark() {
       background: linear-gradient(135deg, #60a5fa, #a78bfa);


### PR DESCRIPTION
Closes #317. **You were right and my "could not reproduce" was wrong** — I checked `innerText`, which proves a value is *present*, not that it is *visible*. Different claims.

## What the screenshot was showing

The badge rendered, was sized, and held the number. Computed styles on the live page, dark theme:

```
-webkit-text-fill-color : rgba(0, 0, 0, 0)         <- transparent
background-image        : none                     <- nothing to paint it with
background-color        : rgba(255,255,255,0.08)   <- the BASE badge pill
border-radius           : 20px                     <- base; --hero sets 0
font-size               : 12px                     <- base; --hero sets 1.4rem
innerText               : "8,306"
```

## Why

`.hov-header-badge` is defined in **seven** stylesheets, all loaded into the same `/analytics` chunk. `&--hero` compiles to `.hov-header-badge--hero`, which **ties** the plain `.hov-header-badge`; in dark mode `.app-mode-dark .hov-header-badge--hero` (0,2,0) ties `.app-mode-dark .hov-header-badge` (0,2,0). Six of the seven base copies live in other files, so one loaded last and won.

**The cascade resolves per property**, which is what made it so odd to look at: the *losing* rule still supplied `-webkit-text-fill-color: transparent` — nothing else in the codebase sets that property — while the *winning* rule supplied the background. Transparent glyphs handed to `background-clip: text`, with a flat grey pill where their gradient should have been.

This is the same specificity/load-order hazard already documented in `DonorTab/index.scss` for `.hov-panel` and `.hov-ranked-row`.

## Fix

Chain the modifier — `&.hov-header-badge--hero` — making these (0,2,0) and (0,3,0), which no `.hov-header-badge` rule can reach. Each base block also sets `-webkit-text-fill-color: currentColor`, so if the gradient is ever lost again the text falls back to a real colour instead of to nothing.

**There were three instances, not one.** The browser sweep found two on the Apps tab; the new guard found a third in `home/HomeOverview` that was latent. All three fixed.

## The guard

`audit/invisibleText.test.js` pins both halves of the lesson generally, rather than pinning this symptom:

1. Every `-webkit-text-fill-color: transparent` must have a gradient **and** `background-clip: text` in the **same block** — text is never handed to a painter that isn't there.
2. A block doing that must be **chained onto its base class**, not a bare `&--modifier`, so it can't lose to a same-specificity rule in another file.

It found the third instance the moment it was written, which is the argument for it existing.

## Verification

- **906 tests / 62 suites** (was 903). 3 new.
- `yarn build` clean.
- Browser, after the fix: `8,306` renders as the intended gradient figure, and a sweep for transparent-filled text with no gradient — discounting elements an ancestor paints — returns **empty on all four Analytics tabs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu