### PR TITLE
Donor: plain Utilization, and close the gap it left (#335, #331)

### DIFF
--- a/client/src/analytics/DonorTab/index.jsx
+++ b/client/src/analytics/DonorTab/index.jsx
@@ -10,6 +10,7 @@ import { fetch_donor_utilization_source, aggregateDonorUtilization } from 'analy
 import { buildDonorAppRows, tallyRowCategories } from 'analytics/donorAppRows';
 import { buildDonorNodeRows } from 'analytics/donorNodeRows';
 import { filterAppRows, utilizationAddresses } from 'analytics/donorFilters';
+import { usageLabel, usagePercent } from 'analytics/utilizationDisplay';
 import { APP_CATEGORY_META } from 'content/appCategoryMeta';
 import { tierMeta } from 'content/nodeTierMeta';
 import { fetch_wallet_tx_history } from 'analytics/walletTxFetch';
@@ -518,42 +519,55 @@ function DonorAppsTable({ rows, totalRows, filtered }) {
   );
 }
 
-// ── Utilization comparison ───────────────────────────────────────────────
+// ── Utilization ──────────────────────────────────────────────────────────
 
 const RESOURCE_ROWS = [
-  { key: 'cores', label: 'CPU Cores' },
-  { key: 'ram', label: 'RAM' },
-  { key: 'ssd', label: 'SSD' },
+  { key: 'cores', label: 'CPU Cores', unit: 'Cores' },
+  { key: 'ram', label: 'RAM', unit: 'GB' },
+  { key: 'ssd', label: 'SSD', unit: 'GB' },
 ];
 
-function UtilizationPanel({ donorUtil, networkPct, selectedNode }) {
+/*
+ * What this wallet's own capacity is doing (issue #335).
+ *
+ * The network-average comparison is gone deliberately. It answered "how do I
+ * rank", which is not the question an operator has about hardware they are
+ * paying for -- and it spent half of every row on a figure nobody acted on.
+ * What is left is the figure they do act on: how much of their own capacity is
+ * in use.
+ *
+ * Totals are SUMMED over the wallet, so ten Cumulus read as forty cores rather
+ * than as an average. One caveat that is easy to trip over: capacity is summed
+ * over unique HOSTS, not per node address -- two nodes on one machine share
+ * that machine's cores, and summing per address would count them twice (see
+ * donorUtilization.js, where an earlier version got exactly this wrong). So
+ * "ten Cumulus = forty cores" holds when they are on ten distinct machines.
+ *
+ * Selecting a node narrows every figure here to that node, which is what makes
+ * an idle node legible: "0 / 4 Cores (0%)".
+ */
+function UtilizationPanel({ donorUtil, selectedNode }) {
   return (
     <div className="hov-panel dt-util-panel">
       <div className="hov-header">
-        <span className="hov-header-title">UTILIZATION VS NETWORK AVERAGE</span>
-        {selectedNode && <span className="hov-header-badge">{selectedNode}</span>}
+        <span className="hov-header-title">UTILIZATION</span>
+        <span className="hov-header-badge">{selectedNode || 'All nodes'}</span>
       </div>
       {donorUtil.nodesWithCapacity === 0 ? (
         <div className="hov-empty">No capacity data available for your nodes</div>
       ) : (
         <div className="dt-util-list">
-          {RESOURCE_ROWS.map(({ key, label }) => {
-            const yours = donorUtil[key].percentage;
-            const net = networkPct[key] || 0;
+          {RESOURCE_ROWS.map(({ key, label, unit }) => {
+            const resource = donorUtil[key] || {};
+            const pct = usagePercent(resource.utilized, resource.total);
             return (
               <div key={key} className="dt-util-row">
-                <span className="dt-util-label">{label}</span>
-                <div className="dt-util-bars">
-                  <div className="dt-util-bar-wrap">
-                    <div className="dt-util-bar-fill dt-util-bar-fill--yours" style={{ width: `${Math.min(yours, 100)}%` }} />
-                  </div>
-                  <span className="dt-util-figure">{fmtPct(yours)} yours</span>
+                <div className="dt-util-head">
+                  <span className="dt-util-label">{label}</span>
+                  <span className="dt-util-figure">{usageLabel(resource, unit)}</span>
                 </div>
-                <div className="dt-util-bars">
-                  <div className="dt-util-bar-wrap">
-                    <div className="dt-util-bar-fill dt-util-bar-fill--network" style={{ width: `${Math.min(net, 100)}%` }} />
-                  </div>
-                  <span className="dt-util-figure">{fmtPct(net)} network avg</span>
+                <div className="dt-util-bar-wrap">
+                  <div className="dt-util-bar-fill" style={{ width: `${pct}%` }} />
                 </div>
               </div>
             );
@@ -596,7 +610,6 @@ export function DonorTab() {
   const [utilSource, setUtilSource] = useState({ benchmarks: [], resources: [] });
   const [nodesByIp, setNodesByIp] = useState({});
   const [specIndex, setSpecIndex] = useState({});
-  const [networkPct, setNetworkPct] = useState({ cores: 0, ram: 0, ssd: 0 });
   /*
    * The loader already fetches the global store for utilisation and app
    * categories, but only kept derived slices of it. The reward-reduction
@@ -652,11 +665,6 @@ export function DonorTab() {
       setSpecIndex(buildSpecIndex(rawSpecs));
       setNodesByIp(fetchedStore.nodesByIp || {});
       setGstore(fetchedStore);
-      setNetworkPct({
-        cores: fetchedStore.utilized.cores_percentage,
-        ram: fetchedStore.utilized.ram_percentage,
-        ssd: fetchedStore.utilized.ssd_percentage,
-      });
 
       setLoading(false);
     })().catch((error) => {
@@ -737,7 +745,7 @@ export function DonorTab() {
           onSelect={setSelectedCategory}
           onReset={() => setSelectedCategory(null)}
         />
-        <UtilizationPanel donorUtil={utilization} networkPct={networkPct} selectedNode={selectedNode} />
+        <UtilizationPanel donorUtil={utilization} selectedNode={selectedNode} />
         <DonorAppsTable
           rows={appRows}
           totalRows={allAppRows.length}

--- a/client/src/analytics/DonorTab/index.scss
+++ b/client/src/analytics/DonorTab/index.scss
@@ -32,9 +32,18 @@
 
 .dt-payout-card     { grid-column: span 7; }
 .dt-impact-panel    { grid-column: span 5; }
-.dt-nodes-panel     { grid-column: span 4; }
-.dt-apps-panel      { grid-column: span 3; }
-.dt-util-panel      { grid-column: span 5; }
+/*
+ * #331: YOUR NODES runs to its 420px cap while APP CATEGORIES and UTILIZATION
+ * are ~270px each, so three-across left roughly 220px and 300px of dead space
+ * under the two short ones -- visible in the issue's screenshot.
+ *
+ * The tall panel now spans both rows and the two short ones stack beside it,
+ * which fills the column instead of leaving a hole. 270 + 270 + the gap comes
+ * out close to the node list's height, so the row bottoms out level.
+ */
+.dt-nodes-panel     { grid-column: span 4; grid-row: span 2; }
+.dt-apps-panel      { grid-column: span 8; }
+.dt-util-panel      { grid-column: span 8; }
 .dt-appstable-panel { grid-column: span 12; }
 .dt-activity-panel  { grid-column: span 12; }
 
@@ -43,7 +52,7 @@
 @media (max-width: 1400px) {
   .dt-payout-card     { grid-column: span 12; }
   .dt-impact-panel    { grid-column: span 12; }
-  .dt-nodes-panel     { grid-column: span 6; }
+  .dt-nodes-panel     { grid-column: span 6; grid-row: auto; }
   .dt-apps-panel      { grid-column: span 6; }
   .dt-util-panel      { grid-column: span 12; }
 }
@@ -656,40 +665,35 @@
   letter-spacing: 0.06em;
 }
 
-.dt-util-bars {
+// Label left, the figure right, the bar spanning underneath (#335). The
+// figure is the thing being read, so it gets the weight the old percentage-
+// beside-a-network-average pair never gave it.
+.dt-util-head {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .dt-util-bar-wrap {
-  flex: 1;
-  height: 6px;
-  border-radius: 3px;
+  height: 8px;
+  border-radius: 4px;
   background: var(--surface-inset);
   overflow: hidden;
 }
 
 .dt-util-bar-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: 4px;
+  background: var(--accent-green);
   transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-
-  &--yours {
-    background: #ec4899;
-  }
-
-  &--network {
-    background: rgba(128, 128, 128, 0.5);
-  }
 }
 
 .dt-util-figure {
-  font-size: 0.68rem;
-  color: var(--text-tertiary);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
   white-space: nowrap;
-  width: 110px;
-  text-align: right;
 }
 
 // ── No-wallet empty state ────────────────────────────────────────────────

--- a/client/src/analytics/utilizationDisplay.js
+++ b/client/src/analytics/utilizationDisplay.js
@@ -1,0 +1,51 @@
+/*
+ * How a resource row on the Donor tab reads (issue #335).
+ *
+ * The panel used to show a percentage beside the network average. An operator
+ * does not care how they rank; they care how much of what they are paying for
+ * is in use. So: "10 / 40 Cores (25%)", summed over their nodes by default and
+ * narrowed to one when one is selected.
+ *
+ * Pure and separate from the component because the edge cases are where this
+ * goes wrong, not the markup: a node with no benchmark reading reports a total
+ * of zero, and 0/0 reaching the page as "NaN%" is exactly the kind of thing
+ * that looks fine in review and wrong on the data.
+ */
+
+const NO_CAPACITY = 'No capacity reported';
+
+/** Share of capacity in use, clamped to 0-100 and never NaN. */
+export function usagePercent(utilized, total) {
+  const used = Number(utilized) || 0;
+  const capacity = Number(total) || 0;
+  if (capacity <= 0) return 0;
+  return Math.min(100, (used / capacity) * 100);
+}
+
+/*
+ * Up to one decimal, and no trailing zero. Reservations are genuinely
+ * fractional -- appsCpusLocked can be half a core -- but "40.0 Cores" reads as
+ * false precision on a figure that is usually a whole number.
+ */
+function fmtAmount(value) {
+  const n = Number(value) || 0;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+/**
+ * "10 / 40 Cores (25%)", or a plain statement when nothing was measured.
+ *
+ * No capacity is deliberately NOT rendered as "0 / 0 (0%)": that asserts a
+ * fact about a node which never reported one, and an operator reading it would
+ * reasonably conclude their node has no CPU rather than that we have no
+ * benchmark for it.
+ */
+export function usageLabel(resource, unit) {
+  const total = Number(resource?.total) || 0;
+  if (total <= 0) return NO_CAPACITY;
+
+  const used = Number(resource?.utilized) || 0;
+  const pct = Math.round(usagePercent(used, total));
+
+  return `${fmtAmount(used)} / ${fmtAmount(total)} ${unit} (${pct}%)`;
+}

--- a/client/src/analytics/utilizationDisplay.test.js
+++ b/client/src/analytics/utilizationDisplay.test.js
@@ -1,0 +1,67 @@
+import { usageLabel, usagePercent } from './utilizationDisplay';
+
+/*
+ * Issue #335. The panel showed percentages and a network-average comparison.
+ * What an operator actually wants is how much of their own capacity is in use:
+ * "10 / 40 Cores (25%)", summed across their nodes by default and narrowed to
+ * one node when one is selected.
+ *
+ * aggregateDonorUtilization already returns {utilized, total, percentage} per
+ * resource -- the old panel rendered only the percentage and discarded the two
+ * numbers the request is asking for.
+ */
+
+describe('usagePercent', () => {
+  it('is the share of capacity in use', () => {
+    expect(usagePercent(10, 40)).toBe(25);
+  });
+
+  it('is zero, not NaN, when there is no capacity to divide by', () => {
+    // A node with no benchmark reading reports total 0. 0/0 must not reach
+    // the page as NaN%.
+    expect(usagePercent(0, 0)).toBe(0);
+    expect(usagePercent(5, 0)).toBe(0);
+  });
+
+  it('does not exceed 100 even if a node reserves more than it benchmarks', () => {
+    // Reservations and benchmarks come from different feeds and can disagree;
+    // a bar past the end of its track reads as a rendering bug.
+    expect(usagePercent(50, 40)).toBe(100);
+  });
+});
+
+describe('usageLabel', () => {
+  it('reads as used over total, with the unit and the share', () => {
+    expect(usageLabel({ utilized: 10, total: 40 }, 'Cores')).toBe('10 / 40 Cores (25%)');
+  });
+
+  it('says zero plainly for an unused node rather than hiding it', () => {
+    // Selecting an idle 4-core node is a case the request calls out.
+    expect(usageLabel({ utilized: 0, total: 4 }, 'Cores')).toBe('0 / 4 Cores (0%)');
+  });
+
+  it('drops trailing zeroes so whole numbers read as whole numbers', () => {
+    expect(usageLabel({ utilized: 12, total: 64 }, 'GB')).toBe('12 / 64 GB (19%)');
+  });
+
+  it('keeps one decimal where the figure genuinely has one', () => {
+    // appsCpusLocked can be fractional -- half a core is a real reservation.
+    expect(usageLabel({ utilized: 0.5, total: 4 }, 'Cores')).toBe('0.5 / 4 Cores (13%)');
+  });
+
+  it('groups thousands, because SSD totals get large quickly', () => {
+    expect(usageLabel({ utilized: 1200, total: 8800 }, 'GB')).toBe('1,200 / 8,800 GB (14%)');
+  });
+
+  it('says so when there is no capacity reading at all', () => {
+    // Distinct from "0 used": nothing was measured, so claiming 0/0 (0%) would
+    // be asserting a fact about a node that never reported.
+    expect(usageLabel({ utilized: 0, total: 0 }, 'Cores')).toBe('No capacity reported');
+  });
+
+  it('tolerates missing or malformed input rather than rendering NaN', () => {
+    for (const input of [null, undefined, {}, { utilized: null, total: null }]) {
+      expect(usageLabel(input, 'Cores')).toBe('No capacity reported');
+    }
+  });
+});


### PR DESCRIPTION
Closes #335 and #331 — same two panels, so they're one change.

## #335 — Utilization

```
UTILIZATION                                        All nodes

CPU CORES                            41.8 / 152 Cores (28%)
[==========                                              ]
RAM                                    97.9 / 570 GB (17%)
[======                                                  ]
SSD                                    837 / 8,360 GB (10%)
[====                                                    ]
```

The network-average bar is gone. It answered *"how do I rank"*, which isn't the question an operator has about hardware they're paying for — and it spent half of every row saying it.

Totals sum across the wallet by default and narrow on selection. **Verified live**: selecting an idle node gives `0 / 8 Cores (0%)`; the reset badge restores `41.8 / 152 Cores (28%)`.

The header badge now **always** says what's being counted — `All nodes` or the node address — rather than appearing only when filtered. A panel whose numbers change because of a selection made in another panel should say which it's showing.

### The formatter is pure and tested, because that's where this goes wrong

- **No capacity reading reads "No capacity reported", not `0 / 0 (0%)`.** The latter asserts a fact about a node that never reported one; an operator would reasonably read it as "this node has no CPU".
- `0/0` never reaches the page as `NaN%`.
- Usage clamps to 100 — reservations and benchmarks come from different feeds and can disagree, and a bar past the end of its track reads as a rendering bug.
- One decimal where the figure genuinely has one (half a core is a real reservation), none where it doesn't.

`networkPct` state and its derivation are removed along with the comparison they fed.

### One caveat on the arithmetic

Capacity is summed over **unique hosts**, not node addresses — two nodes on one machine share that machine's cores, and summing per address double-counts them (`donorUtilization.js` documents this; an earlier version got it wrong). So "ten Cumulus = forty cores" holds when they're on ten distinct machines.

## #331 — the space

Measured on the layout from your screenshot: `YOUR NODES` runs to its 420px cap while `APP CATEGORIES` and `UTILIZATION` are ~270px and ~190px — so three-across left roughly **220px and 300px** of dead space beneath the short ones.

The tall panel now spans both grid rows and the two short ones stack beside it.

**Measured after:** nodes 487→1002, apps 487→760, util 794→985. The column bottoms out **17px** short of the node list instead of hundreds. The category bars also get the full width, which they use.

## Verification

- **935 tests / 65 suites** (was 925). 10 new, written before the code.
- `yarn build` clean.
- Browser: figures above are live readings; per-node filter and reset both confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEXFs93A7ZKsGa5fEDceu