### PR TITLE
Say what the colours and categories mean (#330, #333, #334)

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Spinner } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { Lock } from 'lucide-react';
 import { useDonorStatus } from 'contexts/DonorContext';
 import { PremiumUnlock } from 'donor/PremiumUnlock';
@@ -11,6 +12,7 @@ import { buildDonorAppRows, tallyRowCategories } from 'analytics/donorAppRows';
 import { buildDonorNodeRows } from 'analytics/donorNodeRows';
 import { filterAppRows, utilizationAddresses } from 'analytics/donorFilters';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { CategoryTooltip } from 'components/CategoryTooltip';
 import { tierMeta } from 'content/nodeTierMeta';
 import { fetch_wallet_tx_history } from 'analytics/walletTxFetch';
 import { counterpartyDisplay, WINDOW_DAYS } from 'analytics/walletTxHistory';
@@ -411,22 +413,39 @@ function AppCategoriesPanel({ categories, totalApps, selectedCategory, onSelect,
             const barPct = (count / maxVal) * 100;
             const selected = selectedCategory === category;
             return (
-              <button
-                type="button"
+              /*
+                #334: the row showed an icon, a label and a bar with no way to
+                learn what the category contains. This is the treatment Home
+                used and that home/WorkhorsePanel still uses.
+
+                Wrapping the BUTTON rather than its contents: the row is a
+                filter (#299), and the tooltip target has to sit outside the
+                control so hovering explains the category without interfering
+                with the click or with keyboard focus.
+              */
+              <Tooltip2
                 key={category}
-                className={`dt-apps-row${selected ? ' dt-apps-row--selected' : ''}`}
-                onClick={() => onSelect(category)}
-                title={selected ? 'Selected — click the count to show all' : `Show only ${label} apps`}
+                content={<CategoryTooltip category={category} />}
+                placement="top"
+                hoverOpenDelay={200}
+                popoverClassName="hov-cat-tooltip"
               >
-                <span className="dt-apps-icon" style={{ color }}>
-                  <Icon size={11} />
-                </span>
-                <span className="dt-apps-label">{label}</span>
-                <div className="dt-apps-bar-wrap">
-                  <div className="dt-apps-bar-fill" style={{ width: `${barPct}%`, background: color }} />
-                </div>
-                <span className="hov-badge">{fmtNum(count)}</span>
-              </button>
+                <button
+                  type="button"
+                  className={`dt-apps-row${selected ? ' dt-apps-row--selected' : ''}`}
+                  onClick={() => onSelect(category)}
+                  aria-pressed={selected}
+                >
+                  <span className="dt-apps-icon" style={{ color }}>
+                    <Icon size={11} />
+                  </span>
+                  <span className="dt-apps-label">{label}</span>
+                  <div className="dt-apps-bar-wrap">
+                    <div className="dt-apps-bar-fill" style={{ width: `${barPct}%`, background: color }} />
+                  </div>
+                  <span className="hov-badge">{fmtNum(count)}</span>
+                </button>
+              </Tooltip2>
             );
           })
         )}

--- a/client/src/analytics/DonorTab/index.scss
+++ b/client/src/analytics/DonorTab/index.scss
@@ -925,3 +925,13 @@
   color: var(--text-tertiary);
   padding-top: 8px;
 }
+
+/*
+ * Blueprint's Tooltip2 wraps its target in a span (#334). Inside a flex column
+ * that span becomes the flex child, so it has to carry the full width or the
+ * category rows collapse to their content and stop lining up.
+ */
+.dt-apps-list > .bp4-popover2-target {
+  display: block;
+  width: 100%;
+}

--- a/client/src/analytics/NetworkTab/index.scss
+++ b/client/src/analytics/NetworkTab/index.scss
@@ -655,3 +655,9 @@
     padding: 10px 12px;
   }
 }
+
+/* Same Tooltip2 wrapper consideration as the Donor tab's category rows (#333). */
+.nt-apps-list > .bp4-popover2-target {
+  display: block;
+  width: 100%;
+}

--- a/client/src/analytics/NetworkTab/regionCards.jsx
+++ b/client/src/analytics/NetworkTab/regionCards.jsx
@@ -1,4 +1,6 @@
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
+import { CategoryTooltip } from 'components/CategoryTooltip';
 import { tierMeta } from 'content/nodeTierMeta';
 
 /*
@@ -149,13 +151,27 @@ export function HostedApplicationsCard({ stats, label }) {
             const meta = APP_CATEGORY_META[category] || APP_CATEGORY_META.other;
             const Icon = meta?.Icon;
             return (
-              <div key={category} className="hov-kv-row">
-                <span className="hov-kv-label">
-                  {Icon && <Icon size={11} style={{ color: meta.color }} className="nt-app-icon" />}
-                  {meta?.label || category}
-                </span>
-                <span className="hov-kv-value">{fmtNum(count)}</span>
-              </div>
+              /*
+                #333: the row was a label and a number with no way to find out
+                what is in the category. Same tooltip the Apps tab, the
+                ecosystem panel and the Workhorse showcase already use, so the
+                explanation is written once in CATEGORY_TOOLTIPS.
+              */
+              <Tooltip2
+                key={category}
+                content={<CategoryTooltip category={category} />}
+                placement="top"
+                hoverOpenDelay={200}
+                popoverClassName="hov-cat-tooltip"
+              >
+                <div className="hov-kv-row nt-app-row">
+                  <span className="hov-kv-label">
+                    {Icon && <Icon size={11} style={{ color: meta.color }} className="nt-app-icon" />}
+                    {meta?.label || category}
+                  </span>
+                  <span className="hov-kv-value">{fmtNum(count)}</span>
+                </div>
+              </Tooltip2>
             );
           })}
         </div>

--- a/client/src/home/BlockPulse/index.jsx
+++ b/client/src/home/BlockPulse/index.jsx
@@ -114,26 +114,78 @@ export function BlockPulse() {
   const size = tileSizeFor(particles.length);
   const columns = columnsFor(particles.length);
 
-  const summary = [
-    counts.reward ? `${counts.reward} rewards` : null,
-    counts.confirm ? `${counts.confirm} confirmations` : null,
-    counts.p2p ? `${counts.p2p} transfers` : null,
-  ]
-    .filter(Boolean)
-    .join(', ');
+  /*
+   * #330: a category with zero events is omitted rather than shown as
+   * "0 transfers". Measured, P2P is zero in most blocks, so a permanent
+   * greyed-out row would end up the most visually prominent thing in a panel
+   * that is mostly about the other two.
+   */
+  const legend = [
+    {
+      key: 'reward',
+      count: counts.reward,
+      label: counts.reward === 1 ? 'reward' : 'rewards',
+      /*
+       * Four swatches, not one. A reward particle is always one of four tiers
+       * and each is a different colour -- picking any single one to stand for
+       * the row would be telling the reader the wrong thing about three of the
+       * tiles they can see.
+       */
+      swatches: ['CUMULUS', 'NIMBUS', 'STRATUS', 'DEVFUND']
+        .map((tier) => CATEGORY_META[tier]?.color)
+        .filter(Boolean),
+    },
+    {
+      key: 'confirm',
+      count: counts.confirm,
+      label: counts.confirm === 1 ? 'confirmation' : 'confirmations',
+      swatches: [CATEGORY_META.CONFIRM?.color],
+    },
+    {
+      key: 'p2p',
+      count: counts.p2p,
+      label: counts.p2p === 1 ? 'transfer' : 'transfers',
+      swatches: [CATEGORY_META.P2P?.color],
+    },
+  ].filter((row) => row.count > 0);
+
+  const summary = legend.map((row) => `${row.count} ${row.label}`).join(', ');
 
   return (
     <div className="bp">
-      <div
-        key={flightKey}
-        className="bp-grid"
-        style={{ gridTemplateColumns: `repeat(${columns}, ${size}px)`, gap: GAP }}
-        role="img"
-        aria-label={`Block ${height} contains ${total} events: ${summary}`}
-      >
-        {particles.map((p, i) => (
-          <Tile key={p.key} particle={p} index={i} size={size} still={reduced} />
-        ))}
+      <div className="bp-body">
+        <div
+          key={flightKey}
+          className="bp-grid"
+          style={{ gridTemplateColumns: `repeat(${columns}, ${size}px)`, gap: GAP }}
+          role="img"
+          aria-label={`Block ${height} contains ${total} events: ${summary}`}
+        >
+          {particles.map((p, i) => (
+            <Tile key={p.key} particle={p} index={i} size={size} still={reduced} />
+          ))}
+        </div>
+
+        {/*
+          The legend is aria-hidden: the grid above already carries the whole
+          composition in its aria-label, and repeating it would make a screen
+          reader read the block out twice.
+        */}
+        <dl className="bp-legend" aria-hidden="true">
+          {legend.map((row) => (
+            <div key={row.key} className="bp-legend-row">
+              <dt>
+                <span className="bp-legend-swatches">
+                  {row.swatches.map((colour) => (
+                    <i key={colour} style={{ background: colour }} />
+                  ))}
+                </span>
+                {row.label}
+              </dt>
+              <dd>{row.count.toLocaleString()}</dd>
+            </div>
+          ))}
+        </dl>
       </div>
 
       <p className="bp-caption">

--- a/client/src/home/BlockPulse/index.scss
+++ b/client/src/home/BlockPulse/index.scss
@@ -87,3 +87,71 @@
     animation: none;
   }
 }
+
+/* ── Legend (issue #330) ─────────────────────────────────────────────────── */
+
+/*
+ * Grid and legend side by side. The panel is ~537px and the grid is square-ish
+ * and centred (89px for a typical block), so the legend fits beside it without
+ * making the strip any taller -- which matters, because the strip exists to
+ * fill space rather than create it.
+ */
+.bp-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+  flex-wrap: wrap;
+}
+
+.bp-legend {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 120px;
+}
+
+.bp-legend-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.74rem;
+}
+
+.bp-legend-row dt {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+.bp-legend-row dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/*
+ * One swatch per colour the row actually stands for. Rewards carry four, so
+ * they render as a tight strip rather than a single square claiming to
+ * represent tiles of three other colours.
+ */
+.bp-legend-swatches {
+  display: inline-flex;
+  gap: 1px;
+  flex-shrink: 0;
+
+  i {
+    display: block;
+    width: 7px;
+    height: 10px;
+    border-radius: 1px;
+  }
+
+  i:first-child { border-radius: 2px 1px 1px 2px; }
+  i:last-child  { border-radius: 1px 2px 2px 1px; }
+}


### PR DESCRIPTION
Three items from your feedback, same root cause: something on screen carried a number or a colour with nothing to explain it.

## #330 — legend beside the block pulse

```
   ■ ■ ■ ■ ■     ▮▮▮▮  rewards         4
   ■ ■ ■ ■ ■     ▮     confirmations  13
   ■ ■ ■ ■ ■     ▮     transfer        1
   ■ ■ ■
   Block 2,946,141 carried 18 events
```

To the **right** of the grid, so the strip doesn't get taller — it exists to fill space, not create it.

Two deliberate details:

- **The reward row has four swatches, not one.** A reward particle is always one of four tiers, each its own colour. A single swatch would tell the reader the wrong thing about three of the tiles in front of them.
- **A zero category is omitted, not greyed at zero.** P2P is absent from most blocks, so a permanent "0 transfers" row would become the most prominent thing in a panel that's mostly about the other two.

The legend is `aria-hidden` — the grid's own `aria-label` already reads the full composition, and announcing it twice helps nobody.

## #333 / #334 — category tooltips on Network and Donor

Both panels listed a category and a count with no way to learn what was in it. Both now use `components/CategoryTooltip` — the same component `AppsTab`, `AppEcosystemBreakdown` and `WorkhorsePanel` already share, so the text stays written once in `CATEGORY_TOOLTIPS`. This is the Home treatment you remembered.

**The Donor rows are filter buttons** (#299), so the tooltip wraps the *button* rather than its contents — hovering has to explain the category without interfering with the click or keyboard focus. Verified both still work: hovering shows the text, clicking still takes the apps table **21 → 5 rows**, and the row reports `aria-pressed`.

**One trap worth recording:** Blueprint's `Tooltip2` renders a `span` around its target, which inside these flex columns becomes the flex child and collapses the rows to their content width. Both lists now give that wrapper `display: block; width: 100%`; measured after, wrapper and row widths match exactly.

## Verification

- **925 tests / 64 suites**, `yarn build` clean.
- Browser: legend reads `4 rewards / 13 confirmations / 1 transfer` on a block that had one, swatches 4/1/1, reward-band panel height unchanged.
- Network tooltip: *"Blockchain nodes & explorers (Beldex master nodes, Bitcoin, Kaspa, Blockbook, Firo)"*
- Donor tooltip: *"Volunteer & distributed computing (Folding@Home, BOINC, Rosetta)"*

## Still to come from your list

- **#335** — Utilization rework. Pairing it with **#331** (empty space), since they're the same two panels.
- **#332** — filterable Apps tab on /nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu